### PR TITLE
Adds a $ prompt before the first command in each shell output

### DIFF
--- a/content/contribute/infrastructure.md
+++ b/content/contribute/infrastructure.md
@@ -112,6 +112,7 @@ Expand the tab below to see an annotated `tree` output of the website repository
 
 {{<expand >}}
 ```shell
+tree .
 ├── content                     # Root for all page content
 │   ├── master
 │   ├── v1.10

--- a/content/knowledge-base/guides/composition-functions.md
+++ b/content/knowledge-base/guides/composition-functions.md
@@ -33,14 +33,11 @@ array rather than the typical P&T style array of `resources`.
 
 ## Enabling functions
 
-To enable support for Composition Functions you must:
-
- * Enable the alpha feature flag in Crossplane.
- * Deploy a runner that's responsible for running Functions.
+Enable support for Composition Functions by enabling the alpha feature flag in Crossplane with `helm install --args`.
 
 ```shell
-kubectl create namespace crossplane-system
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane \
+    --create-namespace
     --set "args={--debug,--enable-composition-functions}" \
     --set "xfn.enabled=true" \
     --set "xfn.args={--debug}"
@@ -51,8 +48,8 @@ feature flag enabled, and with the reference _xfn_ Composition Function runner
 deployed as a sidecar pod. Confirm Composition Functions were enabled by looking
 for a log line:
 
-```shell
-$ kubectl -n crossplane-system logs -l app=crossplane
+```shell {copy-lines="1"}
+ kubectl -n crossplane-system logs -l app=crossplane
 {"level":"info","ts":1674535093.36186,"logger":"crossplane","msg":"Alpha feature enabled","flag":"EnableAlphaCompositionFunctions"}
 ```
 
@@ -129,8 +126,8 @@ Use `kubectl explain` to explore the configuration options available when using
 Composition Functions, or take a look at the following example.
 
 {{< expand "View Composition Function configuration options" >}}
-```shell
-$ kubectl explain composition.spec.functions
+```shell {copy-lines="1"}
+kubectl explain composition.spec.functions
 KIND:     Composition
 VERSION:  apiextensions.crossplane.io/v1
 
@@ -815,11 +812,12 @@ ENTRYPOINT ["/venv/bin/python3", "main.py"]
 ```
 {{< /expand >}}
 
-Create and push the Function just like you would any Docker image:
+Create and push the Function just like you would any Docker image.
+
+Build the function.
 
 ```shell
-# Build the Function.
-$ docker build .
+docker build .
 Sending build context to Docker daemon  38.99MB
 Step 1/10 : FROM debian:11-slim AS build
  ---> 4810399f6c13
@@ -850,12 +848,17 @@ Step 10/10 : ENTRYPOINT ["/venv/bin/python3", "main.py"]
 Removing intermediate container 3f4d9dc55bad
  ---> bfd2f920c591
 Successfully built bfd2f920c591
+```
 
-# Tag the Function.
-$ docker tag bfd2f920c591 example-org/xfn-quotable-simple:v0.1.0
+Tag the function.
+```shell
+docker tag bfd2f920c591 example-org/xfn-quotable-simple:v0.1.0
+```
 
