### PR TITLE
Add warning that ControllerConfig is deprecated

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -379,8 +379,10 @@ package without considering the version of Crossplane that is installed.
 
 ### spec.controllerConfigRef
 
-> This field is only available when installing a `Provider` and is an `alpha`
-> feature that depends on the `v1alpha1` [`ControllerConfig` API][controller-config-docs].
+{{< hint "warning" >}}
+The `ControllerConfig` API has been deprecated and will be removed in a future
+release when a comparable alternative is available.
+{{< /hint >}}
 
 Valid values: name of a `ControllerConfig` object
 

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -379,8 +379,10 @@ package without considering the version of Crossplane that is installed.
 
 ### spec.controllerConfigRef
 
-> This field is only available when installing a `Provider` and is an `alpha`
-> feature that depends on the `v1alpha1` [`ControllerConfig` API][controller-config-docs].
+{{< hint "warning" >}}
+The `ControllerConfig` API has been deprecated and will be removed in a future
+release when a comparable alternative is available.
+{{< /hint >}}
 
 Valid values: name of a `ControllerConfig` object
 


### PR DESCRIPTION
Adds a warning in the package documentation that the ControllerConfig API is now deprecated.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>