### PR TITLE
Remove extra &&

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@ status = 302
     command = "sed -i 's/# writeStats: true/writeStats: true/g' config.yaml && cat config.yaml && hugo --minify"
 
 [context.production]
-    command = "sed -i 's/# writeStats: true/writeStats: true/g' config.yaml && && hugo --minify"
+    command = "sed -i 's/# writeStats: true/writeStats: true/g' config.yaml && hugo --minify"
 
 # Use [dev] to set configuration overrides for local
 # development environments run using Netlify Dev - except


### PR DESCRIPTION
#300 changed the build command and has an extra `&&` causing the command to fail.

This wasn't hit in the deploy preview because they use different command lines.

Signed-off-by: Pete Lumbis <pete@upbound.io>