### PR TITLE
Add more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,11 @@
+---
+name: Report a bug in the docs
+about: Report a typo or bad code examples in the docs.
+labels: bug
+---
+
+### URL
+<!-- What's the URL of the page with a problem? -->
+
+### What's Wrong?
+<!-- What problem did you find? -->

--- a/.github/ISSUE_TEMPLATE/content.md
+++ b/.github/ISSUE_TEMPLATE/content.md
@@ -1,0 +1,8 @@
+---
+name: Docs request
+about: Request new or additional content on a subject.
+labels: "content-request"
+---
+
+### What's Missing?
+<!--  What would you like us to work on or what's missing? -->

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -7,3 +7,5 @@ labels: release
 
 - [ ] Update the `/latest` redirect in [netlify.toml](https://github.com/crossplane/docs/blob/master/netlify.toml#L9)
 - [ ] Update `params.latest` in [config.yaml](https://github.com/crossplane/docs/blob/master/config.yaml#L48)
+- [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named "v<EOL version>-archive" to snapshot EOL'd docs.
+- [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.

--- a/.github/ISSUE_TEMPLATE/website.md
+++ b/.github/ISSUE_TEMPLATE/website.md
@@ -1,0 +1,11 @@
+---
+name: Website Issue
+about: Report broken links, bad javascript or request a new site feature.
+labels: infrastructure
+---
+
+
+### What's Wrong?
+<!-- What problem did you find? -->
+
+<!-- If it's related to a specific page, what's the URL? -->


### PR DESCRIPTION
Expands the issue release template with directions regarding EOL versions.

Creates new templates for docs bugs, website issues and content requests.