### PR TITLE
Remove legacy google analytics tag

### DIFF
--- a/themes/geekboot/layouts/partials/google-analytics.html
+++ b/themes/geekboot/layouts/partials/google-analytics.html
@@ -1,12 +1,3 @@
-<!-- Google Analytics -->
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-110275540-2', 'auto');
-    ga('send', 'pageview');
-</script>
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-SFCPQYSLHY"></script>
 <script>


### PR DESCRIPTION
This removes the older google analytics tag and leaves the existing GA4 tag. 