### PR TITLE
add links to feature flags and pod flags

### DIFF
--- a/content/master/concepts/pods.md
+++ b/content/master/concepts/pods.md
@@ -326,8 +326,13 @@ Running multiple Crossplane pods without leader election is unsupported.
 Change Crossplane pod settings either before installing Crossplane by editing
 the Helm `values.yml` file or after installation by editing the `Deployment`.
 
-The full list of configuration options are available in the 
-[Crossplane Install]({{<ref "../software/install">}}) section. 
+The full list of 
+[configuration options]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}) 
+and 
+[feature flags]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}) 
+are available in the 
+[Crossplane Install]({{<ref "../software/install">}}) 
+section. 
 
 {{< hint "note" >}}
 

--- a/content/v1.13/concepts/pods.md
+++ b/content/v1.13/concepts/pods.md
@@ -326,8 +326,13 @@ Running multiple Crossplane pods without leader election is unsupported.
 Change Crossplane pod settings either before installing Crossplane by editing
 the Helm `values.yml` file or after installation by editing the `Deployment`.
 
-The full list of configuration options are available in the 
-[Crossplane Install]({{<ref "../software/install">}}) section. 
+The full list of 
+[configuration options]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}) 
+and 
+[feature flags]({{<ref "../software/install#customize-the-crossplane-helm-chart">}}) 
+are available in the 
+[Crossplane Install]({{<ref "../software/install">}}) 
+section. 
 
 {{< hint "note" >}}
 


### PR DESCRIPTION
A discovery from community support was a challenge in discoverability of feature flags and pod settings. This adds a crosslink from the Pods chapter to the install chapter where the flags are documented.

Resolves #499