### PR TITLE
create a custom 404 to list sections of available content

### DIFF
--- a/themes/geekboot/layouts/404.html
+++ b/themes/geekboot/layouts/404.html
@@ -1,0 +1,53 @@
+{{ define "main" }}
+<div class="bd-layout docs-container">
+    <aside class="bd-sidebar">
+      <div class="offcanvas-lg offcanvas-start bd-sidebar-container" tabindex="-1" id="bdSidebar" aria-labelledby="bdSidebarOffcanvasLabel">
+        <div class="offcanvas-header pb-4 border-bottom">
+          <div class="d-flex offcanvas-title fw-bold" id="bdNavbarOffcanvasLabel">
+            Crossplane Documentation -
+            {{- if $.Param "docs" -}}
+            {{ if ne .Page.Params.version "master" }} v{{ end}}{{.Page.Params.version}}
+            {{- else }}
+             {{.Page.Params.product }}
+            {{ end }}
+          </div>
+          <div class="d-flex"><button type="button" class="btn-close bi align-self-center p-0" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#bdSidebar"></button></div>
+        </div>
+        <div class="offcanvas-body">
+          <div class="container-fluid p-0">
+              {{ partialCached "search-button" . }}
+          </div>
+      </div>
+    </aside>
+
+    <main class="bd-main order-1">
+      <div class="bd-intro pt-2 ps-lg-2">
+        <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
+          <div class="mb-3 mb-md-0 d-flex">
+          </div>
+          <h1 class="bd-title mb-0" id="content">Page not found</h1>
+        </div>
+      </div>
+
+
+        <div class="bd-content ps-lg-2 DocSearch-content">
+          The page you're looking for couldn't be found.
+          <br /><br />
+          Only currently maintained versions of Crossplane are documented. Try
+          looking one of the following sections-
+          <br /><br />
+          {{ range .Site.Sections }}
+          {{ if and (.Page.Params.version) (ne .Page.Params.version "0") (ne .Page.Params.version "master") }}
+              <a href="{{.Permalink}}">v{{ .Page.Params.version }}</a><br />
+            {{ else }}
+              {{ if (eq .Page.Params.version "master") }}
+              {{ else }}
+                <a href="{{.Permalink}}">{{ .Title }}</a><br />
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        </div>
+    </main>
+  </div>
+
+{{ end }}


### PR DESCRIPTION
We delete versions of docs that are EOL'd. The down side is that old bookmarks or bad search results (i.e. #422) can lead to a Netlify default 404 page that leaves you stranded. 

This creates a 404 that provides the search box and lists the available sections.

![Screenshot 2023-04-28 at 4 18 53 PM](https://user-images.githubusercontent.com/10537576/235245618-de6ba50c-f380-407b-b98a-c14aba8f7b29.png)

Resolves #416 