### PR TITLE
Update Styles to clearly indicate links in command text

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -21,8 +21,9 @@ body {
     text-decoration: none;
     color: var(--content-link-color);
 
-    &:hover{
+    &:hover, code{
       text-decoration: underline !important;
+      color: var(--content-link-color);
     }
 
     &:visited {


### PR DESCRIPTION
With the current style if an inline command (i.e., single tick like `this`) is also a link there is no styling to indicate this.

Today:
![Screen Shot 2022-12-29 at 10 49 48 AM](https://user-images.githubusercontent.com/10537576/209977417-c5a8badc-da85-4ff3-baf7-d71282b8a54d.png)

This updates the styling to change the color and add an underline to the link inside the inline command.
![Screen Shot 2022-12-29 at 10 49 27 AM](https://user-images.githubusercontent.com/10537576/209977968-d0464602-c584-4271-8251-6956ea3196ce.png)
