### PR TITLE
content/v.1.11: do not quote links as it leads to 404s

### DIFF
--- a/content/v1.11/concepts/composition.md
+++ b/content/v1.11/concepts/composition.md
@@ -1240,7 +1240,7 @@ so:
 1. Use a `FromCompositeFieldPath` patch to patch from the 'intermediary' field
    you patched to in step 1 to a field on the destination composed resource.
 
-
+[managed-resources]: {{<ref "managed-resources" >}}
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [raise an issue]: https://github.com/crossplane/crossplane/issues/new?assignees=&labels=enhancement&template=feature_request.md
 [issue-2524]: https://github.com/crossplane/crossplane/issues/2524

--- a/content/v1.11/concepts/managed-resources.md
+++ b/content/v1.11/concepts/managed-resources.md
@@ -464,14 +464,14 @@ fields are there and those are enough to import a resource. The tool you're
 using needs to store `annotations` and `spec` fields, which most tools do
 including Velero.
 
-[term-xrm]:  "terminology"
+[term-xrm]: {{<ref "terminology" >}}
 [rds]: https://aws.amazon.com/rds/
 [cloudsql]: https://cloud.google.com/sql
-[composition]: "composition"
+[composition]: {{<ref "composition" >}}
 [api-versioning]: https://kubernetes.io/docs/reference/using-api/#api-versioning#api-versioning
 [velero]: https://velero.io/
-[api-reference]: "../api-docs" 
-[provider]:  "providers"
+[api-reference]: ../api-docs
+[provider]: {{<ref "providers" >}}
 [issue-727]: https://github.com/crossplane/crossplane/issues/727
 [issue-1143]: https://github.com/crossplane/crossplane/issues/1143
 [managed-api-patterns]: https://github.com/crossplane/crossplane/blob/release-1.10/design/one-pager-managed-resource-api-design.md

--- a/content/v1.11/concepts/providers.md
+++ b/content/v1.11/concepts/providers.md
@@ -90,7 +90,7 @@ will attempt to use a `ProviderConfig` named `default`.
 
 <!-- Named Links -->
 
-[getting-started]:  "../getting-started/install-configure" 
-[Google Cloud Platform (GCP) Service Account]: "../cloud-providers/gcp/gcp-provider" 
-[Microsoft Azure Service Principal]:  "../cloud-providers/azure/azure-provider"
-[Amazon Web Services (AWS) IAM User]: "../cloud-providers/aws/aws-provider"
+[getting-started]:  ../../getting-started/introduction
+[Google Cloud Platform (GCP) Service Account]: ../../cloud-providers/provider-gcp
+[Microsoft Azure Service Principal]: ../../cloud-providers/provider-azure
+[Amazon Web Services (AWS) IAM User]: ../../cloud-providers/provider-aws


### PR DESCRIPTION
Currently, some links on the docs site lead to 404 as quotes are treated as parts of the URL (for example in [managed-resources](https://docs.crossplane.io/v1.11/concepts/managed-resources/) page, XRM link leads to `https://docs.crossplane.io/v1.11/concepts/managed-resources/"terminology"` which doesn't exist). This PR attempts to fix this issue.

If you want, I can offer my help with implementing CI workflow with `mdox` for docs formatting and link validation (similar to what was implemented in prometheus-operator at https://github.com/prometheus-operator/prometheus-operator/blob/main/Makefile#L324-L327)