### PR TITLE
docs: composition validation

### DIFF
--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1168,6 +1168,40 @@ not considered to be 'empty', and thus will pass the readiness check.
 
 `None`. Considers the composed resource to be ready as soon as it exists.
 
+### Composition Validation
+
+Crossplane uses a `Validating Webhook` to inform users of any potential
+misconfigurations in a `Composition` as early as possible. The default behavior
+of the webhook is to perform `logical checks` only, enforcing requirements that
+are not explicitly defined in the schema but are assumed to be hold at runtime.
+
+#### Experimental Validation With Schemas
+
+Crossplane provides experimental schema-aware validation that can be enabled
+through the `--enable-composition-webhook-schema-validation` feature flag. This
+will enable Composition validation against available schemas in the Cluster,
+ensuring, for example, that fieldPaths are valid and source and destination
+types match taking into account provided transforms too.
+
+The `crossplane.io/composition-validation-mode` annotation on the Composition
+allows to set one of two modes for schema validation:
+
+There are two modes of validation:
+-  `strict`: Compositions are validated against required schemas, and rejected
+    if any error is found. If any of the required schemas is missing, the
+    Composition will be directly rejected.
+-  `loose` (default): Same as `strict` mode, except that in case of missing
+    required schemas, schema validation will be skipped emitting only a
+    warning.
+
+See the dedicated [design document][validation-design-doc] for more information
+about future development around schema-aware validation.
+
+#### Disabling Webhooks
+
+Webhooks are enabled by default, but can be disabled by setting
+`webhooks.enabled` to `false` in the provided Helm Chart.
+
 ### Missing Functionality
 
 You might find while reading through this reference that Crossplane is missing
@@ -1287,40 +1321,6 @@ so:
    annotation.
 1. Use a `FromCompositeFieldPath` patch to patch from the 'intermediary' field
    you patched to in step 1 to a field on the destination composed resource.
-
-### Composition Validation
-
-Crossplane uses a `Validating Webhook` to inform users of any potential
-misconfigurations in a `Composition` as early as possible. The default behavior
-of the webhook is to perform `logical checks` only, enforcing requirements that
-are not explicitly defined in the schema but are assumed to be hold at runtime.
-
-#### Experimental Validation With Schemas
-
-Crossplane provides experimental schema-aware validation that can be enabled
-through the `--enable-composition-webhook-schema-validation` feature flag. This
-will enable Composition validation against available schemas in the Cluster,
-ensuring, for example, that fieldPaths are valid and source and destination
-types match taking into account provided transforms too.
-
-The `crossplane.io/composition-validation-mode` annotation on the Composition
-allows to set one of two modes for schema validation:
-
-There are two modes of validation:
--  `strict`: Compositions are validated against required schemas, and rejected
-    if any error is found. If any of the required schemas is missing, the
-    Composition will be directly rejected.
--  `loose` (default): Same as `strict` mode, except that in case of missing
-    required schemas, schema validation will be skipped emitting only a
-    warning.
-
-See the dedicated [design document][validation-design-doc] for more information
-about future development around schema-aware validation.
-
-#### Disabling Webhooks
-
-Webhooks are enabled by default, but can be disabled by setting
-`webhooks.enabled` to `false` in the provided Helm Chart.
 
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [raise an issue]: https://github.com/crossplane/crossplane/issues/new?assignees=&labels=enhancement&template=feature_request.md

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1173,29 +1173,28 @@ not considered to be 'empty', and thus will pass the readiness check.
 Crossplane uses a `Validating Webhook` to inform users of any potential
 misconfigurations in a `Composition` as early as possible. The default behavior
 of the webhook is to perform `logical checks` only, enforcing requirements that
-are not explicitly defined in the schema but are assumed to be hold at runtime.
+are not explicitly defined in the schema but are assumed to hold at runtime.
 
 #### Experimental Validation With Schemas
 
 Crossplane provides experimental schema-aware validation that can be enabled
 through the `--enable-composition-webhook-schema-validation` feature flag. This
-will enable Composition validation against available schemas in the Cluster,
-ensuring, for example, that fieldPaths are valid and source and destination
+will enable Composition validation against available schemas in the cluster,
+ensuring, for example, that `fieldPaths` are valid and source and destination
 types match taking into account provided transforms too.
 
 The `crossplane.io/composition-validation-mode` annotation on the Composition
-allows to set one of two modes for schema validation:
+allows setting one of two modes for schema validation:
 