-# Push the Function.
-$ docker push xpkg.upbound.io/example-org/xfn-quotable-simple:v0.1.0
+Push the function.
+
+```shell {copy-lines="1"}
+docker push xpkg.upbound.io/example-org/xfn-quotable-simple:v0.1.0
 The push refers to repository [xpkg.upbound.io/example-org/xfn-quotable-simple]
 cf6d94b88843: Pushed
 77646fd315d2: Mounted from example-org/xfn-quotable

--- a/content/knowledge-base/guides/composition-functions.md
+++ b/content/knowledge-base/guides/composition-functions.md
@@ -816,7 +816,7 @@ Create and push the Function just like you would any Docker image.
 
 Build the function.
 
-```shell
+```shell {copy-lines="1"}
 docker build .
 Sending build context to Docker daemon  38.99MB
 Step 1/10 : FROM debian:11-slim AS build

--- a/content/knowledge-base/guides/troubleshoot.md
+++ b/content/knowledge-base/guides/troubleshoot.md
@@ -2,18 +2,6 @@
 title: Troubleshoot
 weight: 306
 ---
-
-* [Requested Resource Not Found]
-* [Resource Status and Conditions]
-* [Resource Events]
-* [Crossplane Logs]
-* [Provider Logs]
-* [Pausing Crossplane]
-* [Pausing Providers]
-* [Deleting When a Resource Hangs]
-* [Installing Crossplane Package]
-* [Handling Crossplane Package Dependency]
-
 ## Requested Resource Not Found
 
 If you use the kubectl Crossplane plugin to install a `Provider` or
@@ -32,15 +20,10 @@ Most Crossplane resources have a `status` section that can represent the current
 state of that particular resource. Running `kubectl describe` against a
 Crossplane resource will frequently give insightful information about its
 condition. For example, to determine the status of a GCP `CloudSQLInstance`
-managed resource, run:
+managed resource use `kubectl describe` for the resource.
 
-```shell
+```shell {copy-lines="1"}
 kubectl describe cloudsqlinstance my-db
-```
-
-This should produce output that includes:
-
-```console
 Status:
   Conditions:
     Last Transition Time:  2019-09-16T13:46:42Z
@@ -183,14 +166,14 @@ lingering resources to clean up.
 
 In general, a finalizer can be removed from an object with this command:
 
-```console
+```shell
 kubectl patch <resource-type> <resource-name> -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
 For example, for a `CloudSQLInstance` managed resource (`database.gcp.crossplane.io`) named
 `my-db`, you can remove its finalizer with:
 
-```console
+```shell
 kubectl patch cloudsqlinstance my-db -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
@@ -202,7 +185,7 @@ you can do.
 
 Run below command to list all Crossplane resources available on your cluster:
 
-```console
+```shell
 kubectl get crossplane
 ```
 
@@ -220,14 +203,14 @@ package are listed if the package is installed successfully.
 If you only care about the installed packages, you can also run below command
 which will show you all installed Configuration and Provider packages:
 
-```console
+```shell
 kubectl get pkg
 ```
 
 When there are errors, you can run below command to check detailed information 
 for the packages that are getting installed.
 
-```console
+```shell
 kubectl get lock -o yaml
 ```
 

--- a/content/knowledge-base/integrations/vault-as-secret-store.md
+++ b/content/knowledge-base/integrations/vault-as-secret-store.md
@@ -58,12 +58,12 @@ for the cluster where Crossplane is running.
 
 Add the Vault Helm chart.
 ```shell
-helm repo add hashicorp https://helm.releases.hashicorp.com --force-update --create-namespace
+helm repo add hashicorp https://helm.releases.hashicorp.com --force-update 
 ```
 
 Install Vault.
 ```shell
-helm -n vault-system upgrade --install vault hashicorp/vault
+helm -n vault-system --create-namespace upgrade --install vault hashicorp/vault
 ```
 
 2. [Unseal] Vault
@@ -159,7 +159,7 @@ kubectl -n vault-system exec -it vault-0 -- vault write auth/kubernetes/role/cro
 - Annotating for [Vault Agent Sidecar Injection]
 
 ```shell
-helm repo add crossplane-stable https://charts.crossplane.io/stable --force-update --create-namespace
+helm repo add crossplane-stable https://charts.crossplane.io/stable --force-update 
 ```
 
 Create the Vault configuration settings.
@@ -177,7 +177,7 @@ customAnnotations:
 
 Apply the settings to the Crossplane installation. 
 ```shell 
-helm upgrade --install crossplane crossplane-stable/crossplane --namespace crossplane-system -f values.yaml
+helm upgrade --install crossplane crossplane-stable/crossplane --namespace crossplane-system --create-namespace -f values.yaml
 ```
 
 2. Create a Secret `StoreConfig` for Crossplane to be used by

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -20,11 +20,15 @@ Install Crossplane using the Crossplane published _Helm chart_.
 
 ### Add the Crossplane Helm repository
 
-Add the Crossplane repository with the `helm repo add` command and update the
-local Helm chart cache with `helm repo update`.
+Add the Crossplane repository with the `helm repo add` command.
 
 ```shell
 helm repo add crossplane-stable https://charts.crossplane.io/stable
+```
+
+Update the
+local Helm chart cache with `helm repo update`.
+```shell
 helm repo update
 ```
 
