### PR TITLE
Fixing composition functions install command

### DIFF
--- a/content/knowledge-base/guides/composition-functions.md
+++ b/content/knowledge-base/guides/composition-functions.md
@@ -37,7 +37,7 @@ Enable support for Composition Functions by enabling the alpha feature flag in C
 
 ```shell
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane \
-    --create-namespace
+    --create-namespace \
     --set "args={--debug,--enable-composition-functions}" \
     --set "xfn.enabled=true" \
     --set "xfn.args={--debug}"


### PR DESCRIPTION
The composition functions install command was missing a new line continuation and was not working.