### PR TITLE
Enable optional line/field editing in code examples

### DIFF
--- a/content/contribute/code-style-guide.md
+++ b/content/contribute/code-style-guide.md
@@ -168,3 +168,31 @@ metadata:
   name: aProvider
 ```
 ````
+
+## Editable fields
+
+The `editCode` shortcode makes specific lines or words editable. Editable fields allow readers to put their own inputs as part of a command and copy out the entire modified block. 
+
+For example, the following code block allows editing the key and secret fields.
+
+{{< editCode >}}
+```ini {copy-lines="all"}
+[default]
+aws_access_key_id = $$<aws_access_key>$$
+aws_secret_access_key = $$<aws_secret_key>$$
+```
+{{</ editCode >}}
+
+To set a field as editable wrap a standard code block, including language highlighting hints in the `{{</* editCode */>}}` shortcode. 
+
+Wrap any editable element in two dollar-sign characters (`$$`).
+
+````go
+{{</* editCode */>}}
+```ini {copy-lines="all"}
+[default]
+aws_access_key_id = $$<aws_access_key>$$
+aws_secret_access_key = $$<aws_secret_key>$$
+```
+{{</* /editCode */>}}
+````

--- a/themes/geekboot/layouts/shortcodes/editCode.html
+++ b/themes/geekboot/layouts/shortcodes/editCode.html
@@ -1,1 +1,1 @@
-{{ replaceRE `\$(.*)\$` "<span class=\"pe-2\" contentEditable=\"true\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}
+{{ replaceRE `\$\$(.*)\$\$` "<span class=\"pe-2\" contentEditable=\"true\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}

--- a/themes/geekboot/layouts/shortcodes/editCode.html
+++ b/themes/geekboot/layouts/shortcodes/editCode.html
@@ -1,0 +1,1 @@
+{{ replaceRE `\$(.*)\$` "<span class=\"pe-2\" contentEditable=\"true\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}


### PR DESCRIPTION
This PR creates a new shortcode called `editCode`. Authors can add `$$` around a word or line to make it editable in the code block. 

This works by using a regex for `\$\$(.*)\$\$` and replacing it with `<span contentEditable="true">`. The HTML [contenteditable](https://www.w3schools.com/tags/att_global_contenteditable.asp) tag does the work. 

A live example and docs are in the deploy preview. 
https://deploy-preview-311--crossplane.netlify.app/contribute/code-style-guide/#editable-fields

Signed-off-by: Pete Lumbis <pete@upbound.io>