@@ -48,7 +52,7 @@ helm install crossplane \
 
 View the installed Crossplane pods with `kubectl get pods -n crossplane-system`.
 
-```shell
+```shell {copy-lines="1"}
 kubectl get pods -n crossplane-system
 NAME                                       READY   STATUS    RESTARTS   AGE
 crossplane-6d67f8cd9d-g2gjw                1/1     Running   0          26m
@@ -71,7 +75,7 @@ helm install crossplane \
 Crossplane creates two Kubernetes _deployments_ in the `crossplane-system`
 namespace to deploy the Crossplane pods. 
 
-```shell
+```shell {copy-lines="1"}
 kubectl get deployments -n crossplane-system
 NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
 crossplane                1/1     1            1           8m13s
@@ -252,11 +256,15 @@ Only use `master` for testing and development.
 
 #### Add the Crossplane master Helm repository
 
-Add the Crossplane repository with the `helm repo add` command and update the
-local Helm chart cache with `helm repo update`.
+Add the Crossplane repository with the `helm repo add` command.
 
 ```shell
 helm repo add crossplane-master https://charts.crossplane.io/master/
+```
+
+Update the
+local Helm chart cache with `helm repo update`.
+```shell
 helm repo update
 ```
 

--- a/content/v1.10/contributing/adding_external_secret_store_support.md
+++ b/content/v1.10/contributing/adding_external_secret_store_support.md
@@ -28,7 +28,7 @@ We need a workaround for code generation since latest runtime both adds new API
 but also adds a new interface to managed.resourceSpec. Without this workaround,
 expect errors similar to below:
 
-  ```shell
+  ```console
   16:40:56 [ .. ] go generate darwin_amd64
   angryjet: error: error loading packages using pattern ./...: /Users/hasanturken/  Workspace/crossplane/provider-gcp/apis/cache/v1beta1/zz_  generated.managedlist.go:27:14: cannot use &l.Items[i] (value of type *  CloudMemorystoreInstance) as "github.com/crossplane/crossplane-runtime/pkg/  resource".Managed value in assignment: missing method GetPublishConnectionDetailsTo
   exit status 1
@@ -42,10 +42,7 @@ First, we need to consume a temporary runtime version together with the latest
 Crossplane Tools:
 
   ```shell
-  go mod edit -replace=github.com/crossplane/crossplane-runtime=github.com/turkenh/crossplane-runtime@v0.0.0-20220314141040-6f74175d3c1f
-  go get github.com/crossplane/crossplane-tools@master
-
-  go mod tidy
+  go mod edit -replace=github.com/crossplane/crossplane-runtime=github.com/turkenh/crossplane-runtime@v0.0.0-20220314141040-6f74175d3c1f && go get github.com/crossplane/crossplane-tools@master && go mod tidy
   ```
 
 Then, remove `trivialVersions=true` in the file `api/generate.go`:
@@ -65,10 +62,7 @@ Finally, we can revert our workaround by consuming the latest Crossplane
 Runtime:
 
   ```shell
-  go mod edit -dropreplace=github.com/crossplane/crossplane-runtime
-  go get github.com/crossplane/crossplane-runtime@master
-  go mod tidy
-  make generate
+  go mod edit -dropreplace=github.com/crossplane/crossplane-runtime && go get github.com/crossplane/crossplane-runtime@master && go mod tidy && make generate
   ```
 
 **2. Add a new Type and CRD for Secret StoreConfig.**

--- a/content/v1.10/contributing/docs.md
+++ b/content/v1.10/contributing/docs.md
@@ -471,7 +471,7 @@ bundle size.
 Expand the tab below to see an annotated `tree` output of the website repo.
 
 {{<expand >}}
-```shell
+```console
 ├── content                     # Root for all page content
 │   ├── master
 │   ├── v1.10

--- a/content/v1.10/guides/vault-as-secret-store.md
+++ b/content/v1.10/guides/vault-as-secret-store.md
@@ -56,18 +56,26 @@ for the cluster where Crossplane is running.
 
 1. Install Vault Helm Chart
 
+Add the Helm repo.
 ```shell
-kubectl create ns vault-system
-
 helm repo add hashicorp https://helm.releases.hashicorp.com --force-update
-helm -n vault-system upgrade --install vault hashicorp/vault
+```
+
+Install the Helm chart.
+```shell
+helm -n vault-system upgrade --install vault hashicorp/vault --create-namespace
 ```
 
 2. [Unseal] Vault
 
