### PR TITLE
Changes for moving docs source of truth

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,5 +1,6 @@
 ---
 name: New Release
+title: "[New Release]: "
 about: Cut a Crossplane release
 labels: release
 ---

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,6 +1,6 @@
 ---
 name: New Release
-title: "[New Release]: "
+title: "Release Crossplane version... "
 about: Cut a Crossplane release
 labels: release
 ---

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,0 +1,8 @@
+---
+name: New Release
+about: Cut a Crossplane release
+labels: release
+---
+
+- [ ] Update the `/latest` redirect in [netlify.toml](https://github.com/crossplane/docs/blob/master/netlify.toml#L9)
+- [ ] Update `params.latest` in [config.yaml](https://github.com/crossplane/docs/blob/master/config.yaml#L48)

--- a/Makefile
+++ b/Makefile
@@ -90,17 +90,3 @@ build: $(HUGO)
 # NOTE(hasheddan): this target exists so that validation can expand to inlude
 # other actions rather than just building.
 validate: build
-
-# Push new changes to the live site.
-publish:
-	$(eval ROOT_DIR = $(shell pwd -P))
-	git -C "$(ROOT_DIR)" add -A
-	@if git -C "$(ROOT_DIR)" diff-index --cached --quiet HEAD --; then\
-		echo "no changes detected";\
-	else \
-		echo "committing changes...";\
-		git -C "$(ROOT_DIR)" -c user.email="info@crossplane.io" -c user.name="Crossplane" commit --message="docs snapshot for crossplane version \`$(DOCS_VERSION)\`"; \
-		echo "pushing changes..."; \
-		git -C "$(ROOT_DIR)" push; \
-		echo "crossplane.github.io changes published"; \
-	fi


### PR DESCRIPTION
Related to Crossplane issue [#3461](https://github.com/crossplane/crossplane/issues/3461).

This creates a new issue template for Crossplane releases and removes the publish directive from the local Makefile. 