### PR TITLE
Accordion header padding fix

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -100,4 +100,8 @@ blockquote {
 
 h1,h2,h3,h4,h5,h6 {
   padding-top: 1rem;
+
+  &.accordion-header {
+    padding-top: 0 !important;
+  }
 }


### PR DESCRIPTION
This fixes a regression caused by #230.

The accordion feature (`{{<expand ... >}}`) uses a heading for the title. This creates extra top margin
![Screen Shot 2022-12-29 at 11 14 20 AM](https://user-images.githubusercontent.com/10537576/209980113-0aa75d72-8418-48c6-bd8d-bd90f9bfd4f3.png)

This removes that margin for heading elements that are also accordion features.
![Screen Shot 2022-12-29 at 11 11 46 AM](https://user-images.githubusercontent.com/10537576/209980147-5cb83dba-2ea5-40e8-9f7a-2c3851b07efe.png)


