### PR TITLE
add an example for claiming existing xr

### DIFF
--- a/content/master/concepts/composition.md
+++ b/content/master/concepts/composition.md
@@ -1288,6 +1288,18 @@ an existing Composite Resource as long as its a type of XR that offers a claim
 and no one else has already claimed it. To do so:
 
 1. Set the `spec.resourceRef` of your claim to reference the existing XR.
+    ```yaml
+    apiVersion: database.example.org/v1alpha1
+    kind: PostgreSQLInstance
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      resourceRef:
+        apiVersion: database.example.org/v1alpha1
+        kind: XPostgreSQLInstance
+        name: example-d4lmv
+    ```
 1. Make sure the rest of your claim's spec fields match the XR's.
 
 If your claim's spec fields don't match the XR's Crossplane will still claim it

--- a/content/v1.12/concepts/composition.md
+++ b/content/v1.12/concepts/composition.md
@@ -1288,6 +1288,18 @@ an existing Composite Resource as long as its a type of XR that offers a claim
 and no one else has already claimed it. To do so:
 
 1. Set the `spec.resourceRef` of your claim to reference the existing XR.
+    ```yaml
+    apiVersion: database.example.org/v1alpha1
+    kind: PostgreSQLInstance
+    metadata:
+      name: example
+      namespace: default
+    spec:
+      resourceRef:
+        apiVersion: database.example.org/v1alpha1
+        kind: XPostgreSQLInstance
+        name: example-d4lmv
+    ```
 1. Make sure the rest of your claim's spec fields match the XR's.
 
 If your claim's spec fields don't match the XR's Crossplane will still claim it


### PR DESCRIPTION
This adds an example of claiming existing composite resources. Currently, the documentation instructs readers to update the `spec.resourceRef` field but does not give an example.
This PR does not introduce new vale errors or warnings.