### PR TITLE
Add a step to manually reindex search after publishing a version

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -10,3 +10,4 @@ labels: release
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>`
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named "v<EOL version>-archive" to snapshot EOL'd docs.
 - [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.
+- [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results.


### PR DESCRIPTION
When cutting a new version we need to manually trigger an algolia search reindex so search results don't include the recently removed version. 