### PR TITLE
Weekly scheduled external link checking

### DIFF
--- a/.github/workflows/weekly-link-checker.yml
+++ b/.github/workflows/weekly-link-checker.yml
@@ -1,0 +1,34 @@
+name: Validate external links
+
+on:
+  schedule:
+    # “At 04:05 on Monday”
+    - cron:  '5 4 * * 1'
+
+  # Allows manual workflow run (must in default branch to work)
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the docs repo
+        uses: actions/checkout@v3
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.109.0'
+          extended: true
+
+      - name: Build
+        # Set to env=dev so SCSS isn't required.
+        run: hugo --environment development
+
+      - name: Enable external link checking
+        run: "sed -i 's/CheckExternal: false/CheckExternal: true/' utils/htmltest/.htmltest.yml"
+
+      - name: Run htmltest
+        uses: wjdp/htmltest-action@master
+        with:
+          config: ./utils/htmltest/.htmltest.yml

--- a/utils/htmltest/.htmltest.yml
+++ b/utils/htmltest/.htmltest.yml
@@ -5,3 +5,6 @@ IgnoreInternalEmptyHash: true
 CheckExternal: false
 IgnoreURLs:
   - "github.com/crossplane/docs/tree/master/content/(.*).md" # Ignore the links to "view this source"
+  - "www.googletagmanager.com/*" # Ignore google tag manager
+  - "twitter.com/*" # Ignore twitter links since they send to login page
+


### PR DESCRIPTION
External links are not checked in CI since it would dramatically increase the test time. 

Inspired by #486, this adds a weekly github action to check external links. The time selected doesn't matter, but Monday morning seems good since any failures would be top of inbox to fix.

Signed-off-by: Pete Lumbis <pete@upbound.io>