+Get the Vault keys.
 ```shell
 kubectl -n vault-system exec vault-0 -- vault operator init -key-shares=1 -key-threshold=1 -format=json > cluster-keys.json
 VAULT_UNSEAL_KEY=$(cat cluster-keys.json | jq -r ".unseal_keys_b64[]")
+```
+
+Unseal the vault with the keys.
+```shell
 kubectl -n vault-system exec vault-0 -- vault operator unseal $VAULT_UNSEAL_KEY
 ```
 

--- a/content/v1.10/reference/troubleshoot.md
+++ b/content/v1.10/reference/troubleshoot.md
@@ -2,18 +2,6 @@
 title: Troubleshoot
 weight: 306
 ---
-
-* [Requested Resource Not Found]
-* [Resource Status and Conditions]
-* [Resource Events]
-* [Crossplane Logs]
-* [Provider Logs]
-* [Pausing Crossplane]
-* [Pausing Providers]
-* [Deleting When a Resource Hangs]
-* [Installing Crossplane Package]
-* [Handling Crossplane Package Dependency]
-
 ## Requested Resource Not Found
 
 If you use the kubectl Crossplane plugin to install a `Provider` or
@@ -32,15 +20,10 @@ Most Crossplane resources have a `status` section that can represent the current
 state of that particular resource. Running `kubectl describe` against a
 Crossplane resource will frequently give insightful information about its
 condition. For example, to determine the status of a GCP `CloudSQLInstance`
-managed resource, run:
+managed resource use `kubectl describe` for the resource.
 
-```shell
+```shell {copy-lines="1"}
 kubectl describe cloudsqlinstance my-db
-```
-
-This should produce output that includes:
-
-```console
 Status:
   Conditions:
     Last Transition Time:  2019-09-16T13:46:42Z
@@ -183,14 +166,14 @@ lingering resources to clean up.
 
 In general, a finalizer can be removed from an object with this command:
 
-```console
+```shell
 kubectl patch <resource-type> <resource-name> -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
 For example, for a `CloudSQLInstance` managed resource (`database.gcp.crossplane.io`) named
 `my-db`, you can remove its finalizer with:
 
-```console
+```shell
 kubectl patch cloudsqlinstance my-db -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
@@ -202,7 +185,7 @@ you can do.
 
 Run below command to list all Crossplane resources available on your cluster:
 
-```console
+```shell
 kubectl get crossplane
 ```
 
@@ -220,14 +203,14 @@ package are listed if the package is installed successfully.
 If you only care about the installed packages, you can also run below command
 which will show you all installed Configuration and Provider packages:
 
-```console
+```shell
 kubectl get pkg
 ```
 
 When there are errors, you can run below command to check detailed information 
 for the packages that are getting installed.
 
-```console
+```shell
 kubectl get lock -o yaml
 ```
 
@@ -276,9 +259,9 @@ spec:
 ```
 
 <!-- Named Links -->
-
+<!-- 
 [Requested Resource Not Found]: #requested-resource-not-found
-[install Crossplane CLI]: {{<ref "../getting-started/install-configure" >}}#install-crossplane-cli
+[install Crossplane CLI]: "../getting-started/install-configure"
 [Resource Status and Conditions]: #resource-status-and-conditions
 [Resource Events]: #resource-events
 [Crossplane Logs]: #crossplane-logs
@@ -287,6 +270,6 @@ spec:
 [Pausing Providers]: #pausing-providers
 [Deleting When a Resource Hangs]: #deleting-when-a-resource-hangs
 [Installing Crossplane Package]: #installing-crossplane-package
-[Crossplane package]: {{<ref "../concepts/packages" >}}
+[Crossplane package]: "../concepts/packages"
 [Handling Crossplane Package Dependency]: #handling-crossplane-package-dependency
-[semver spec]: https://github.com/Masterminds/semver#basic-comparisons
+[semver spec]: https://github.com/Masterminds/semver#basic-comparisons -->

