### PR TITLE
Fix mobility issues reported by Google Console

### DIFF
--- a/content/v1.10/reference/install.md
+++ b/content/v1.10/reference/install.md
@@ -64,9 +64,8 @@ including all the custom resources and controllers.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Crossplane chart
-and their default values.
-
+{{< expand "Select to view all configuration options" >}}
+{{< table "table table-hover table-striped table-sm">}}
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `affinity` | Enable affinity for Crossplane pod | `{}` |
@@ -118,7 +117,8 @@ and their default values.
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 | `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 | `webhooks.enabled` | Enable webhook functionality for Crossplane as well as packages installed by Crossplane. | `false` |
-
+{{< /table >}}
+{{< /expand >}}
 ### Command Line
 
 You can pass the settings with helm command line parameters. Specify each

--- a/content/v1.9/reference/install.md
+++ b/content/v1.9/reference/install.md
@@ -71,6 +71,8 @@ including all the custom resources and controllers.
 The following tables lists the configurable parameters of the Crossplane chart
 and their default values.
 
+{{< expand "Select to view all configuration options" >}}
+{{< table "table table-hover table-striped table-sm">}}
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `affinity` | Enable affinity for Crossplane pod | `{}` |
@@ -122,7 +124,8 @@ and their default values.
 | `extraEnvVarsCrossplane` | List of extra environment variables to set in the crossplane deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 | `extraEnvVarsRBACManager` | List of extra environment variables to set in the crossplane rbac manager deployment. Any `.` in variable names will be replaced with `_` (example: `SAMPLE.KEY=value1` becomes `SAMPLE_KEY=value1`). | `{}` |
 | `webhooks.enabled` | Enable webhook functionality for Crossplane as well as packages installed by Crossplane. | `false` |
-
+{{< /table >}}
+{{< /expand >}}
 ### Command Line
 
 You can pass the settings with helm command line parameters. Specify each

--- a/themes/geekboot/assets/scss/_code-theme-base.scss
+++ b/themes/geekboot/assets/scss/_code-theme-base.scss
@@ -48,6 +48,12 @@
         color: #f8f9fa;   // Code color if there is no defined highlighter style
         background-color: var(--code-block-background-color);
 
+        .line {
+          @include media-breakpoint-down(lg){
+            padding-bottom: 3px;
+            padding-top: 3px;
+          }
+        }
         // Line numbers
         .ln {
           background-color: var(--code-line-numbers-background-color);

--- a/themes/geekboot/layouts/partials/analytics.html
+++ b/themes/geekboot/layouts/partials/analytics.html
@@ -1,3 +1,2 @@
 {{ partialCached "ms-clarity" . }}
 {{ partialCached "google-analytics" . }}
-{{ partialCached "hubspot" . }}

--- a/themes/geekboot/layouts/partials/hubspot.html
+++ b/themes/geekboot/layouts/partials/hubspot.html
@@ -1,3 +1,0 @@
-<!-- Start of HubSpot Embed Code -->
-<script type="text/javascript" id="hs-script-loader" async defer src="https://js.hs-scripts.com/5557732.js"></script>
-<!-- End of HubSpot Embed Code -->


### PR DESCRIPTION
Google Search Console reports issues with mobility due to text size and elements too close together.

This PR removes the unused Hubspot analytics that contains too small text and puts additional space between code box line numbers when the viewport is a mobile device.

Two pages have outputs that create large horizontal scrolls. This places their content into responsive tables to prevent other mobile issues.

Signed-off-by: Pete Lumbis <pete@upbound.io>