### PR TITLE
Fix search and version drop down

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ params:
   prodFormLink: "https://docs.google.com/forms/d/e/1FAIpQLSev-5clADSdkwi_wiFqBCAECeIoAQDE91chBbeWbvyTjRCeYg/viewform"
   infoMailToLink: "mailto:info@crossplane.io"
   upboundGithubLink: "https://github.com/upbound"
-
+  docs: true
   repoLink: "https://github.com/crossplane/crossplane"
   anchors:
     min: 2

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -6,6 +6,3 @@
 {{ if eq hugo.Environment "production" -}}
     {{ partialCached "analytics" . }}
 {{ end }}
-
-
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>

--- a/themes/geekboot/layouts/partials/search-button.html
+++ b/themes/geekboot/layouts/partials/search-button.html
@@ -14,6 +14,7 @@
     <div class="p-0" id="docSearch"></div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script>
 
     docsearch({


### PR DESCRIPTION
Fixes two issues:
* Oversight on my part that #262 implies a `docs` param. This happened because it was pulled from the larger #254 PR and I missed the update to config.yml
* The script that loads the search box wasn't moved into the header in #259. My local previews worked because of caching. 

Signed-off-by: Pete Lumbis <pete@upbound.io>