### PR TITLE
Remove 'disabled'

### DIFF
--- a/utils/vale/styles/alex/Ablist.yml
+++ b/utils/vale/styles/alex/Ablist.yml
@@ -73,7 +73,6 @@ swap:
   detox center: treatment center
   diffability: has a disability|person with a disability|people with disabilities
   differently abled: has a disability|person with a disability|people with disabilities
-  disabled: turned off|has a disability|person with a disability|people with disabilities
   downs syndrome: Down Syndrome
   dumb: foolish|ludicrous|speechless|silent
   dummy: test double|placeholder|fake|stub


### PR DESCRIPTION
The original definition
(https://github.com/retextjs/retext-equality/blob/main/rules.md) of this rule shows the context to be specific to how people with disabilities are addressed.

Since we are not discussing humans we can remove the check.

@jeanduplessis put it well in [#402](https://github.com/crossplane/docs/pull/402#issuecomment-1512548507)

> If I take a step back and look at "acceptable" language in engineering, I don't see folks objecting to enable/disable as a language choice in the same way that things like master and whitelist/blacklist are objected to. The rule in Vale also clearly speaks to the subject being a person, not an inanimate/abstract concept.
> 
> It is highly unlikely that we would be talking about people in the context of a disability in our technical documentation. The one area I could imagine it being relevant is in our contribution guidelines to give guidance on making content accessible for those with a disability.
> 
> That said, it's such a small part of the potential use case that I favor disabling the rule and relying on the maintainers of this repo to be vigilant when reviewing PRs.

This seems like a very sensible approach to me. 