### PR TITLE
Script to clear or reset span contents for editable elements

### DIFF
--- a/themes/geekboot/assets/scss/_code-theme-base.scss
+++ b/themes/geekboot/assets/scss/_code-theme-base.scss
@@ -16,6 +16,15 @@
     margin-top: 1rem; // prevent boxes from running together
     margin-bottom: 1rem;
 
+    [contentEditable=true]:empty:before{
+      content:attr(data-default);
+    }
+
+
+    [contentEditable=true]:empty:focus:before{
+      color:#ddd;
+    }
+
     :target{
       margin-top: 0;
       padding-top: 0;

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -19,3 +19,21 @@
     });
 
 </script>
+
+<script>
+    // Used by editCode shortcode to clear the editable element
+    function clearSpan(spanElem){
+        // Only clear the contents if it's the default contents
+        if (!spanElem.innerText.localeCompare(spanElem.dataset.default)){
+            spanElem.innerText = ""
+        }
+    }
+
+    // Used by editCode shortcode to restore the placeholder text
+    function checkSpanDefault(spanElem){
+        // Restore the placeholder text if the box is empty
+        if (spanElem.innerText === ""){
+            spanElem.innerText = spanElem.dataset.default
+        }
+    }
+</script>

--- a/themes/geekboot/layouts/partials/scripts.html
+++ b/themes/geekboot/layouts/partials/scripts.html
@@ -19,21 +19,3 @@
     });
 
 </script>
-
-<script>
-    // Used by editCode shortcode to clear the editable element
-    function clearSpan(spanElem){
-        // Only clear the contents if it's the default contents
-        if (!spanElem.innerText.localeCompare(spanElem.dataset.default)){
-            spanElem.innerText = ""
-        }
-    }
-
-    // Used by editCode shortcode to restore the placeholder text
-    function checkSpanDefault(spanElem){
-        // Restore the placeholder text if the box is empty
-        if (spanElem.innerText === ""){
-            spanElem.innerText = spanElem.dataset.default
-        }
-    }
-</script>

--- a/themes/geekboot/layouts/shortcodes/editCode.html
+++ b/themes/geekboot/layouts/shortcodes/editCode.html
@@ -1,1 +1,1 @@
-{{ replaceRE `\$\$(.*)\$\$` "<span class=\"pe-2 editable\" data-default=\"$1\" contentEditable=\"true\" onfocusout=\"checkSpanDefault(this)\" onclick=\"clearSpan(this);\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}
+{{ replaceRE `\$\$(.*)\$\$` "<span class=\"pe-2 editable\" data-default=\"$1\" contentEditable=\"true\"></span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}

--- a/themes/geekboot/layouts/shortcodes/editCode.html
+++ b/themes/geekboot/layouts/shortcodes/editCode.html
@@ -1,1 +1,1 @@
-{{ replaceRE `\$\$(.*)\$\$` "<span class=\"pe-2\" contentEditable=\"true\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}
+{{ replaceRE `\$\$(.*)\$\$` "<span class=\"pe-2 editable\" data-default=\"$1\" contentEditable=\"true\" onfocusout=\"checkSpanDefault(this)\" onclick=\"clearSpan(this);\">$1</span><svg class=\"bi text-white\" width=\"1em\" height=\"1em\"><use xlink:href=\"#pencil-square\"/></svg>" (.Inner | markdownify) | safeHTML }}


### PR DESCRIPTION
Resolves #329 

When clicking on an editable field, if the contents are the placeholder text, the contents are cleared.

If you click away and the contents are blank the placeholder text is restored.

To support this the placeholder text is added as a `data-` element in the span. 

 
![329-demo](https://user-images.githubusercontent.com/10537576/222224493-952451c3-d23c-405a-9a83-caee70a39676.gif)

Demo: https://deploy-preview-374--crossplane.netlify.app/v1.11/getting-started/provider-aws/#generate-an-aws-key-pair-file

Signed-off-by: Pete Lumbis <pete@upbound.io>