### PR TITLE
Drop symlink to master directory

### DIFF
--- a/content/master
+++ b/content/master
@@ -1,1 +1,0 @@
-/home/runner/work/crossplane/crossplane/docs


### PR DESCRIPTION
Drops symlink to master directory so that the directory itself can be re-inserted on next merge.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>