-There are two modes of validation:
--  `strict`: Compositions are validated against required schemas, and rejected
-    if any error is found. If any of the required schemas is missing, the
-    Composition will be directly rejected.
 -  `loose` (default): Same as `strict` mode, except that in case of missing
     required schemas, schema validation will be skipped emitting only a
     warning.
+-  `strict`: Compositions are validated against required schemas, and rejected
+    if any error is found. If any of the required schemas is missing, the
+    Composition will be directly rejected.
 
-See the dedicated [design document][validation-design-doc] for more information
-about future development around schema-aware validation.
+See the [Composition Validating Webhook design document][validation-design-doc]
+for more information about future development around schema-aware validation.
 
 #### Disabling Webhooks
 

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1186,9 +1186,9 @@ types match taking into account provided transforms too.
 The `crossplane.io/composition-validation-mode` annotation on the Composition
 allows setting one of two modes for schema validation:
 
--  `loose` (default): Same as `strict` mode, except that in case of missing
-    required schemas, schema validation will be skipped emitting only a
-    warning.
+-  `loose` (default): Validates Compositions against required schemas. If a 
+    required schema is missing, schema validation stops, emits a warning and 
+    falls back to `logical checks` only.
 -  `strict`: Validates Compositions against required schemas, and rejects them
     when finding errors. Rejects any Compositions missing required schemas.
 

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1168,19 +1168,19 @@ not considered to be 'empty', and thus will pass the readiness check.
 
 `None`. Considers the composed resource to be ready as soon as it exists.
 
-### Composition Validation
+### Composition validation
 
 Crossplane uses a `Validating Webhook` to inform users of any potential
-misconfigurations in a `Composition` as early as possible. The default behavior
-of the webhook is to perform `logical checks` only, enforcing requirements that
-aren't explicitly defined in the schema but are assumed to hold at runtime.
+errors in a `Composition`. By default webhooks only perform
+`logical checks`. `logical checks` enforce requirements that
+aren't explicitly defined in the schema but Crossplane assumes to hold at runtime.
 
-#### Experimental Validation With Schemas
+#### Experimental validation with schemas
 
-Crossplane provides experimental schema-aware validation that can be enabled
+Enable experimental schema-aware validation in Crossplane
 through the `--enable-composition-webhook-schema-validation` feature flag. This
-will enable Composition validation against available schemas in the cluster,
-ensuring, for example, that `fieldPaths` are valid and source and destination
+enables Composition validation against available schemas in the cluster.
+For example, ensuring that `fieldPaths` are valid and source and destination
 types match taking into account provided transforms too.
 
 The `crossplane.io/composition-validation-mode` annotation on the Composition
@@ -1189,16 +1189,15 @@ allows setting one of two modes for schema validation:
 -  `loose` (default): Same as `strict` mode, except that in case of missing
     required schemas, schema validation will be skipped emitting only a
     warning.
--  `strict`: Compositions are validated against required schemas, and rejected
-    if any error is found. If any of the required schemas is missing, the
-    Composition will be directly rejected.
+-  `strict`: Validates Compositions against required schemas, and rejects them
+    when finding errors. Rejects any Compositions missing required schemas.
 
 See the [Composition Validating Webhook design document][validation-design-doc]
 for more information about future development around schema-aware validation.
 
-#### Disabling Webhooks
+#### Disabling webhooks
 
-Webhooks are enabled by default, but can be disabled by setting
+Crossplane enables webhooks by default. Turn off webhooks by
 `webhooks.enabled` to `false` in the provided Helm Chart.
 
 ### Missing Functionality

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1290,28 +1290,34 @@ so:
 
 ### Composition Validation
 
-In order to notify users as soon as possible of any `Composition`'s
-misconfiguration, Crossplane deploys a `Validating Webhook`. By default, only
-"logical" checks are performed, enforcing requirements not encoded in the
-schema itself, but documented and assumed by Crossplane to hold at runtime.
+Crossplane uses a `Validating Webhook` to inform users of any potential
+misconfigurations in a `Composition` as early as possible. The default behavior
+of the webhook is to perform `logical checks` only, enforcing requirements that
+are not explicitly defined in the schema but are assumed to be hold at runtime.
 
-In addition to the above, experimental schema-aware validation can be enabled
-by setting the `--enable-composition-webhook-schema-validation` feature flag.
-This will validate the given Composition at deploy time against the available
-schemas, e.g. fieldPaths are valid and source and destination types match in
-patches. Two modes are available for it and can be set through the
-`crossplane.io/composition-validation-mode` annotation on the Composition:
+#### Experimental Validation With Schemas
 
