### PR TITLE
Make entire sidebar menu clickable

### DIFF
--- a/themes/geekboot/assets/scss/_sidebar.scss
+++ b/themes/geekboot/assets/scss/_sidebar.scss
@@ -15,6 +15,11 @@
 .bd-links-nav {
   font-size: .95rem !important;
 
+  a.bd-links{
+    text-decoration: none !important;
+    color: var(--body-color) !important;
+  }
+
   @include media-breakpoint-down(lg) {
     margin-top: 0 !important;
     font-size: 1rem !important;

--- a/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -11,7 +11,7 @@
       {{ if not .Page.Params.tocHidden }}
         <div class="section-container container pe-0 pt-1">
           <div class="container nav-container pe-0 d-flex w-100 {{if eq . $current}}active{{ else if $expand }}active-parent{{end}}">
-            <div class="d-flex w-100 border-0"><a href="{{.Permalink}}">{{ .Title }} </a></div>
+            <a class="d-flex w-100 border-0" href="{{.Permalink}}">{{ .Title }} </a>
             {{ if and .IsSection (ne .FirstSection .) }}
               {{/* Don't put an expand icon on pages that aren't sections or the section index */}}
               <div class="d-flex flex-shrink-1 sidebar-control-container align-self-center">
@@ -28,7 +28,7 @@
               {{ if not .Page.Params.tocHidden }}
                 <div class="container flex-row collapse {{if $expand}} show {{ end }}" id="collapse-{{$id }}">
                   <div class="d-flex flex-column">
-                    <div class="bd-links d-flex {{if eq $current . }}active{{end}}"><a href="{{ .Permalink }} ">{{.Title }}</a></div>
+                    <a class="bd-links d-flex {{if eq $current . }}active{{end}}" href="{{ .Permalink }} ">{{.Title }}</a>
                   </div>
                 </div>
               {{ end }}


### PR DESCRIPTION
Resolves #297

makes the entire left-nav menu item clickable instead of only the word. 

Signed-off-by: Pete Lumbis <pete@upbound.io>