### PR TITLE
Add redirects for top 404 pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,27 @@ from = "/docs/*"
 to = "/:splat"
 status = 302
 
+[[redirects]]
+from = "/v1.9/concepts/managed-resources.html"
+to = "/latest/concepts/managed-resources"
+status = 302
+
+[[redirects]]
+from = "/v1.9/concepts/providers.html"
+to = "/latest/concepts/providers"
+status = 302
+
+[[redirects]]
+from = "/v1.9/getting-started/create-configuration"
+to = "/latest/getting-started"
+status = 302
+
+[[redirects]]
+from = "/v1.9/getting-started/install-configure"
+to = "/latest/software/install/"
+status = 302
+
+
 [context.deploy-preview]
     command = "bash netlify_build.sh"
 


### PR DESCRIPTION
A few pages for the v1.9 docs are in existing press about Crossplane that direct to pages that are no longer live.

This creates Netlify redirects for those pages. 