-- `strict`: if the required schemas are available, the Composition will be
-   validated against them and any error will make it invalid, otherwise it will
-   just error out straight away due to the missing requirement.
-- `loose` (default): if the required schemas are
-    available, it will behave as in `strict` mode. Instead, if they
-    are not available, schema validation will be skipped, emitting a
-    warning to notify the users about it.
+Crossplane provides experimental schema-aware validation that can be enabled
+through the `--enable-composition-webhook-schema-validation` feature flag. This
+will enable Composition validation against available schemas in the Cluster,
+ensuring, for example, that fieldPaths are valid and source and destination
+types match taking into account provided transforms too.
+
+The `crossplane.io/composition-validation-mode` annotation on the Composition
+allows to set one of two modes for schema validation:
+
+There are two modes of validation:
+-  `strict`: Compositions are validated against required schemas, and rejected
+    if any error is found. If any of the required schemas is missing, the
+    Composition will be directly rejected.
+-  `loose` (default): Same as `strict` mode, except that in case of missing
+    required schemas, schema validation will be skipped emitting only a
+    warning.
 
 See the dedicated [design document][validation-design-doc] for more information
 about future development around schema-aware validation.
+
+#### Disabling Webhooks
 
 Webhooks are enabled by default, but can be disabled by setting
 `webhooks.enabled` to `false` in the provided Helm Chart.

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1288,6 +1288,34 @@ so:
 1. Use a `FromCompositeFieldPath` patch to patch from the 'intermediary' field
    you patched to in step 1 to a field on the destination composed resource.
 
+### Composition Validation
+
+In order to notify users as soon as possible of any `Composition`'s
+misconfiguration, Crossplane deploys a `Validating Webhook`. By default, only
+"logical" checks are performed, enforcing requirements not encoded in the
+schema itself, but documented and assumed by Crossplane to hold at runtime.
+
+In addition to the above, experimental schema-aware validation can be enabled
+by setting the `--enable-composition-webhook-schema-validation` feature flag.
+This will validate the given Composition at deploy time against the available
+schemas, e.g. fieldPaths are valid and source and destination types match in
+patches. Two modes are available for it and can be set through the
+`crossplane.io/composition-validation-mode` annotation on the Composition:
+
+- `strict`: if the required schemas are available, the Composition will be
+   validated against them and any error will make it invalid, otherwise it will
+   just error out straight away due to the missing requirement.
+- `loose` (default): if the required schemas are
+    available, it will behave as in `strict` mode. Instead, if they
+    are not available, schema validation will be skipped, emitting a
+    warning to notify the users about it.
+
+See the dedicated [design document][validation-design-doc] for more information
+about future development around schema-aware validation.
+
+Webhooks are enabled by default, but can be disabled by setting
+`webhooks.enabled` to `false` in the provided Helm Chart.
+
 [crd-docs]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 [raise an issue]: https://github.com/crossplane/crossplane/issues/new?assignees=&labels=enhancement&template=feature_request.md
 [issue-2524]: https://github.com/crossplane/crossplane/issues/2524
@@ -1303,3 +1331,4 @@ so:
 [claims-and-xrs]: /media/composition-claims-and-xrs.svg
 [xr-ref]: {{<ref "#compositions" >}}
 [managed-resources]: {{<ref "managed-resources" >}}
+[validation-design-doc]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-composition-validating-webhook.md

--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1173,7 +1173,7 @@ not considered to be 'empty', and thus will pass the readiness check.
 Crossplane uses a `Validating Webhook` to inform users of any potential
 misconfigurations in a `Composition` as early as possible. The default behavior
 of the webhook is to perform `logical checks` only, enforcing requirements that
-are not explicitly defined in the schema but are assumed to hold at runtime.
+aren't explicitly defined in the schema but are assumed to hold at runtime.
 
 #### Experimental Validation With Schemas
 
@@ -1211,7 +1211,7 @@ understand that the Crossplane maintainers are growing the feature set of the
 community, but we also feel it's critical to avoid bloat and complexity. We
 therefore wish to carefully consider each new addition. We feel some features
 may be better suited for a real, expressive programming language and intend to
-build an alternative to the `Composition` type as it is documented here per
+build an alternative to the `Composition` type as it's documented here per
 [this proposal][issue-2524].
 
 ## Tips, Tricks, and Troubleshooting


### PR DESCRIPTION
Documenting Composition Validation introduced in https://github.com/crossplane/crossplane/pull/3756, https://github.com/crossplane/crossplane/pull/3921 and https://github.com/crossplane/crossplane/pull/3937.