### PR TITLE
chore: Add npm.install make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ $(HUGO):
 # ====================================================================================
 # Targets
 
+# Setup npm packages
+npm.init:
+	@$(INFO) Installing npm packages
+	@npm install
+	@$(OK) Installed npm packages
+
 # Run local development server.
 run: $(HUGO)
 	@$(INFO) starting hugo development server


### PR DESCRIPTION
Add `npm.install` as a make target to easily install the npm packages required by Hugo.