### PR TITLE
Support dynamic GA tag

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -76,3 +76,8 @@ h1,h2,h3,h4,h5,h6 {
   --bs-table-hover-color: var(--font-body-color);
   --bs-table-hover-bg: var(--nav-highlight-color);
 }
+
+.ga-tag{
+  color: var(--toc-font-color);
+
+}

--- a/themes/geekboot/layouts/partials/ga-tag.html
+++ b/themes/geekboot/layouts/partials/ga-tag.html
@@ -1,0 +1,3 @@
+<div class="ga-tag float-end">
+GA release: {{.Page.Params.ga}}
+</div>

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -28,6 +28,9 @@
         {{ if .Page.Params.state }}
           {{ partial "feature-state-alert" . }}
         {{ end }}
+        {{ if .Page.Params.ga }}
+          {{ partial "ga-tag" . }}
+        {{ end }}
       </div>
 
 


### PR DESCRIPTION
This adds support for a new front matter element `ga: <version>`. 

This doesn't validate the version tag but will print a "GA version: <>" on the page to indicate when a feature went GA.

Resolves #417 

An example of usage is here, under the version drop down. 
https://deploy-preview-425--crossplane.netlify.app/v1.12/concepts/providers/

**Note** The edit to `/content/v1.12/concepts/providers.md` needs to be reverted before merging. 

Signed-off-by: Pete Lumbis <pete@upbound.io>