### PR TITLE
Sanitize expand titles

### DIFF
--- a/themes/geekboot/layouts/shortcodes/expand.html
+++ b/themes/geekboot/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 <!-- 2000 is the maxium Hugo seq length -->
 {{ $randNum := index (seq 2000 | shuffle) 0 }}
 {{ $title := .Get 0 | default "Expand"}}
-{{ $id := (replaceRE "(\\s)" "" (printf "%s-%d" $title $randNum))  }}
+{{ $id := (replaceRE "(\\s)" "" (printf "%s-%d" (anchorize $title) $randNum))  }}
 <div class="accordion mb-3" id="{{$id}}-Parent">
   <div class="accordion-item">
     <h2 class="accordion-header" id="{{$id}}">


### PR DESCRIPTION
@negz hit an issue in #298 where using a period in an `expand` shortcode title would cause the expand to not work.

The root cause was that the title is turned into a table used as a [DOM selector](https://developer.mozilla.org/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors#selectors). The period (and most other special characters) can't be used as a selector.

Hugo's [anchorize](https://gohugo.io/functions/anchorize/) function can sanitize an input and return a clean string we can use in the expand selector. 

This makes no changes to what is displayed on the page. 

Resolves #301

Signed-off-by: Pete Lumbis <pete@upbound.io>