### PR TITLE
Use proper URL for production builds

### DIFF
--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+LATEST_VER="1.12"
+
+cp -R content/v$LATEST_VER content/latest
+
+sed -i "s/^\s*version: \"$LATEST_VER\"//g" content/latest/_index.md
+
+sed -i 's/# writeStats: true/writeStats: true/g' config.yaml
+cat config.yaml
+
+if [ $CONTEXT = "production"]
+then
+hugo --minify --baseURL https://docs.crossplane.io/
+else
+hugo --minify --baseURL $DEPLOY_URL
+fi


### PR DESCRIPTION
The fix in #422 uses the netlify dynamic URL, which changes all the links on the site. This forces the links to use docs.crossplane.io 