### PR TITLE
Add last changed metadata to pages for search

### DIFF
--- a/themes/geekboot/layouts/partials/header.html
+++ b/themes/geekboot/layouts/partials/header.html
@@ -1,6 +1,11 @@
 {{ partialCached "meta-common" . }}
 <meta name="description" content="{{ .Page.Params.description | default .Site.Params.description | markdownify }}">
 <meta property="og:url"             content="{{ .Permalink }}" />
+
+{{if not .Page.IsHome }}
+    <meta name="docsearch:modified" content='{{printf "%s" (.Page.Lastmod | time.Format ":date_long") }}' />
+{{ end }}
+
 {{ if .Page.Params.version }}
     {{if eq .Page.Params.version "master" }}
         <!-- "master" is not a SemVer version. Set it to 0.0.0 to derank it in search -->

--- a/themes/geekboot/layouts/partials/master-version-alert.html
+++ b/themes/geekboot/layouts/partials/master-version-alert.html
@@ -7,7 +7,7 @@
             This document is for an unreleased version of Crossplane.
         </div>
     </div>
-    <div class="bd-content mt-3">
+    <div class="mt-3">
         <p>
             This document applies to the Crossplane <code>master</code> branch and not to the latest release v{{.Site.Params.latest}}.
         </p>

--- a/themes/geekboot/layouts/partials/old-version-alert.html
+++ b/themes/geekboot/layouts/partials/old-version-alert.html
@@ -7,7 +7,7 @@
             This document is for an older version of Crossplane.
         </div>
     </div>
-    <div class="bd-content mt-3">
+    <div class="mt-3">
         <p>
             This document applies to Crossplane version v{{ .Page.Params.version }} and not to the latest release v{{.Site.Params.latest}}.
         </p>


### PR DESCRIPTION
This PR adds metadata to each page of when the page was last modified in Git. 

This will be used to influence Algolia search results to favor more recently changed files (among other parameters including version and content).

This is related to #315

Signed-off-by: Pete Lumbis <pete@upbound.io>