### PR TITLE
add netlify dev files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ docs/.DS_Store
 # jekyll_files
 ######################
 jekyll_files/*
+
+# Netlify local dev
+######################
+.netlify/*


### PR DESCRIPTION
When running [Netlify CLI](https://docs.netlify.com/cli/get-started/) locally to test the netlify build it creates a `.netlify` folder. This should never be added to the repo.

Signed-off-by: Pete Lumbis <pete@upbound.io>