### PR TITLE
Update azure-provider.md

### DIFF
--- a/content/v1.10/cloud-providers/azure/azure-provider.md
+++ b/content/v1.10/cloud-providers/azure/azure-provider.md
@@ -25,7 +25,7 @@ authenticate to Azure:
 
 ```bash
 # create service principal with Owner role
-az ad sp create-for-rbac --sdk-auth --role Owner > crossplane-azure-provider-key.json
+az ad sp create-for-rbac --sdk-auth --role Owner --scopes="/subscriptions/<azure subscription id>"  > crossplane-azure-provider-key.json
 ```
 
 Take note of the `clientID` value from the JSON file that we just created, and


### PR DESCRIPTION
Azure CLI report following error if `az ad sp create-for-rbac` command is executed without specifying `--scope`:
`Usage error: To create role assignments, specify both --role and --scopes.`