### PR TITLE
Be less specific about supported k8s version

### DIFF
--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -11,14 +11,9 @@ If you don't have a Kubernetes cluster create one locally with [Kind](https://ki
 {{< /hint >}}
 
 ## Prerequisites
-* [Kubernetes](https://kubernetes.io/releases/) version `v1.23.0` or later
+* An actively [supported Kubernetes version](https://kubernetes.io/releases/patch-releases/#support-period)
 * [Helm](https://helm.sh/docs/intro/install/) version `v3.2.0` or later
 
-{{< hint "note" >}}
-Crossplane supports the versions of Kubernetes [supported by the
-Kubernetes
-community](https://kubernetes.io/releases/patch-releases/#support-period).
-{{< /hint >}} 
 
 ## Install Crossplane
 

--- a/content/v1.11/software/install.md
+++ b/content/v1.11/software/install.md
@@ -11,14 +11,9 @@ If you don't have a Kubernetes cluster create one locally with [Kind](https://ki
 {{< /hint >}}
 
 ## Prerequisites
-* [Kubernetes](https://kubernetes.io/releases/) version `v1.23.0` or later
+* An actively [supported Kubernetes version](https://kubernetes.io/releases/patch-releases/#support-period)
 * [Helm](https://helm.sh/docs/intro/install/) version `v3.2.0` or later
 
-{{< hint "note" >}}
-Crossplane supports the versions of Kubernetes [supported by the
-Kubernetes
-community](https://kubernetes.io/releases/patch-releases/#support-period).
-{{< /hint >}} 
 
 ## Install Crossplane
 

--- a/content/v1.12/software/install.md
+++ b/content/v1.12/software/install.md
@@ -11,14 +11,8 @@ If you don't have a Kubernetes cluster create one locally with [Kind](https://ki
 {{< /hint >}}
 
 ## Prerequisites
-* [Kubernetes](https://kubernetes.io/releases/) version `v1.23.0` or later
+* An actively [supported Kubernetes version](https://kubernetes.io/releases/patch-releases/#support-period)
 * [Helm](https://helm.sh/docs/intro/install/) version `v3.2.0` or later
-
-{{< hint "note" >}}
-Crossplane supports the versions of Kubernetes [supported by the
-Kubernetes
-community](https://kubernetes.io/releases/patch-releases/#support-period).
-{{< /hint >}} 
 
 ## Install Crossplane
 


### PR DESCRIPTION
Makes a change to PR #437 to stay "actively supported k8s version" instead of a specific release so we don't have to keep it updated.


Signed-off-by: Pete Lumbis <pete@upbound.io>	