### PR TITLE
Add Browserstack notice for OSS project sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Crossplane.io is built using [Hugo](https://gohugo.io/).
 
 For detailed information about contributing to documentation read the [Docs Contributing Guide](https://crossplane.io/master/contributing/docs/).
 
+This project is tested with BrowserStack.
+
 ## License
 The Crossplane documentation is under the [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) license. CC-BY allows reuse, remixing and republishing of Crossplane documentation with attribution to the Crossplane organization.
 


### PR DESCRIPTION
[Browserstack ](https://www.browserstack.com/open-source) provides a number of automated UI regression and browser compatibility tests for websites.

Browserstack provides free accounts for OSS projects but requires acknowledgment of their support in the project README and uses this to line verify project ownership.

Signed-off-by: Pete Lumbis <pete@upbound.io>