### PR TITLE
Fixes links that generate bad links due to Hugo limitation

### DIFF
--- a/content/master/software/_index.md
+++ b/content/master/software/_index.md
@@ -4,11 +4,8 @@ weight: 300
 description: Manage Crossplane installations
 ---
 
-## [Install Crossplane]({{<ref "install" >}})
+## [Install Crossplane](./install/)
 How to install and customize Crossplane in an existing Kubernetes cluster.
 
-## [Upgrade Crossplane]({{<ref "upgrade" >}})
-How to upgrade existing Crossplane installations.
-
-## [Uninstall Crossplane]({{<ref "uninstall" >}})
+## [Uninstall Crossplane](./uninstall/)
 How to remove Crossplane from a Kubernetes cluster.

--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade Crossplane
 weight: 200
+draft: true
 ---
 
 Install, Uninstall, Upgrade

--- a/content/v1.11/software/_index.md
+++ b/content/v1.11/software/_index.md
@@ -4,11 +4,8 @@ weight: 300
 description: Manage Crossplane installations
 ---
 
-## [Install Crossplane]({{<ref "install" >}})
+## [Install Crossplane](./install/)
 How to install and customize Crossplane in an existing Kubernetes cluster.
 
-## [Upgrade Crossplane]({{<ref "upgrade" >}})
-How to upgrade existing Crossplane installations.
-
-## [Uninstall Crossplane]({{<ref "uninstall" >}})
+## [Uninstall Crossplane](./uninstall/)
 How to remove Crossplane from a Kubernetes cluster.

--- a/content/v1.11/software/upgrade.md
+++ b/content/v1.11/software/upgrade.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade Crossplane
 weight: 200
+draft: true
 ---
 
 Install, Uninstall, Upgrade


### PR DESCRIPTION
While investigating #315 I noticed there are links to "https://docs.crossplane.io/v1.11/software/HAHAHUGOSHORTCODE-s0-HBHB". 

This turns out to be an issue in Hugo with using the table of contents short code for things that are tied to a shortcode (in our case `{{<ref>}}`). 

This updates the links and sets the Upgrade  guide to `draft` since it hasn't been written yet. 

Signed-off-by: Pete Lumbis <pete@upbound.io>