### PR TITLE
Update link to docs contributing guide in README.md  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # Crossplane Documentation
 
-This is the repository for the [Crossplane documentation](https://docs.crossplane.io).
+This is the repository for the [Crossplane
+documentation](https://docs.crossplane.io).
 
-The documentation site is built using [Hugo](https://gohugo.io/) and tested with BrowserStack.
+The documentation site is built using [Hugo](https://gohugo.io/) and tested with
+BrowserStack.
 
-For detailed information about contributing to documentation read the [Docs Contributing Guide](https://docs.crossplane.io/contribute/).
-
+For detailed information about contributing to documentation read the [Docs
+Contributing Guide](https://docs.crossplane.io/contribute/).
 
 ## License
-The Crossplane documentation is under the [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) license. CC-BY allows reuse, remixing and republishing of Crossplane documentation with attribution to the Crossplane organization.
+The Crossplane documentation is under the [Creative Commons
+Attribution](https://creativecommons.org/licenses/by/4.0/) license. CC-BY allows
+reuse, remixing and republishing of Crossplane documentation with attribution to
+the Crossplane organization.
 
-The docs.crossplane.io theme is based on [Geekdoc](https://github.com/thegeeklab/hugo-geekdoc) and [Bootstrap](https://github.com/twbs/bootstrap), both licensed under the MIT License.
+The docs.crossplane.io theme is based on
+[Geekdoc](https://github.com/thegeeklab/hugo-geekdoc) and
+[Bootstrap](https://github.com/twbs/bootstrap), both licensed under the MIT
+License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for the [Crossplane documentation](https://docs.crossplan
 
 The documentation site is built using [Hugo](https://gohugo.io/) and tested with BrowserStack.
 
-For detailed information about contributing to documentation read the [Docs Contributing Guide](https://crossplane.io/master/contributing/docs/).
+For detailed information about contributing to documentation read the [Docs Contributing Guide](https://docs.crossplane.io/contribute/).
 
 
 ## License


### PR DESCRIPTION
This PR updates the README.md in this docs repo to point to the correct URL for crossplane docs contribution guide - it was missing the docs subdomain.

This PR contains 2 commits, one to make the small URL/link change, and another to wrap the lines.