### PR TITLE
Clarify that this repo is only the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# crossplane.io
+# Crossplane Documentation
 
-This is the repository for [crossplane.io](https://crossplane.io/) including the [Crossplane documentation](https://crossplane.io/docs).
+This is the repository for the [Crossplane documentation](https://crossplane.io/docs).
 
-Crossplane.io is built using [Hugo](https://gohugo.io/).
+The documentation site is built using [Hugo](https://gohugo.io/) and tested with BrowserStack.
 
 For detailed information about contributing to documentation read the [Docs Contributing Guide](https://crossplane.io/master/contributing/docs/).
 
-This project is tested with BrowserStack.
 
 ## License
 The Crossplane documentation is under the [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) license. CC-BY allows reuse, remixing and republishing of Crossplane documentation with attribution to the Crossplane organization.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crossplane Documentation
 
-This is the repository for the [Crossplane documentation](https://crossplane.io/docs).
+This is the repository for the [Crossplane documentation](https://docs.crossplane.io).
 
 The documentation site is built using [Hugo](https://gohugo.io/) and tested with BrowserStack.
 


### PR DESCRIPTION
I was making a fresh clone of this repo when I saw that it was forked from crossplane.github.io and stated in the README that it was both the website and docs. This surprised me, since crossplane/docs seemed like a misleading place to find the website.

I then learned that the website is in fact a separate repo, at https://github.com/crossplane/website