### PR TITLE
Fix copy button to only copy the command and not the output

### DIFF
--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -1190,7 +1190,7 @@ Crossplane created the bucket when the values `READY` and `SYNCED` are `True`.
 This may take up to 5 minutes.  
 {{< /hint >}}
 
-```shell
+```shell {copy-lines="1"}
 kubectl get buckets
 NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
 crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s

--- a/content/v1.12/getting-started/provider-aws.md
+++ b/content/v1.12/getting-started/provider-aws.md
@@ -1190,7 +1190,7 @@ Crossplane created the bucket when the values `READY` and `SYNCED` are `True`.
 This may take up to 5 minutes.  
 {{< /hint >}}
 
-```shell
+```shell {copy-lines="1"}
 kubectl get buckets
 NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
 crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s


### PR DESCRIPTION
A command in the AWS quickstart didn't limit the copy lines and copies the command and output. 

Resolves #464.