### PR TITLE
Create an issue template for new releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,5 +1,6 @@
 ---
 name: New Release
+title: "[New Release]: "
 about: Cut a Crossplane release
 labels: release
 ---

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,6 +1,6 @@
 ---
 name: New Release
-title: "[New Release]: "
+title: "Release Crossplane version... "
 about: Cut a Crossplane release
 labels: release
 ---

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,0 +1,8 @@
+---
+name: New Release
+about: Cut a Crossplane release
+labels: release
+---
+
+- [ ] Update the `/latest` redirect in [netlify.toml](https://github.com/crossplane/docs/blob/master/netlify.toml#L9)
+- [ ] Update `params.latest` in [config.yaml](https://github.com/crossplane/docs/blob/master/config.yaml#L48)


### PR DESCRIPTION
When the docs source of truth moves from crossplane/crossplane ([#3461](https://github.com/crossplane/crossplane/issues/3461)) cutting a new Crossplane release will change.

To simplify the process for crossplane/crossplane maintainers this issue template will identify what needs to be done. By having a template we can create a link directly to this issue template.