### PR TITLE
Fix heading font sizes

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -11,11 +11,6 @@ body {
   font-size: $body-font-size;
   line-height: 1.8em;
 
-  h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
-    margin-top: 1rem !important;
-    margin-bottom: 1rem !important;
-  }
-
   code {
     background-color: var(--code-background);
     color: var(--code-color);
@@ -42,26 +37,6 @@ body {
     margin-top: -5rem;
   }
 
-  > h2:not(:first-child) {
-    margin-top: 2rem;
-    font-size: 1.5rem;
-  }
-
-  > h3 {
-    margin-top: 2rem;
-  }
-
-  > ul li,
-  > ol li {
-    margin-bottom: .25rem;
-
-    // stylelint-disable selector-max-type, selector-max-compound-selectors
-    > p ~ ul {
-      margin-top: -.5rem;
-      margin-bottom: 1rem;
-    }
-    // stylelint-enable selector-max-type, selector-max-compound-selectors
-  }
 
   // Override Bootstrap defaults
   > .table,
@@ -103,26 +78,11 @@ body {
   }
 }
 
-.table-options {
-  td:nth-child(2) {
-    min-width: 160px;
-  }
-}
-
-.table-options td:last-child,
-.table-utilities td:last-child {
-  min-width: 280px;
-}
-
 .bd-title {
-  @include font-size(2rem);
+  @include font-size(2.25rem);
   font-weight: 600;
 }
 
-.bd-lead {
-  @include font-size(1.5rem);
-  font-weight: 300;
-}
 
 .bi {
   width: 1em;
@@ -136,4 +96,8 @@ blockquote {
   background: var(--nav-highlight-color) !important;
   line-height: 1.5rem;
   font-size: 1rem
+}
+
+h1,h2,h3,h4,h5,h6 {
+  padding-top: 1rem;
 }

--- a/themes/geekboot/assets/scss/bootstrap/_variables.scss
+++ b/themes/geekboot/assets/scss/bootstrap/_variables.scss
@@ -566,12 +566,12 @@ $line-height-base:            1.5 !default;
 $line-height-sm:              1.25 !default;
 $line-height-lg:              2 !default;
 
-$h1-font-size:                $font-size-base * 2.5 !default;
+$h1-font-size:                $font-size-base * 2.25 !default;
 $h2-font-size:                $font-size-base * 2 !default;
 $h3-font-size:                $font-size-base * 1.75 !default;
 $h4-font-size:                $font-size-base * 1.5 !default;
 $h5-font-size:                $font-size-base * 1.25 !default;
-$h6-font-size:                $font-size-base !default;
+$h6-font-size:                $font-size-base * 1.15 !default;
 // scss-docs-end font-variables
 
 // scss-docs-start font-sizes

--- a/themes/geekboot/assets/scss/docs.scss
+++ b/themes/geekboot/assets/scss/docs.scss
@@ -24,6 +24,7 @@
 // Happy Bootstrapping!
 
 
+// Import the entire Bootstrap library and let PurgeCSS optimize in production
 @import "bootstrap/bootstrap";
 @import "variables";
 /* purgecss start ignore */


### PR DESCRIPTION
Fixes #230

Updates the headings to use [Bootstrap RFS](https://getbootstrap.com/docs/5.2/getting-started/rfs/) so heading sizes are responsive based on window size.

This also makes the heading sizes have expected relative sizes, independent of location in the page. 

![Screen Shot 2022-12-16 at 12 34 12 PM](https://user-images.githubusercontent.com/10537576/208156285-a89eed89-b902-4c98-bfac-1c9530ee8186.png)

Signed-off-by: Pete Lumbis <pete@upbound.io>