--- a/content/v1.10/reference/troubleshoot.md
+++ b/content/v1.10/reference/troubleshoot.md
@@ -259,7 +259,6 @@ spec:
 ```
 
 <!-- Named Links -->
-<!-- 
 [Requested Resource Not Found]: #requested-resource-not-found
 [install Crossplane CLI]: "../getting-started/install-configure"
 [Resource Status and Conditions]: #resource-status-and-conditions
@@ -272,4 +271,4 @@ spec:
 [Installing Crossplane Package]: #installing-crossplane-package
 [Crossplane package]: "../concepts/packages"
 [Handling Crossplane Package Dependency]: #handling-crossplane-package-dependency
-[semver spec]: https://github.com/Masterminds/semver#basic-comparisons -->
+[semver spec]: https://github.com/Masterminds/semver#basic-comparisons

--- a/content/v1.11/getting-started/introduction.md
+++ b/content/v1.11/getting-started/introduction.md
@@ -54,7 +54,7 @@ Custom Resource Definitions (`CRDs`) of the core Crossplane components.
 After installing Crossplane use `kubectl get crds` to view the Crossplane
 installed CRDs.
 
-```shell
+```shell {copy-lines="1"}
 kubectl get crds
 NAME                                                     
 compositeresourcedefinitions.apiextensions.crossplane.io 

--- a/content/v1.11/getting-started/provider-aws-part-2.md
+++ b/content/v1.11/getting-started/provider-aws-part-2.md
@@ -29,7 +29,7 @@ DynamoDB instance
 helm repo add \
 crossplane-stable https://charts.crossplane.io/stable
 helm repo update
-
+&&
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \

--- a/content/v1.11/getting-started/provider-aws-part-3.md
+++ b/content/v1.11/getting-started/provider-aws-part-3.md
@@ -30,7 +30,7 @@ set in a _claim_ change or get applied the associated _composite resources_.
 helm repo add \
 crossplane-stable https://charts.crossplane.io/stable
 helm repo update
-
+&&
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \

--- a/content/v1.11/getting-started/provider-aws.md
+++ b/content/v1.11/getting-started/provider-aws.md
@@ -41,8 +41,7 @@ Enable the Crossplane Helm Chart repository:
 
 ```shell
 helm repo add \
-crossplane-stable https://charts.crossplane.io/stable
-helm repo update
+crossplane-stable https://charts.crossplane.io/stable && helm repo update
 ```
 
 Run the Helm dry-run to see all the Crossplane components Helm installs.

--- a/content/v1.11/software/install.md
+++ b/content/v1.11/software/install.md
@@ -24,8 +24,7 @@ Add the Crossplane repository with the `helm repo add` command and update the
 local Helm chart cache with `helm repo update`.
 
 ```shell
-helm repo add crossplane-stable https://charts.crossplane.io/stable
-helm repo update
+helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update
 ```
 
 ### Install the Crossplane Helm chart

--- a/content/v1.9/contributing/adding_external_secret_store_support.md
+++ b/content/v1.9/contributing/adding_external_secret_store_support.md
@@ -28,7 +28,7 @@ We need a workaround for code generation since latest runtime both adds new API
 but also adds a new interface to managed.resourceSpec. Without this workaround,
 expect errors similar to below:
 
-  ```shell
+  ```console
   16:40:56 [ .. ] go generate darwin_amd64
   angryjet: error: error loading packages using pattern ./...: /Users/hasanturken/  Workspace/crossplane/provider-gcp/apis/cache/v1beta1/zz_  generated.managedlist.go:27:14: cannot use &l.Items[i] (value of type *  CloudMemorystoreInstance) as "github.com/crossplane/crossplane-runtime/pkg/  resource".Managed value in assignment: missing method GetPublishConnectionDetailsTo
   exit status 1

--- a/themes/geekboot/assets/scss/_code-theme-base.scss
+++ b/themes/geekboot/assets/scss/_code-theme-base.scss
@@ -1,4 +1,11 @@
 @mixin code-theme-base {
+// code.language-shell::before {
+//   content: "$ ";
+// }
+
+  .language-shell :first-child .cl::before{
+      content: "$ "
+  }
 
   // Code box div
   .highlight {


### PR DESCRIPTION
The first commit updates the CSS to apply a `$` character before the first line of a ` ```shell ` codefence.

The other, larger, commit scrubs existing shell code fences to ensure each codefence executes a single command. 

Resolves #317 

Signed-off-by: Pete Lumbis <pete@upbound.io>