### PR TITLE
Add notices to top of all v1.10 pages that moved after PR #271

### DIFF
--- a/content/v1.10/cloud-providers/aws/aws-provider.md
+++ b/content/v1.10/cloud-providers/aws/aws-provider.md
@@ -3,6 +3,13 @@ title: Adding Amazon Web Services (AWS) to Crossplane
 tocHidden: true
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+View the latest 
+[AWS quickstart guide]({{<ref "/v1.11/getting-started/provider-aws" >}}).
+{{</hint >}}
+
 In this guide, we will walk through the steps necessary to configure your AWS
 account to be ready for integration with Crossplane. This will be done by adding
 an AWS `ProviderConfig` resource type, which enables Crossplane to communicate with an

--- a/content/v1.10/cloud-providers/azure/azure-provider.md
+++ b/content/v1.10/cloud-providers/azure/azure-provider.md
@@ -3,6 +3,13 @@ title: Adding Microsoft Azure to Crossplane
 tocHidden: true
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+View the latest 
+[Azure quickstart guide]({{<ref "/v1.11/getting-started/provider-azure" >}}).
+{{</hint >}}
+
 In this guide, we will walk through the steps necessary to configure your Azure
 account to be ready for integration with Crossplane. The general steps we will
 take are summarized below:

--- a/content/v1.10/cloud-providers/gcp/gcp-provider.md
+++ b/content/v1.10/cloud-providers/gcp/gcp-provider.md
@@ -3,6 +3,12 @@ title: Adding Google Cloud Platform (GCP) to Crossplane
 tocHidden: true
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+View the latest 
+[GCP quickstart guide]({{<ref "/v1.11/getting-started/provider-gcp" >}}).
+{{</hint >}}
 
 In this guide, we will walk through the steps necessary to configure your GCP
 account to be ready for integration with Crossplane. The general steps we will

