### PR TITLE
Moves the search box JS from end of page to search div

### DIFF
--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -9,15 +9,3 @@
 
 
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
-
-<script>
-
-    docsearch({
-    container: '#docSearch',
-    appId: '9UXKYX61NK',
-    indexName: 'crossplane',
-    apiKey: 'e07e181044d561f6a4cb7261931d980a',
-    placeholder: 'Search the docs'
-    });
-
-</script>

--- a/themes/geekboot/layouts/partials/search-button.html
+++ b/themes/geekboot/layouts/partials/search-button.html
@@ -13,3 +13,15 @@
 <div class="search-container d-flex row pt-3 ps-4 docsearch opacity-50"  data-bs-target="#bdSidebar" data-bs-dismiss="offcanvas" aria-label="Docs navigation">
     <div class="p-0" id="docSearch"></div>
 </div>
+
+<script>
+
+    docsearch({
+    container: '#docSearch',
+    appId: '9UXKYX61NK',
+    indexName: 'crossplane',
+    apiKey: 'e07e181044d561f6a4cb7261931d980a',
+    placeholder: 'Search the docs'
+    });
+
+</script>


### PR DESCRIPTION
The Algolia search box is created by the Algolia JS block based on a provided div `id`.

Today the script that does this is in the footer of the page, making it the last thing rendered. The problem is that it causes a content shift, moving the nav down to inject the box.

This puts the JS immediately after the div. The JS will be loaded before the rest of the page and prevents the content shift.

Signed-off-by: Pete Lumbis <pete@upbound.io>