### PR TITLE
Update roadmap links to include info panel

### DIFF
--- a/themes/geekboot/layouts/partials/sidebar/roadmap.html
+++ b/themes/geekboot/layouts/partials/sidebar/roadmap.html
@@ -1,6 +1,6 @@
 <div class="section-container container pe-0 pt-1">
     <div class="nav-container  align-items-center">
-        <a href="https://github.com/orgs/crossplane/projects/20/views/3" target="_blank" class="d-inline-flex align-items-center">
+        <a href="https://github.com/orgs/crossplane/projects/20/views/3?pane=info" target="_blank" class="d-inline-flex align-items-center">
         Crossplane Roadmap
         </a>
         <svg class="ms-1 mb-1" width=".8rem" height=".8rem"><use xlink:href="#box-arrow-up-right"/></svg>


### PR DESCRIPTION
Similar to https://github.com/crossplane/crossplane/pull/4179, this PR updates all links in the docs repo to the public roadmap so that the info panel is also shown upon landing on the roadmap. All the important expectation setting details are included in that info panel, which GitHub does not display by default, so we would like to increase the chances that users will see it.

Compare:

with info panel: https://github.com/orgs/crossplane/projects/20/views/3?pane=info
without info panel: https://github.com/orgs/crossplane/projects/20/views/3

I've tested the deploy preview and the link works OK ✅ 