### PR TITLE
Support styling for bootstrap tables

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -39,44 +39,6 @@ body {
   }
 
 
-  // Override Bootstrap defaults
-  > .table,
-  > .table-responsive .table {
-    margin-bottom: 1.5rem;
-    @include font-size(.875rem);
-
-    @include media-breakpoint-down(lg) {
-      &.table-bordered {
-        border: 0;
-      }
-    }
-
-    thead {
-      border-bottom: 2px solid currentcolor;
-    }
-
-    tbody:not(:first-child) {
-      border-top: 2px solid currentcolor;
-    }
-
-    th,
-    td {
-      &:first-child {
-        padding-left: 0;
-      }
-
-      &:not(:last-child) {
-        padding-right: 1.5rem;
-      }
-    }
-
-    // Prevent breaking of code
-    // stylelint-disable-next-line selector-max-compound-selectors
-    th,
-    td:first-child > code {
-      white-space: nowrap;
-    }
-  }
 }
 
 .bd-title {
@@ -105,4 +67,12 @@ h1,h2,h3,h4,h5,h6 {
   &.accordion-header {
     padding-top: 0 !important;
   }
+}
+
+
+.table {
+  color: var(--font-body-color);
+  // Override bootstrap defaults to support dark mode
+  --bs-table-hover-color: var(--font-body-color);
+  --bs-table-hover-bg: var(--nav-highlight-color);
 }

--- a/themes/geekboot/layouts/shortcodes/table.html
+++ b/themes/geekboot/layouts/shortcodes/table.html
@@ -1,0 +1,8 @@
+{{ $htmlTable := .Inner | markdownify }}
+{{ $old := "<table>" }}
+{{ $class := .Get 0 | default "table"}}
+{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $htmlTable := replace $htmlTable $old $new }}
+<div class="table-responsive">
+{{ $htmlTable | safeHTML }}
+</div>


### PR DESCRIPTION
Currently tables are not styled. 

<img width="890" alt="Screen Shot 2022-12-29 at 8 27 09 PM" src="https://user-images.githubusercontent.com/10537576/210025697-e0345937-07d3-4f07-8f9d-a4b4c6fb6ca7.png">


This adds support for an opt-in table styling via Hugo Shortcode. The shortcode enables support for all `table` level [classes from Bootstrap](https://getbootstrap.com/docs/5.2/content/tables/). 

This also adds support for light and dark mode styled tables, including Bootstrap hover highlighting.

Light:
![Screen Shot 2022-12-29 at 6 26 42 PM](https://user-images.githubusercontent.com/10537576/210025768-e8ecac87-1497-474e-ba37-5dd5e3b175b4.png)

Dark:
![Screen Shot 2022-12-29 at 6 25 46 PM](https://user-images.githubusercontent.com/10537576/210025773-29651fdc-4cd4-4d1a-86f4-2befdaf3c6e5.png)

The deleted content is from the original porting of Bootstrap styling and is not used anywhere in the docs today. 
