### PR TITLE
Add htmltest generated tmp/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ jekyll_files/*
 # Netlify local dev
 ######################
 .netlify/*
+
+# Ignore htmltest generated /tmp folder
+######################
+tmp/*


### PR DESCRIPTION
Locally running the [htmltest](https://github.com/wjdp/htmltest) app we run in CI generates a `/tmp` folder that htmltest uses as a cache. 

This PR adds the /tmp folder to gitignore.