### PR TITLE
fix OG title generation for latest version

### DIFF
--- a/themes/geekboot/layouts/partials/social.html
+++ b/themes/geekboot/layouts/partials/social.html
@@ -1,10 +1,11 @@
+{{ $ver := .Page.Params.version | default .Site.Params.latest }}
 {{- if .IsHome -}}
     <meta property="og:title" {{ printf "content=%s" .Site.Title }} />
 {{- else }}
     {{ if eq .Page.Params.version "master" }}
         <meta property="og:title" {{ printf "content='Crossplane Docs · master · %s'" .Params.Title | safeHTMLAttr }} />
-    {{ else if gt .Page.Params.version 0}}
-        <meta property="og:title" {{ printf "content='Crossplane Docs · v%s · %s'" .Params.version .Params.Title | safeHTMLAttr }} />
+    {{ else if and (ne .Page.Params.version "0") (ne .Page.Params.version "master") }}
+        <meta property="og:title" {{ printf "content='Crossplane Docs · v%s · %s'" $ver .Params.Title | safeHTMLAttr }} />
     {{ else }}
         <meta property="og:title" {{ printf "content='Crossplane %s · %s'" .Params.Product .Page.Params.Title | safeHTMLAttr  }} />
     {{ end }}


### PR DESCRIPTION
Fix issue where version number isn't displayed properly in opengraph previews

![image](https://github.com/crossplane/docs/assets/10537576/9bf83313-9044-4054-bf41-155e40bdab23)
