### PR TITLE
Collapse icon fix #220

### DIFF
--- a/themes/geekboot/assets/scss/_sidebar.scss
+++ b/themes/geekboot/assets/scss/_sidebar.scss
@@ -51,22 +51,24 @@
 
     .sidebar-checkbox{
       display: none !important;
+    }
 
-      &:not(:checked){
+    .sidebar-label {
+      &.collapsed{
 
-        & ~ label svg.sidebar-icon.plus {
+        svg.sidebar-icon.plus {
           display: block !important;
         }
-        & ~ label svg.sidebar-icon.x {
+        svg.sidebar-icon.x {
           display: none !important;
         }
       }
-      &:checked{
+      &:not(.collapsed){
 
-        & ~ label svg.sidebar-icon.plus {
+        svg.sidebar-icon.plus {
           display: none !important;
         }
-        & ~ label svg.sidebar-icon.x {
+        svg.sidebar-icon.x {
           display: block !important;
         }
       }

--- a/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -44,7 +44,9 @@
         </div>
         <div class="d-flex flex-shrink-1 sidebar-control-container align-self-center">
           <input type="checkbox" class="d-flex sidebar-checkbox" {{if $expand}}checked{{ end }} aria-label="Close or Expand {{.thisPage.Title}} Section" />
-          <label for="collapse-{{$id}}" class="sidebar-label" data-bs-toggle="collapse" data-bs-target="#collapse-{{$id}}" aria-expanded="false" aria-label="Close or Expand {{.thisPage.Title}} Section">
+          <label for="collapse-{{$id}}" class="sidebar-label {{if not $expand}} collapsed {{ end }}" data-bs-toggle="collapse"
+          data-bs-target="#collapse-{{$id}}" aria-expanded="false"
+          aria-label="Close or Expand {{.thisPage.Title}} Section">
           <svg class="flex bi sidebar-icon plus" ><use xlink:href="#plus"></use></svg>
           <svg class="flex bi sidebar-icon x " ><use xlink:href="#x"></use></svg>
           </label>


### PR DESCRIPTION
This pre-adds the `collapsed` class to left-nav elements and updates the icon styles to key on the collapsed element instead of the checkbox state.

Fixes: #220 

Signed-off-by: Pete Lumbis <pete@upbound.io>