### PR TITLE
Adds @phisco and @lsviben as Reviewers to sync with c/c OWNERS

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://
 * Daren Iott <daren@upbound.io> ([nullable-eth](https://github.com/nullable-eth))
 * Ezgi Demirel <ezgi@upbound.io> ([ezgidemirel](https://github.com/ezgidemirel))
 * Max Blatt ([MisterMX](https://github.com/MisterMX))
+* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
+* Lovro Sviben <lovro.sviben@upbound.io> ([lsviben](https://github.com/lsviben))
 
 ## Emeritus maintainers
 


### PR DESCRIPTION
Updates the docs OWNERS to include two new c/c maintainers to align with the current c/c OWNERS