### PR TITLE
Update Vale rules based on PR #407 and #402

### DIFF
--- a/utils/vale/.vale.ini
+++ b/utils/vale/.vale.ini
@@ -30,9 +30,14 @@ gitlab.InclusionGender = NO
 # Don't enforce oxford comma
 Google.OxfordComma = NO
 
+# Ignore Google duplicates
+Google.Will = NO
+Google.Latin = NO
+
 # Ingore Microsoft duplicates
 Microsoft.We = NO
 Microsoft.FirstPerson = NO
+Microsoft.Foreign = NO
 
 # ignore indivudal tokens
 TokenIgnores = ({{< img)

--- a/utils/vale/styles/Crossplane/spelling-exceptions.txt
+++ b/utils/vale/styles/Crossplane/spelling-exceptions.txt
@@ -7,6 +7,7 @@ Crossplane's
 Dataflow
 Datastore
 editCode
+Enum
 Env
 GCP's
 Geekdocs

--- a/utils/vale/styles/Microsoft/Terms.yml
+++ b/utils/vale/styles/Microsoft/Terms.yml
@@ -8,7 +8,6 @@ swap:
   '(?:agent|virtual assistant|intelligent personal assistant)': personal digital assistant
   '(?:drive C:|drive C>|C: drive)': drive C
   '(?:internet bot|web robot)s?': bot(s)
-  '(?:microsoft cloud|the cloud)': cloud
   '(?:mobile|smart) ?phone': phone
   '24/7': every day
   'audio(?:-| )book': audiobook

--- a/utils/vale/styles/gitlab/Wordy.yml
+++ b/utils/vale/styles/gitlab/Wordy.yml
@@ -7,7 +7,7 @@
 extends: substitution
 message: '%s "%s".'
 link: https://docs.gitlab.com/ee/development/documentation/styleguide/word_list.html
-level: suggestion
+level: warning
 ignorecase: true
 swap:
   in order to: "Be concise: use 'to' rather than"

--- a/utils/vale/styles/write-good/Weasel.yml
+++ b/utils/vale/styles/write-good/Weasel.yml
@@ -7,7 +7,6 @@ tokens:
   - accidentally
   - additionally
   - allegedly
-  - alternatively
   - angrily
   - anxiously
   - approximately

--- a/utils/vale/styles/write-good/Weasel.yml
+++ b/utils/vale/styles/write-good/Weasel.yml
@@ -162,7 +162,6 @@ tokens:
   - shyly
   - significantly
   - silently
-  - simply
   - sleepily
   - slowly
   - smartly


### PR DESCRIPTION
PR #407 and #402 exposed a few Vale rules that needed to be adjusted.

* Turns off "prefer `cloud` over `the cloud`". This is a problem in marketing not for our docs. "The cloud provider" is a common phrase in Crossplane.
* Turns off Google and Microsoft Latin checks, which are duplicates of the Gitlab Latin checks (1/3rd the errors for using `i.e.`!) 
* Turns off Google check for `will`. This is covered by Gitlab.FutureTense (50% fewer errors!)
* Promotes Gitlab.Wordy to warning to catch the use of `please`. Previously it was a `suggestion`. Changing our warning level to `suggestion` will be way too noisy. 
* Adds the word `Enum` to our custom word list
* Removes duplicate words `Alternatively` and `Simply` which are covered by other checks.

Signed-off-by: Pete Lumbis <pete@upbound.io>