--- a/content/v1.10/contributing/_index.md
+++ b/content/v1.10/contributing/_index.md
@@ -3,6 +3,16 @@ title: Contributing
 weight: 1000
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Contributing to the Crossplane project and provider development is now in the
+[Crossplane contributing repository](https://github.com/crossplane/crossplane/tree/master/contributing).
+
+Contributing to Crossplane documentation is in the docs 
+[Contributing]({{<ref "contribute" >}}) section.
+{{</hint >}}
+
 The best place to start if you're thinking about contributing to Crossplane is
 our [`CONTRIBUTING.md`] file. The following documents supplement that guide.
 

--- a/content/v1.10/contributing/adding_external_secret_store_support.md
+++ b/content/v1.10/contributing/adding_external_secret_store_support.md
@@ -3,14 +3,21 @@ title: Adding Secret Store Support
 weight: 1004
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+The [Crossplane contributing repository](https://github.com/crossplane/crossplane/blob/master/contributing/guide-adding-external-secret-stores.md)
+contains any future revisions to this document.
+{{</hint >}}
+
 To add support for [External Secret Stores] in a provider, we need the following
 changes at a high level:
 
 1. Bump Crossplane Runtime and Crossplane Tools to latest and generate existing
 resources to include `PublishConnectionDetails` API.
-2. Add a new Type and CRD for Secret StoreConfig.
-3. Add feature flag for enabling External Secret Store support.
-4. Add Secret Store Connection Details Manager as a `ConnectionPublisher` if
+1. Add a new Type and CRD for Secret StoreConfig.
+2. Add feature flag for enabling External Secret Store support.
+3. Add Secret Store Connection Details Manager as a `ConnectionPublisher` if
 feature enabled.
 
 In this document, we will go through each step in details. You can check 

--- a/content/v1.10/contributing/docs.md
+++ b/content/v1.10/contributing/docs.md
@@ -2,6 +2,16 @@
 title: "Crossplane Documentation"
 weight: 2000
 ---
+
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+The 
+[Crossplane docs contributing guide]({{<ref "contribute">}})
+contains any future revisions to this document.
+{{</hint >}}
+
+
 ## Code of conduct
 Crossplane follows the [CNCF Code of
 Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/content/v1.10/contributing/observability_developer_guide.md
+++ b/content/v1.10/contributing/observability_developer_guide.md
@@ -3,6 +3,14 @@ title: Observability Developer Guide
 weight: 1002
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+The [Crossplane contributing repository](https://github.com/crossplane/crossplane/blob/master/contributing/guide-observability.md)
+contains any future revisions to this document.
+{{</hint >}}
+
+
 ## Introduction
 
 Observability is crucial to Crossplane users; both those operating Crossplane

--- a/content/v1.10/contributing/provider_development_guide.md
+++ b/content/v1.10/contributing/provider_development_guide.md
@@ -3,6 +3,13 @@ title: Provider Development Guide
 weight: 1001
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+The [Crossplane contributing repository](https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md)
+contains any future revisions to this document.
+{{</hint >}}
+
 Crossplane allows you to manage infrastructure directly from Kubernetes. Each
 infrastructure API resource that Crossplane orchestrates is known as a "managed
 resource". This guide will walk through the process of adding support for a new

--- a/content/v1.10/contributing/release-process.md
+++ b/content/v1.10/contributing/release-process.md
@@ -3,6 +3,14 @@ title: Release Process
 weight: 1003
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+The [Crossplane contributing repository](https://github.com/crossplane/crossplane/blob/master/contributing/release-process.md)
+contains any future revisions to this document.
+{{</hint >}}
+
+
 This document is meant to be a complete end-to-end guide for how to release new
 versions of software for Crossplane and its related projects.
 

--- a/content/v1.10/faqs/_index.md
+++ b/content/v1.10/faqs/_index.md
@@ -3,6 +3,10 @@ title: FAQ
 weight: 1200
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 ### Where did the name Crossplane come from?
 
 Crossplane is the fusing of cross-cloud control plane. We wanted to use a noun

--- a/content/v1.10/faqs/related_projects.md
+++ b/content/v1.10/faqs/related_projects.md
@@ -3,6 +3,10 @@ title: Related Projects
 weight: 1201
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 While there are many projects that address similar issues, none of them
 encapsulate the full use case that Crossplane addresses. This list is not
 exhaustive and is not meant to provide a deep analysis of the following

--- a/content/v1.10/getting-started/create-configuration.md
+++ b/content/v1.10/getting-started/create-configuration.md
@@ -3,6 +3,13 @@ title: Create a Configuration
 weight: 4
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Current Crossplane documentation versions introduce configurations as part of
+the [Getting Started]({{<ref "/v1.11/getting-started" >}}) guides. 
+{{</hint >}}
+
 In the [previous section] we were able to create a PostgreSQL database because
 we had installed a configuration package that defined the `PostgreSQLInstance`
 type and a `Composition` of managed resources that mapped to it. Crossplane

--- a/content/v1.10/getting-started/install-configure.md
+++ b/content/v1.10/getting-started/install-configure.md
@@ -2,6 +2,14 @@
 title: Install & Configure
 weight: 2
 ---
+
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Read the current [Install and Upgrade]({{<ref "/v1.11/software" >}}) guide.
+{{</hint >}}
+
+
 ## Choosing Your Crossplane Distribution
 
 Users looking to use Crossplane for the first time have two options available to

--- a/content/v1.10/getting-started/provision-infrastructure.md
+++ b/content/v1.10/getting-started/provision-infrastructure.md
@@ -3,6 +3,13 @@ title: Provision Infrastructure
 weight: 3
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Current Crossplane documentation versions introduce configurations as part of
+the [Getting Started]({{<ref "/v1.11/getting-started" >}}) guides. 
+{{</hint >}}
+
 Composite resources (XRs) are always cluster scoped - they exist outside of any
 namespace. This allows an XR to represent infrastructure that might be consumed
 from several different namespaces. This is often true for VPC networks - an

--- a/content/v1.10/guides/_index.md
+++ b/content/v1.10/guides/_index.md
@@ -3,6 +3,10 @@ title: Guides
 weight: 200
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 This section contains guides for using Crossplane in specific scenarios or
 alongside other technologies. If you are interested in writing and
 maintaining a guide for your own use-case please feel free to [open an issue] to

--- a/content/v1.10/guides/argo-cd-crossplane.md
+++ b/content/v1.10/guides/argo-cd-crossplane.md
@@ -3,6 +3,12 @@ title: Configuring Crossplane with Argo CD
 weight: 270
 ---  
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/integrations/argo-cd-crossplane" >}}).
+{{</hint >}}
+
 [Argo CD](https://argoproj.github.io/cd/) and [Crossplane](https://crossplane.io)
 are a great combination. Argo CD provides GitOps while Crossplane turns any Kubernetes
 cluster into a Universal Control Plane for all of your resources. There are

--- a/content/v1.10/guides/composition-revisions.md
+++ b/content/v1.10/guides/composition-revisions.md
@@ -2,6 +2,12 @@
 title: Composition Revisions
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/composition-revisions" >}}).
+{{</hint >}}
+
 This guide discusses the use of "Composition Revisions" to safely make and roll
 back changes to a Crossplane [`Composition`][composition-type]. It assumes
 familiarity with Crossplane, and particularly with

--- a/content/v1.10/guides/multi-tenant.md
+++ b/content/v1.10/guides/multi-tenant.md
@@ -3,6 +3,12 @@ title: Multi-Tenant Crossplane
 weight: 240
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/multi-tenant" >}}).
+{{</hint >}}
+
 This guide describes how to use Crossplane effectively in multi-tenant
 environments by utilizing Kubernetes primitives and compatible policy
 enforcement projects in the cloud-native ecosystem.

--- a/content/v1.10/guides/self-signed-ca-certs.md
+++ b/content/v1.10/guides/self-signed-ca-certs.md
@@ -3,6 +3,12 @@ title: Self-Signed CA Certs
 weight: 270   
 ---  
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/self-signed-ca-certs" >}}).
+{{</hint >}}
+
 >  Using self-signed certificates is not advised in production, it is 
 recommended to only use self-signed certificates for testing.
 

--- a/content/v1.10/guides/upgrading-to-v0.14.md
+++ b/content/v1.10/guides/upgrading-to-v0.14.md
@@ -3,6 +3,10 @@ title: Upgrading to v0.14
 weight: 210
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 Crossplane made a small handful of breaking changes in v0.14. The most broadly
 impactful change was updating the `CompositeResourceDefinition` (XRD) schema to
 support defining multiple versions of a composite resource (XR) at once. This

--- a/content/v1.10/guides/upgrading-to-v1.x.md
+++ b/content/v1.10/guides/upgrading-to-v1.x.md
@@ -3,6 +3,11 @@ title: Upgrading to v1.x
 weight: 220
 ---
 
+
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 Crossplane versions post v1.0 do not introduce any breaking changes, but may
 make some backward compatible changes to the core Crossplane CRDs. Helm [does
 not currently touch CRDs](https://github.com/helm/helm/issues/6581) when a chart

--- a/content/v1.10/guides/vault-as-secret-store.md
+++ b/content/v1.10/guides/vault-as-secret-store.md
@@ -3,6 +3,12 @@ title: Vault as an External Secret Store
 weight: 230
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/integrations/vault-as-secret-store" >}}).
+{{</hint >}}
+
 This guide walks through the steps required to configure Crossplane and
 its Providers to use [Vault] as an [External Secret Store]. For the sake of
 completeness, we will also include steps for Vault installation and setup,

--- a/content/v1.10/guides/vault-injection.md
+++ b/content/v1.10/guides/vault-injection.md
@@ -3,6 +3,11 @@ title: Vault Credential Injection
 weight: 230
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/integrations/vault-injection" >}}).
+{{</hint >}}
 
 > This guide is adapted from the [Vault on Minikube] and [Vault Kubernetes
 > Sidecar] guides.

--- a/content/v1.10/reference/_index.md
+++ b/content/v1.10/reference/_index.md
@@ -3,6 +3,10 @@ title: Reference
 weight: 300
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 The reference documentation includes answers to frequently asked questions,
 information about similar projects, and links to resources that can help you
 learn more about Crossplane and Kubernetes. If you have additional information

--- a/content/v1.10/reference/composition.md
+++ b/content/v1.10/reference/composition.md
@@ -3,6 +3,13 @@ title: Composition
 weight: 304
 ---
 
+{{<hint "important" >}}
+This document moved in recent versions of Crossplane documentation. 
+
+Read the new 
+[Crossplane Introduction]({{<ref "/v1.11/getting-started/introduction">}}).
+{{</hint >}}
+
 
 This reference provides detailed examples of defining, configuring, and using
 Composite Resources in Crossplane. You can also refer to Crossplane's [API

--- a/content/v1.10/reference/configure.md
+++ b/content/v1.10/reference/configure.md
@@ -3,6 +3,13 @@ title: Configure Your Cloud Provider Account
 weight: 302
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Current Crossplane documentation versions introduce configurations as part of
+the [Getting Started]({{<ref "/v1.11/getting-started" >}}) guides. 
+{{</hint >}}
+
 In order for Crossplane to be able to manage resources in a specific cloud
 provider, you will need to create an account for Crossplane to use. Use the
 links below for cloud-specific instructions to create an account that can be

--- a/content/v1.10/reference/feature-lifecycle.md
+++ b/content/v1.10/reference/feature-lifecycle.md
@@ -5,6 +5,11 @@ weight: 309
 indent: true
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/feature-lifecycle" >}}).
+{{</hint >}}
 # Feature Lifecycle
 
 Crossplane follows a similar feature lifecycle to [upstream

--- a/content/v1.10/reference/install.md
+++ b/content/v1.10/reference/install.md
@@ -3,6 +3,12 @@ title: Install Crossplane
 weight: 301
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Read the current [Install and Upgrade]({{<ref "/v1.11/software" >}}) guide.
+{{</hint >}}
+
 Crossplane can be easily installed into any existing Kubernetes cluster using
 the regularly published Helm chart. The Helm chart contains all the custom
 resources and controllers needed to deploy and configure Crossplane.

--- a/content/v1.10/reference/learn_more.md
+++ b/content/v1.10/reference/learn_more.md
@@ -3,6 +3,10 @@ title: Learn More
 weight: 307
 ---
 
+{{<hint "important" >}}
+Recent versions of Crossplane documentation removed this document.
+{{</hint >}}
+
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 
 ***Learn more about using Crossplane***

--- a/content/v1.10/reference/release-cycle.md
+++ b/content/v1.10/reference/release-cycle.md
@@ -3,6 +3,12 @@ title: Release Cycle
 weight: 308
 ---
 
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/release-cycle" >}}).
+{{</hint >}}
+
 Starting with the v1.10.0 release, Crossplane is released on a quarterly (13
 week) cadence. A cycle is comprised of three general stages:
 

--- a/content/v1.10/reference/troubleshoot.md
+++ b/content/v1.10/reference/troubleshoot.md
@@ -2,6 +2,13 @@
 title: Troubleshoot
 weight: 306
 ---
+
+{{<hint "important" >}}
+This document has moved. 
+Read the recent version in the 
+[Crossplane Knowledge Base]({{< ref "knowledge-base/guides/troubleshoot" >}}).
+{{</hint >}}
+
 ## Requested Resource Not Found
 
 If you use the kubectl Crossplane plugin to install a `Provider` or

--- a/content/v1.10/reference/uninstall.md
+++ b/content/v1.10/reference/uninstall.md
@@ -3,6 +3,12 @@ title: Uninstall Crossplane
 weight: 303
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Read the current [Install and Upgrade]({{<ref "/v1.11/software" >}}) guide.
+{{</hint >}}
+
 Crossplane has a number of components that must be cleaned up in order to
 guarantee proper removal from the cluster. When deleting objects, it is best to
 consider parent-child relationships and clean up the children first to ensure

--- a/content/v1.10/reference/xpkg.md
+++ b/content/v1.10/reference/xpkg.md
@@ -3,6 +3,12 @@ title: xpkg Specification
 weight: 305
 ---
 
+{{<hint "important" >}}
+This document has moved in recent versions of Crossplane documentation. 
+
+Read the current [Crossplane Packages]({{<ref "/v1.11/concepts/packages" >}}) guide.
+{{</hint >}}
+
 Crossplane supports two types of [packages]: Providers and Configurations. These
 packages are distributed as generic [OCI images], which contain [YAML] content
 informing the Crossplane package manager how to alter the state of a cluster by


### PR DESCRIPTION
This adds an `important` notice to all pages that were moved from v1.10 to v1.11 with the reorg in PR #271 

For example:

![Screenshot 2023-03-06 at 10 54 47 AM](https://user-images.githubusercontent.com/10537576/223162278-7d020697-9109-4fef-8ba5-382485dd7192.png)

Vale failures are expected since this is old content.

Resolves #377