### PR TITLE
Roadmap link styling fix

### DIFF
--- a/themes/geekboot/layouts/partials/sidebar/roadmap.html
+++ b/themes/geekboot/layouts/partials/sidebar/roadmap.html
@@ -1,8 +1,8 @@
 <div class="section-container container pe-0 pt-1">
-    <div class="nav-container  align-items-center">
-        <a href="https://github.com/orgs/crossplane/projects/20/views/3?pane=info" target="_blank" class="d-inline-flex align-items-center">
-        Crossplane Roadmap
-        </a>
-        <svg class="ms-1 mb-1" width=".8rem" height=".8rem"><use xlink:href="#box-arrow-up-right"/></svg>
+    <div class="container nav-container pe-0 d-flex w-100 ">
+        <a class="d-flex w-100 border-0" href="https://github.com/orgs/crossplane/projects/20/views/3?pane=info" target="_blank">Crossplane Roadmap</a>      
+        <div class="d-flex flex-shrink-1 sidebar-control-container align-self-center">
+            <a href="https://github.com/orgs/crossplane/projects/20/views/3?pane=info"><svg class="flex bi"><use xlink:href="#box-arrow-up-right"/></svg></a>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
This PR addresses some styling issues with the roadmap sidebar link specifically relating to the external link icon's positioning and color in dark mode.

## Before
|  `lg` breakpoint  | `md` breakpoint |
| ------------- | ------------- |
| <img width="295" alt="CleanShot 2023-06-20 at 13 33 27@2x" src="https://github.com/crossplane/docs/assets/492942/28d3fb08-77a4-418e-bf84-1e7bd98eee7a">| <img width="242" alt="CleanShot 2023-06-20 at 13 33 41@2x" src="https://github.com/crossplane/docs/assets/492942/59c508c4-37ef-4000-b422-22192edb61b0">|
|<img width="292" alt="CleanShot 2023-06-20 at 13 33 18@2x" src="https://github.com/crossplane/docs/assets/492942/b129fa48-af47-4226-80c3-59a4efea8b3f">| <img width="242" alt="CleanShot 2023-06-20 at 13 33 50@2x" src="https://github.com/crossplane/docs/assets/492942/2b816689-38f5-48b6-b70a-84dade06e155">|

## After
|  `lg` breakpoint  | `md` breakpoint |
| ------------- | ------------- |
| <img width="296" alt="CleanShot 2023-06-20 at 13 34 29@2x" src="https://github.com/crossplane/docs/assets/492942/05297d80-8261-4e79-b607-15814c56460e">| <img width="241" alt="CleanShot 2023-06-20 at 13 34 17@2x" src="https://github.com/crossplane/docs/assets/492942/bc5a08ea-cfbd-4c47-ab25-b1ef39589a14">|
<img width="292" alt="CleanShot 2023-06-20 at 13 34 36@2x" src="https://github.com/crossplane/docs/assets/492942/261ffab5-12b7-4938-b7b4-595b576c8763">| <img width="245" alt="CleanShot 2023-06-20 at 13 34 08@2x" src="https://github.com/crossplane/docs/assets/492942/b1833a17-2d83-4e5b-88bd-4c9abde84fc1">|






