### PR TITLE
Make navbar Documentation Link relative to environment

### DIFF
--- a/themes/geekboot/layouts/partials/docs-navbar.html
+++ b/themes/geekboot/layouts/partials/docs-navbar.html
@@ -55,7 +55,7 @@
             <a class="navbar-link" href="https://www.crossplane.io/why-control-planes">Why Control Planes?</a>
           </li>
           <li class="nav-item">
-            <a class="navbar-link"  aria-current="page" href="https://docs.crossplane.io">Documentation</a>
+            <a class="navbar-link"  aria-current="page" href="{{.Site.BaseURL}}">Documentation</a>
           </li>
           <li class="nav-item">
             <a class="navbar-link"  href="https://www.crossplane.io/community">Community</a>


### PR DESCRIPTION
Updates the link to `Documentation` to be relative based on where hugo is being run. This makes the link correct for local development (localhost), build previews (netlify) and prod (docs.crossplane.io)

Signed-off-by: Pete Lumbis <pete@upbound.io>