### PR TITLE
Fix broken links and includes

### DIFF
--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -34,8 +34,6 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-{{</* include file="install-crossplane.md" type="page" */>}}
-
 ## Install the Azure provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -21,7 +21,7 @@ This guide walks you through the steps required to get started with the Upbound 
 This quickstart requires:
 * a Kubernetes cluster with at least 3 GB of RAM
 * permissions to create pods and secrets in the Kubernetes cluster
-* [Helm] version `v3.2.0` or later
+* [Helm](https://helm.sh/) version `v3.2.0` or later
 * a GCP account with permissions to create a storage bucket
 * GCP [account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 * GCP [Project ID](https://support.google.com/googleapi/answer/7014113?hl=en)

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -35,9 +35,6 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-
-{{</* include file="install-crossplane.md" type="page" */>}}
-
 ## Install the GCP provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 

--- a/content/v1.11/getting-started/provider-gcp.md
+++ b/content/v1.11/getting-started/provider-gcp.md
@@ -21,7 +21,7 @@ This guide walks you through the steps required to get started with the Upbound 
 This quickstart requires:
 * a Kubernetes cluster with at least 3 GB of RAM
 * permissions to create pods and secrets in the Kubernetes cluster
-* [Helm] version `v3.2.0` or later
+* [Helm](https://helm.sh/) version `v3.2.0` or later
 * a GCP account with permissions to create a storage bucket
 * GCP [account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 * GCP [Project ID](https://support.google.com/googleapi/answer/7014113?hl=en)

--- a/content/v1.11/getting-started/provider-gcp.md
+++ b/content/v1.11/getting-started/provider-gcp.md
@@ -35,9 +35,6 @@ If you don't have a Kubernetes cluster create one locally with [minikube](https:
 All commands use the current `kubeconfig` context and configuration. 
 {{< /hint >}}
 
-
-{{</* include file="install-crossplane.md" type="page" */>}}
-
 ## Install the GCP provider
 
 Install the provider into the Kubernetes cluster with a Kubernetes configuration file. 


### PR DESCRIPTION
Fixes a broken helm link in the GCP quickstart.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Removes broken crossplane installation instructions.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>