### PR TITLE
Fix Safari Styling

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,8 @@
-const postcssLightningcss = require("postcss-lightningcss");
+const postcssLightningcss = require("postcss-lightningcss")({
+  browsers: ">= .25%",
+  lightningcssOptions: {
+  }
+});
 
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./hugo_stats.json'],


### PR DESCRIPTION
We found an issue today where Safari renders the top navbar incorrectly. 

After a bunch of testing it seems this has never worked properly and is possibly related to the use of media queries with Safari. 

The fix was to update the [LightningCSS](https://lightningcss.dev/) configuration to transpile our CSS to ensure support for common browsers (including Safari).

I've verified this looks right in Safari 14.1, 15.6 and 16.3. Chrome 112 and Firefox 112.