### PR TITLE
corrects link to managed-resources that has incorrect quotes

### DIFF
--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -94,4 +94,3 @@ will attempt to use a `ProviderConfig` named `default`.
 [Google Cloud Platform (GCP) Service Account]: "../cloud-providers/gcp/gcp-provider" 
 [Microsoft Azure Service Principal]:  "../cloud-providers/azure/azure-provider"
 [Amazon Web Services (AWS) IAM User]: "../cloud-providers/aws/aws-provider"
-[managed-resources]: "managed-resources"

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -3,8 +3,8 @@ title: Providers
 weight: 101
 ---
 
-Providers are Crossplane packages that bundle a set of [Managed
-Resources][managed-resources] and their respective controllers to allow
+Providers are Crossplane packages that bundle a set of 
+[Managed Resources]({{<ref "managed-resources" >}}) and their respective controllers to allow
 Crossplane to provision the respective infrastructure resource.
 
 ## Installing Providers

--- a/content/v1.11/concepts/providers.md
+++ b/content/v1.11/concepts/providers.md
@@ -3,8 +3,8 @@ title: Providers
 weight: 101
 ---
 
-Providers are Crossplane packages that bundle a set of [Managed
-Resources][managed-resources] and their respective controllers to allow
+Providers are Crossplane packages that bundle a set of 
+[Managed Resources]({{<ref "./managed-resources" >}}) and their respective controllers to allow
 Crossplane to provision the respective infrastructure resource.
 
 ## Installing Providers
@@ -94,4 +94,3 @@ will attempt to use a `ProviderConfig` named `default`.
 [Google Cloud Platform (GCP) Service Account]: "../cloud-providers/gcp/gcp-provider" 
 [Microsoft Azure Service Principal]:  "../cloud-providers/azure/azure-provider"
 [Amazon Web Services (AWS) IAM User]: "../cloud-providers/aws/aws-provider"
-[managed-resources]: "managed-resources"

--- a/content/v1.11/concepts/providers.md
+++ b/content/v1.11/concepts/providers.md
@@ -4,7 +4,7 @@ weight: 101
 ---
 
 Providers are Crossplane packages that bundle a set of 
-[Managed Resources]({{<ref "./managed-resources" >}}) and their respective controllers to allow
+[Managed Resources]({{<ref "managed-resources" >}}) and their respective controllers to allow
 Crossplane to provision the respective infrastructure resource.
 
 ## Installing Providers


### PR DESCRIPTION
A markdown link is breaking across lines due to line wrap and is generating a link to `"managed-resources"` (with quotes).

This changes those links to use `ref` shortcode to catch broken links in the future. 

Signed-off-by: Pete Lumbis <pete@upbound.io>