### PR TITLE
docs: suggest using image digests for security reasons

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -332,6 +332,10 @@ to avoid having to manually activate new versions. However, each user should
 consider their specific environment and choose a combination that makes sense
 for them.
 
+For security reasons, it's suggested using image digests instead or alongside
+tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+with.
+
 ### spec.revisionHistoryLimit
 
 Valid values: any integer, disabled by explicitly setting to `0` (default `1`)

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -333,7 +333,7 @@ consider their specific environment and choose a combination that makes sense
 for them.
 
 For security reasons, it's suggested using image digests instead or alongside
-tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+tags (`vx.y.z@sha256:...`), to ensure that the package content wasn't tampered
 with.
 
 ### spec.revisionHistoryLimit

--- a/content/v1.10/concepts/packages.md
+++ b/content/v1.10/concepts/packages.md
@@ -332,6 +332,10 @@ to avoid having to manually activate new versions. However, each user should
 consider their specific environment and choose a combination that makes sense
 for them.
 
+For security reasons, it's suggested using image digests instead or alongside
+tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+with.
+
 ### spec.revisionHistoryLimit
 
 Valid values: any integer, disabled by explicitly setting to `0` (default `1`)

--- a/content/v1.10/concepts/packages.md
+++ b/content/v1.10/concepts/packages.md
@@ -333,7 +333,7 @@ consider their specific environment and choose a combination that makes sense
 for them.
 
 For security reasons, it's suggested using image digests instead or alongside
-tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+tags (`vx.y.z@sha256:...`), to ensure that the package content wasn't tampered
 with.
 
 ### spec.revisionHistoryLimit

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -332,6 +332,10 @@ to avoid having to manually activate new versions. However, each user should
 consider their specific environment and choose a combination that makes sense
 for them.
 
+For security reasons, it's suggested using image digests instead or alongside
+tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+with.
+
 ### spec.revisionHistoryLimit
 
 Valid values: any integer, disabled by explicitly setting to `0` (default `1`)

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -333,7 +333,7 @@ consider their specific environment and choose a combination that makes sense
 for them.
 
 For security reasons, it's suggested using image digests instead or alongside
-tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+tags (`vx.y.z@sha256:...`), to ensure that the package content wasn't tampered
 with.
 
 ### spec.revisionHistoryLimit

--- a/content/v1.12/concepts/packages.md
+++ b/content/v1.12/concepts/packages.md
@@ -332,6 +332,10 @@ to avoid having to manually activate new versions. However, each user should
 consider their specific environment and choose a combination that makes sense
 for them.
 
+For security reasons, it's suggested using image digests instead or alongside
+tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+with.
+
 ### spec.revisionHistoryLimit
 
 Valid values: any integer, disabled by explicitly setting to `0` (default `1`)

--- a/content/v1.12/concepts/packages.md
+++ b/content/v1.12/concepts/packages.md
@@ -333,7 +333,7 @@ consider their specific environment and choose a combination that makes sense
 for them.
 
 For security reasons, it's suggested using image digests instead or alongside
-tags (`vx.y.z@sha256:...`), to ensure that the package content was not tampered
+tags (`vx.y.z@sha256:...`), to ensure that the package content wasn't tampered
 with.
 
 ### spec.revisionHistoryLimit


### PR DESCRIPTION
Suggesting to use image digests instead of tags for security reasons.
This is due to the underlying implementation of go-containerregistry we use to pull images, which is not able to validate digests if not provided, see the [code](https://github.com/google/go-containerregistry/blob/5fe7f2e11795fcfd5a7c7d3a550c4e668a9a9789/pkg/v1/remote/fetcher.go#L172-L180) for more details.
I didn't specifically point out the details, as I feel it's kind of well known in the field that specifying digests is a good practice and a requirement in highly regulated and security-aware environments.
