### PR TITLE
Search index only for /latest

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -5,7 +5,7 @@ about: Cut a Crossplane release
 labels: release
 ---
 
-- [ ] Update the `/latest` redirect in [netlify.toml](https://github.com/crossplane/docs/blob/master/netlify.toml#L9)
+- [ ] Update the `$LATEST_VER` parameter in [netlify_build.sh](https://github.com/crossplane/docs/blob/master/netlify_build.sh#L3)
 - [ ] Update `params.latest` in [config.yaml](https://github.com/crossplane/docs/blob/master/config.yaml#L48)
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>`
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named "v<EOL version>-archive" to snapshot EOL'd docs.

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,20 +5,15 @@
 
 
 [[redirects]]
-from = "/latest/*"
-to = "/v1.12/:splat"
-status = 302
-
-[[redirects]]
 from = "/docs/*"
 to = "/:splat"
 status = 302
 
 [context.deploy-preview]
-    command = "sed -i 's/# writeStats: true/writeStats: true/g' config.yaml && cat config.yaml && hugo --minify"
+    command = "bash netlify_build.sh"
 
 [context.production]
-    command = "sed -i 's/# writeStats: true/writeStats: true/g' config.yaml && hugo --minify"
+    command = "bash netlify_build.sh"
 
 # Use [dev] to set configuration overrides for local
 # development environments run using Netlify Dev - except

--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -8,4 +8,10 @@ sed -i "s/^\s*version: \"$LATEST_VER\"//g" content/latest/_index.md
 
 sed -i 's/# writeStats: true/writeStats: true/g' config.yaml
 cat config.yaml
-hugo --minify
+
+if [ $CONTEXT = "production"]
+then
+hugo --minify --baseURL $URL
+else
+hugo --minify --baseURL $DEPLOY_URL
+fi

--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+LATEST_VER="1.12"
+
+cp -R content/v$LATEST_VER content/latest
+
+sed -i "s/^\s*version: \"$LATEST_VER\"//g" content/latest/_index.md
+
+sed -i 's/# writeStats: true/writeStats: true/g' config.yaml
+cat config.yaml
+hugo --minify

--- a/themes/geekboot/layouts/_default/sitemap.xml
+++ b/themes/geekboot/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range where .Site.Pages "Params.version" .Site.Params.latest }}
+  {{ range where .Site.Pages "Section" "latest" }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}

--- a/themes/geekboot/layouts/_default/sitemap.xml
+++ b/themes/geekboot/layouts/_default/sitemap.xml
@@ -1,0 +1,17 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range where .Site.Pages "Params.version" .Site.Params.latest }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+  </url>
+  {{ end }}
+  {{/* For KB and Contrib guides */}}
+  {{ range where .Site.Pages "Params.version" "0" }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+  </url>
+  {{ end }}
+</urlset>

--- a/themes/geekboot/layouts/partials/header.html
+++ b/themes/geekboot/layouts/partials/header.html
@@ -15,9 +15,43 @@
     {{ end }}
 {{ end }}
 
+{{ $ver := .Page.Params.version | default .Site.Params.latest }}
+
 <title>
-    {{- if .IsHome -}}{{- .Site.Title | markdownify }} · {{.Site.Params.subtitle | markdownify }} {{- else }}{{- .Title | markdownify}} · {{ .Site.Title | markdownify }} {{ if and (ne .Page.Params.version "0") (ne .Page.Params.version "master")}}v{{.Page.Params.version }}{{end}}{{if eq .Page.Params.version "master"}}{{.Page.Params.version }}{{end}}{{ end }}</title>
-<link rel="canonical" href="https://docs.crossplane.io{{ .Permalink }}">
+    {{- if .IsHome -}}{{- .Site.Title | markdownify }} · {{.Site.Params.subtitle | markdownify }} {{- else }}{{- .Title | markdownify}} · {{ .Site.Title | markdownify }} {{ if and (ne .Page.Params.version "0") (ne .Page.Params.version "master")}}v{{ $ver }}{{end}}{{if eq .Page.Params.version "master"}}{{.Page.Params.version }}{{end}}{{ end }}</title>
+
+
+{{/* Don't do the URL processing for KB and Contrib guides */}}
+{{ if not .Page.Params.Product }}
+    {{/* Strip out the version from the path to get just the section + page */}}
+    {{ $sectionPage := replaceRE (printf "v%s/" .Page.Params.version) "" .RelPermalink }}
+
+    {{/* Handle the /latest directory */}}
+    {{ if not .Page.Params.version }}
+        {{ $sectionPage = replaceRE "/latest" "" .RelPermalink }}
+    {{ end }}
+
+    {{/* Handle the /master directory */}}
+    {{ if eq .Page.Params.version "master" }}
+        {{ $sectionPage = replaceRE "/master" "" .RelPermalink }}
+    {{ end }}
+
+    {{/* Strip training / so .GetPage works */}}
+    {{ $sectionPage = strings.TrimRight "/" $sectionPage }}
+
+    {{/* Look for the Page matching this page, but in the latest version directory */}}
+    {{ $latestPage := .Site.GetPage (printf "/v%s%s" .Site.Params.latest $sectionPage) }}
+
+    {{/* If it exists set the canonical URL to the latest, otherwise we are canonical */}}
+    {{ if $latestPage }}
+    <link rel="canonical" href="{{$latestPage.Permalink }}">
+    {{ else }}
+    <link rel="canonical" href="{{.Permalink}}">
+    {{ end }}
+
+{{ else }}
+    <link rel="canonical" href="{{.Permalink}}">
+{{ end }}
 
 {{ partialCached "stylesheet-cached" . }}
 {{ partial "stylesheet-dynamic" . }}

--- a/themes/geekboot/layouts/partials/header.html
+++ b/themes/geekboot/layouts/partials/header.html
@@ -39,14 +39,12 @@
     {{/* Strip training / so .GetPage works */}}
     {{ $sectionPage = strings.TrimRight "/" $sectionPage }}
 
-    {{/* Look for the Page matching this page, but in the latest version directory */}}
-    {{ $latestPage := .Site.GetPage (printf "/v%s%s" .Site.Params.latest $sectionPage) }}
+    {{/* Look for the Page matching this page, but in the latest directory */}}
+    {{ $latestPage := .Site.GetPage (printf "/latest%s" $sectionPage) }}
 
     {{/* If it exists set the canonical URL to the latest, otherwise we are canonical */}}
     {{ if $latestPage }}
     <link rel="canonical" href="{{$latestPage.Permalink }}">
-    {{ else }}
-    <link rel="canonical" href="{{.Permalink}}">
     {{ end }}
 
 {{ else }}

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -60,9 +60,11 @@
 
         <div class="bd-content ps-lg-2 DocSearch-content">
           {{ if $.Param "docs" }}
+            {{ $pageVer := .Page.Params.version | default .Site.Params.latest }}
+
             {{- if eq .Page.Params.version "master" -}}
               {{ partialCached "master-version-alert" . }}
-            {{- else if ne .Page.Params.version .Site.Params.latest -}}
+            {{- else if ne $pageVer .Site.Params.latest -}}
               {{ partialCached "old-version-alert" . .Section }}
             {{ end }}
           {{ end }}

--- a/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -2,7 +2,7 @@
 {{ $majordict := dict }}
 {{ $majorlist := slice }}
 {{ $sorted_list := slice }}
-{{ $cur_ver := .Page.Params.version }}
+{{ $cur_ver := .Page.Params.version | default .Site.Params.latest }}
 
 <!-- get all the versions and break out semver order -->
 {{ range .Site.Sections }}
@@ -28,34 +28,42 @@
 
 <div class="dropdown float-end bd-dropdown">
     <a class="btn btn-outline-secondary dropdown-toggle bd-dropdown-item text-reset" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        {{ if ne .Page.Params.version "master" }}v{{ end }}{{ .Page.Params.version }}
-        {{ if eq .Page.Params.version .Site.Params.latest }}
+        {{ if ne .Page.Params.version "master" }}v{{ end }}{{ $cur_ver }}
+        {{ if eq $cur_ver .Site.Params.latest }}
         <div class="badge rounded-pill latest">Latest</div>
         {{ end }}
     </a>
 
     <div class="dropdown-menu bd-border-color bd-dropdown" aria-labelledby="dropdownMenuLink">
         {{ $master_url := replaceRE "v[0-9].[0-9]" "master" .Permalink }}
-       {{/*  Iterate over the ordered list of available versions. */}}
+        {{/*  Iterate over the ordered list of available versions. */}}
         {{ range $sorted_list }}
-                {{/*  For a version, see if there is a page with an identical title to the page we're on. If not use the page at /content/v<version>  */}}
-                {{ $versionPage :=  index (where (where $.Site.Pages "Title" $.Title) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}
-                {{/*  If the version is master get the master page since "vmaster" doesn't exist  */}}
-                {{ if not $versionPage }}
-                    {{ $versionPage = $.Site.GetPage "master" }}
-                {{ end }}
-                    {{ with $versionPage }}
-                        <a class="dropdown-item bd-dropdown-item {{- if eq .Page.Params.version $cur_ver }} active {{- end}}" {{- if eq .Page.Params.version $cur_ver }}aria-current="true"{{end}} href="{{ .Permalink }}">
-                            {{ if eq .Page.Params.version "master" }}
-                                master
+            {{/*  For a version, see if there is a page with an identical title to the page we're on. If not use the page at /content/v<version>  */}}
+            {{ $versionPage :=  index (where (where $.Site.Pages "Title" $.Title) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}
+            {{/*  If the version is master get the master page since "vmaster" doesn't exist  */}}
+            {{ if not $versionPage }}
+                {{ $versionPage = $.Site.GetPage "master" }}
+            {{ end }}
+                {{ with $versionPage }}
+                    {{ $isLatest := false }}
+                    {{ if or (eq .Page.Params.version "") (eq .Page.Params.version $cur_ver) }}
+                        {{ $isLatest = true }}
+                    {{ end }}
+                    <a class="dropdown-item bd-dropdown-item {{- if $isLatest }} active {{- end}}" {{- if $isLatest }}aria-current="true"{{end}} href="{{ .Permalink }}">
+                        {{ if eq .Page.Params.version "master" }}
+                            master
+                        {{ else }}
+                            {{ if eq .Page.Params.version "" }}
+                                {{ (printf "v%s" .Site.Params.latest) }}
                             {{ else }}
                                 {{ (printf "v%s" .Page.Params.version) }}
                             {{ end }}
-                            {{ if eq .Page.Params.version .Site.Params.latest }}
-                            <div class="badge rounded-pill latest">Latest</div>
-                            {{ end }}
-                        </a>
-                    {{ end }}
+                        {{ end }}
+                        {{ if or (eq .Page.Params.version .Site.Params.latest) (eq .Page.Params.version "") }}
+                        <div class="badge rounded-pill latest">Latest</div>
+                        {{ end }}
+                    </a>
+                {{ end }}
             {{ end }}
     </div>
 </div>


### PR DESCRIPTION
Fixes #422

This required a bit of work to make it future proof-

* Generate a `/latest` directory of content at build time. This replaces the current method of 302 redirects. This is needed to have actual content Google can index on instead of redirects
* Custom generate the sitemap.xml to only list the content in /latest + KB and Contrib guides. No older pages should be indexed.
* Fixing canonical URLs point to /latest if the older page exists in the /latest version
* Dropdown menu fixes related to version checking. 
* Moving the Netlify build commands into a stand alone bash script instead of one long command 

On the Netlify admin panel I also enabled a plugin to submit any updates to the sitemap.xml on production build, to help improve the speed of search updates 

Signed-off-by: Pete Lumbis <pete@upbound.io>