### PR TITLE
update management policies with GMP changes

### DIFF
--- a/content/knowledge-base/guides/import-existing-resources.md
+++ b/content/knowledge-base/guides/import-existing-resources.md
@@ -85,29 +85,29 @@ managed resource `spec` changes the external resource.
 
 ## Import resources automatically 
 
-Automatically import external resources with the
-`ObserveOnly` [`managementPolicy`]({{<ref "/v1.12/concepts/managed-resources#managementpolicy">}}).
+Automatically import external resources with the granular management polices
+[`spec.managementPolicies: ["Observe"]`]({{<ref "/v1.13/concepts/managed-resources#managementpolicies">}}).
 
-Crossplane imports `ObserveOnly` resources but never changes or deletes the
+Crossplane imports `Observe` only resources but never changes or deletes the
 resources.
 
 {{<hint "important" >}}
-The managed resource `managementPolicy` option is an alpha feature. 
+The managed resource `managementPolicies` option is an alpha feature. 
 
-Enable the `managementPolicy` in a provider with `--enable-management-policies` 
+Enable the `managementPolicies` in a provider with `--enable-management-policies` 
 in a 
 [ControllerConfig]({{<ref "/v1.12/concepts/providers#controller-configuration" >}}).
 {{< /hint >}}
 
 <!-- vale off -->
-### Apply the ObserveOnly managementPolicy
+### Apply the ["Observe"] managementPolicies
 <!-- vale on -->
 
 Create a new managed resource matching the 
 {{<hover label="oo-policy" line="1">}}apiVersion{{</hover>}} and 
 {{<hover label="oo-policy" line="2">}}kind{{</hover>}} of the resource
 to import and add
-{{<hover label="oo-policy" line="4">}}managementPolicy: ObserveOnly{{</hover>}} to the 
+{{<hover label="oo-policy" line="4">}}managementPolicies: ["Observe"]{{</hover>}} to the 
 {{<hover label="oo-policy" line="3">}}spec{{</hover>}}
 
 For example, to import a GCP SQL DatabaseInstance, create a new resource with
@@ -117,7 +117,7 @@ set.
 apiVersion: sql.gcp.upbound.io/v1beta1
 kind: DatabaseInstance
 spec:
-  managementPolicy: ObserveOnly
+  managementPolicies: ["Observe"]
 ```
 
 ### Add the external-name annotation
@@ -138,7 +138,7 @@ metadata:
   annotations:
     crossplane.io/external-name: my-external-database
 spec:
-  managementPolicy: ObserveOnly
+  managementPolicies: ["Observe"]
 ```
 
 ### Create a Kubernetes object name
@@ -156,7 +156,7 @@ metadata:
   annotations:
     crossplane.io/external-name: my-external-database
 spec:
-  managementPolicy: ObserveOnly
+  managementPolicies: ["Observe"]
 ```
 
 ### Identify a specific external resource
@@ -175,7 +175,7 @@ metadata:
   annotations:
     crossplane.io/external-name: my-external-database
 spec:
-  managementPolicy: ObserveOnly
+  managementPolicies: ["Observe"]
   forProvider:
     region: "us-central1"
 ```
@@ -198,7 +198,7 @@ metadata:
     crossplane.io/external-name: existing-database-instance
   name: existing-database-instance
 spec:
-  managementPolicy: ObserveOnly
+  managementPolicies: ["Observe"]
   forProvider:
     region: us-central1
 status:
@@ -234,11 +234,11 @@ status:
 <!-- vale on --> 
 
 Crossplane can take active control of `ObserveOnly` imported resources by 
-changing the `managementPolicy` after import.
+changing the `managementPolicies` after import.
 
 Change the {{<hover label="fc" line="8">}}managementPolicy{{</hover>}} field
 of the managed resource to 
-{{<hover label="fc" line="8">}}FullControl{{</hover>}}.
+{{<hover label="fc" line="8">}}["*"]{{</hover>}}.
 
 Copy any required parameter values from
 {{<hover label="fc" line="16">}}status.atProvider{{</hover>}} and provide them
@@ -256,7 +256,7 @@ metadata:
     crossplane.io/external-name: existing-database-instance
   name: existing-database-instance
 spec:
-  managementPolicy: FullControl
+  managementPolicies: ["*"]
   forProvider:
     databaseVersion: POSTGRES_14
     region: us-central1

--- a/content/knowledge-base/guides/import-existing-resources.md
+++ b/content/knowledge-base/guides/import-existing-resources.md
@@ -8,9 +8,8 @@ you can import them as managed resources and let Crossplane manage them.
 A managed resource's [`managementPolicy`]({{<ref "/v1.12/concepts/managed-resources#managementpolicy">}}) 
 field enables importing external resources into Crossplane.
 
-Crossplane can import resources either [manually]({{<ref
-"#import-resources-manually">}}) or [automatically]({{<ref
-"#import-resources-automatically">}}).
+Crossplane can import resources either [manually]({{<ref "#import-resources-manually">}})
+or [automatically]({{<ref "#import-resources-automatically">}}).
 
 ## Import resources manually
 

--- a/content/knowledge-base/guides/import-existing-resources.md
+++ b/content/knowledge-base/guides/import-existing-resources.md
@@ -85,22 +85,21 @@ managed resource `spec` changes the external resource.
 
 ## Import resources automatically 
 
-Automatically import external resources with the granular management polices
-[`spec.managementPolicies: ["Observe"]`]({{<ref "/v1.13/concepts/managed-resources#managementpolicies">}}).
+Automatically import external resources with an `Observe` [management policy]({{<ref "/v1.13/concepts/managed-resources#managementpolicies">}}).
 
-Crossplane imports `Observe` only resources but never changes or deletes the
+Crossplane imports observe only resources but never changes or deletes the
 resources.
 
 {{<hint "important" >}}
 The managed resource `managementPolicies` option is an alpha feature. 
 
-Enable the `managementPolicies` in a provider with `--enable-management-policies` 
+Enable `managementPolicies` in a provider with `--enable-management-policies` 
 in a 
 [ControllerConfig]({{<ref "/v1.12/concepts/providers#controller-configuration" >}}).
 {{< /hint >}}
 
 <!-- vale off -->
-### Apply the ["Observe"] managementPolicies
+### Apply the Observe management policy
 <!-- vale on -->
 
 Create a new managed resource matching the 
@@ -111,7 +110,7 @@ to import and add
 {{<hover label="oo-policy" line="3">}}spec{{</hover>}}
 
 For example, to import a GCP SQL DatabaseInstance, create a new resource with
-the {{<hover label="oo-policy" line="4">}}managementPolicy: ObserveOnly{{</hover>}} 
+the {{<hover label="oo-policy" line="4">}}managementPolicies: ["Observe"]{{</hover>}} 
 set.
 ```yaml {label="oo-policy",copy-lines="none"}
 apiVersion: sql.gcp.upbound.io/v1beta1
@@ -233,10 +232,10 @@ status:
 ## Control imported ObserveOnly resources
 <!-- vale on --> 
 
-Crossplane can take active control of `ObserveOnly` imported resources by 
+Crossplane can take active control of observe only imported resources by 
 changing the `managementPolicies` after import.
 
-Change the {{<hover label="fc" line="8">}}managementPolicy{{</hover>}} field
+Change the {{<hover label="fc" line="8">}}managementPolicies{{</hover>}} field
 of the managed resource to 
 {{<hover label="fc" line="8">}}["*"]{{</hover>}}.
 

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -61,8 +61,9 @@ Provider deletes the managed resource but doesn't delete the external resource.
 #### Interaction with management policies
 
 If a resource configures a Crossplane
-[management policy](#managementpolicies), the management policy takes precedence 
-over the `deletionPolicy` setting, unless it's the default management policy.
+[management policy](#managementpolicies) and the related management policy alpha
+feature is enabled, the management policy takes precedence over the
+`deletionPolicy` setting, unless it's the default management policy.
 
 {{< table "table table-sm table-hover">}}
 | managementPolicies          | deletionPolicy   | result  |
@@ -113,13 +114,6 @@ inside a Provider's web console, Crossplane reverts that change back to what's
 configured in the `forProvider` setting. 
 {{< /hint >}}
 
-#### Late initialization
-
-After the external resource creation, providers add some provider defaulted
-settings not manually set to the `forProvider` field of the created managed
-resource object into their respected `forProvider` fields.
-Use `kubectl describe <managed_resource>` to view the applied values. 
- 
 #### Referencing other resources
 
 Some fields in a managed resource may depend on values from other managed
@@ -229,7 +223,7 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
 <!-- vale write-good.Passive = YES -->
 {{< /hint >}}
 
-#### Late Initialization
+#### Late initialization
 
 For some of the optional fields, users rely on the default that the cloud
 provider chooses for them. Since Crossplane treats the managed resource as the
@@ -309,10 +303,10 @@ spec:
 <!-- vale on --> 
 
 {{<hint "important" >}}
-The managed resource `managementPolicies` option is an alpha feature. 
+The managed resource `managementPolicies` option is an alpha feature.
 
-Enable `managementPolicies` in a provider with `--enable-management-policies` 
-in a 
+Enable `managementPolicies` in a provider with `--enable-management-policies`
+in a
 [ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
 {{< /hint >}}
 

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -59,10 +59,11 @@ Provider deletes the managed resource but doesn't delete the external resource.
 * `deletionPolicy: Orphan` - Leave the external resource when deleting the managed resource.
 
 #### Interaction with management policies
+
 If a resource configures a Crossplane
 [management policy](#managementpolicies) and the related management policy alpha
-feature is enabled, the managment policy takes precedence over the
-`deletionPolicy` setting, unless it is the default management policy.
+feature is enabled, the management policy takes precedence over the
+`deletionPolicy` setting, unless it's the default management policy.
 
 {{< table >}}
 | managementPolicies          | deletionPolicy   | result  |

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -214,8 +214,8 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
 For some of the optional fields, users rely on the default that the cloud
 provider chooses for them. Since Crossplane treats the managed resource as the
 source of the truth, values of those fields need to exist in `spec` of the
-managed resource. So, in each reconciliation, Crossplane will fill the value of
-a field that is left empty by the user but is assigned a value by the provider.
+managed resource. In each reconciliation, Crossplane will fill the value of
+a field that's left empty by the user but is assigned a value by the provider.
 For example, there could be two fields like `region` and `availabilityZone` and
 you might want to give only `region` and leave the availability zone to be
 chosen by the cloud provider. In that case, if the provider assigns an
@@ -243,7 +243,7 @@ For example, setting just `["Observe"]` makes Crossplane treat the resource as
 a read-only resource, importing the external resources not originally created
 by Crossplane. This allows other managed resources to reference the read-only
 resource, for example, a shared database or network. Importing a resource as
-read-only is convenient since Crossplane will not attempt to take control and
+read-only is convenient since Crossplane wont attempt to take control and
 only identifier parameters are needed to be specified in the managed resource.
 
 {{< hint "tip" >}}
@@ -281,8 +281,8 @@ if the management policy alpha feature is enabled. To sum it up in a table:
 | "*" (default)               | Orphan           | Orphan  |
 | contains "Delete"           | Delete (default) | Delete  |
 | contains "Delete"           | Orphan           | Delete  |
-| does not contain "Delete"   | Delete (default) | Orphan  |
-| does not contain "Delete"   | Orphan           | Orphan  |
+| doesn't contain "Delete"   | Delete (default) | Orphan  |
+| doesn't contain "Delete"   | Orphan           | Orphan  |
 {{< /table >}}
 
 #### Options
@@ -297,7 +297,7 @@ if the management policy alpha feature is enabled. To sum it up in a table:
   `spec.forProvider`.
 * `Delete` - the external resource will be deleted when the managed resource is
   deleted.
-* `LateInitialize` - Unprovided spec fields are late-initialized to
+* `LateInitialize` - Unprovided spec fields are late initialized to
   `spec.forProvider` with the default values from the cloud provider. This
   enables Crossplane to take full control of the external resource, even those
   values not provided by the user upfront. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -56,7 +56,24 @@ Provider deletes the managed resource but doesn't delete the external resource.
 
 #### Options
 * `deletionPolicy: Delete` - **Default** - Delete the external resource when deleting the managed resource.
-* `deletionPolicy: Orphan` - Leave the external resource when deleting the managed resource. 
+* `deletionPolicy: Orphan` - Leave the external resource when deleting the managed resource.
+
+#### Interaction with management policies
+If a resource configures a Crossplane
+[management policy](#managementpolicies) and the related management policy alpha
+feature is enabled, the managment policy takes precedence over the
+`deletionPolicy` setting, unless it is the default management policy.
+
+{{< table >}}
+| managementPolicies          | deletionPolicy   | result  |
+|-----------------------------|------------------|---------|
+| "*" (default)               | Delete (default) | Delete  |
+| "*" (default)               | Orphan           | Orphan  |
+| contains "Delete"           | Delete (default) | Delete  |
+| contains "Delete"           | Orphan           | Delete  |
+| doesn't contain "Delete"   | Delete (default) | Orphan  |
+| doesn't contain "Delete"   | Orphan           | Orphan  |
+{{< /table >}}
 
 <!-- vale off -->
 ### forProvider
@@ -96,8 +113,11 @@ inside a Provider's web console, Crossplane reverts that change back to what's
 configured in the `forProvider` setting. 
 {{< /hint >}}
 
-Providers add any settings not manually set to the `forProvider` field of the 
-created managed resource object.
+#### Late Initialization
+
+After the external resource creation, providers add some provider defaulted
+settings not manually set to the `forProvider` field of the created managed
+resource object into their respected `forProvider` fields.
 Use `kubectl describe <managed_resource>` to view the applied values. 
  
 #### Referencing other resources
@@ -223,91 +243,11 @@ availability zone, Crossplane gets that value and fills `availabilityZone`. Note
 that if the field is already filled, the controller won't override its value.
 
 <!-- vale off -->
-### managementPolicies
-<!-- vale on --> 
-
-{{<hint "important" >}}
-The managed resource `managementPolicies` option is an alpha feature. 
-
-Enable the `managementPolicies` in a provider with `--enable-management-policies` 
-in a 
-[ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
-{{< /hint >}}
-
-Granular `managementPolicies` determine what actions Crossplane can take on a
-managed and its external resource. `managementPolicies` is an array of actions
-(`Observe`, `Create`, `Update`, `Delete`, `LateInitialize`, `*`), and there are
-multiple combinations that Crossplane supports based on the use case.
-
-For example, setting just `["Observe"]` makes Crossplane treat the resource as
-a read-only resource, importing the external resources not originally created
-by Crossplane. This allows other managed resources to reference the read-only
-resource, for example, a shared database or network. Importing a resource as
-read-only is convenient since Crossplane wont attempt to take control and
-only identifier parameters are needed to be specified in the managed resource.
-
-{{< hint "tip" >}}
-Read the [Import Existing Resources]({{<ref "/knowledge-base/guides/import-existing-resources" >}})
-guide for more
-information on using the `managementPolicies` to import existing resources.
-{{< /hint >}}
-
-Another application of `managementPolicies` is to skip the [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
-of the managed resource, by not including `LateInitialize` in the
-`managementPolicies`, which is useful when there are fields in the resource,
-that we would not like Crossplane to control, but would usually be filled in
-by Late Initialization.
-
-{{< hint "tip" >}}
-Read the [initProvider]({{<ref "./managed-resources#initprovider" >}}) section
-for more info about how we can use management policies without `LateInitialize`
-and `initProvider` together to ignore changes to fields that are controlled
-externally.
-{{< /hint >}}
-
-The `"Delete"` action replaces the [deletionPolicy]({{<ref "./managed-resources#deletionpolicy" >}})
-field in the managed resource. For now the `deletionPolicy` is still supported,
-but only if it's set to a non default value, which is `Orphan`. If it's set to
-`Orphan`, and the `managementPolicies` is set to `["*"]`, which is default,
-then the external resource will be orphaned when the managed resource is
-deleted. In other cases, non default `managementPolicies` take precedence over
-the `deletionPolicy` field. Keep in mind that this behavior is only applicable
-if the management policy alpha feature is enabled. To sum it up in a table:
-
-{{< table >}}
-| managementPolicies          | deletionPolicy   | result  |
-|-----------------------------|------------------|---------|
-| "*" (default)               | Delete (default) | Delete  |
-| "*" (default)               | Orphan           | Orphan  |
-| contains "Delete"           | Delete (default) | Delete  |
-| contains "Delete"           | Orphan           | Delete  |
-| doesn't contain "Delete"   | Delete (default) | Orphan  |
-| doesn't contain "Delete"   | Orphan           | Orphan  |
-{{< /table >}}
-
-#### Options
-* `*` - ** Default ** - Crossplane can observe, create, change, delete the
-  external resource and update the managed resource spec with late init
-  parameters.
-* `Observe` - managed resource `status.atProvider` will be updated with the
-  external resource state.
-* `Create` - external resource will be created using the managed resource
-  `spec.initProvider` and `spec.forProvider`.
-* `Update` - external resource will be updated using the managed resource
-  `spec.forProvider`.
-* `Delete` - the external resource will be deleted when the managed resource is
-  deleted.
-* `LateInitialize` - Unprovided spec fields are late initialized to
-  `spec.forProvider` with the default values from the cloud provider. This
-  enables Crossplane to take full control of the external resource, even those
-  values not provided by the user upfront. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
-
-<!-- vale off -->
 ### initProvider
 <!-- vale on -->
 
 {{<hint "important" >}}
-The managed resource `initProvider` option is an alpha feature related to 
+The managed resource `initProvider` option is an alpha feature related to
 [managementPolicies]({{<ref "./managed-resources#managementpolicies" >}}).
 
 Enable the `initProvider` in a provider with `--enable-management-policies`
@@ -315,14 +255,37 @@ in a
 [ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
 {{< /hint >}}
 
-The `spec.initProvider` is a subset of the `spec.forProvider` fields that
-Crossplane merges with `forProvider` to create the external resource, but
-ignores when updating it. This allows users to create a resource with all the
-required fields which may then be controlled externally. For example, a user may
-want to create a `NodeGroup` with the required `desiredSize` field, but then
-let an autoscaler control the field. If the `desiredSize` field is included
-in the`forProvider` field, Crossplane will attempt to update the field, which
-will conflict with the autoscaler.
+The
+{{<hover label="initProvider" line="7">}}initProvider{{</hover>}} defines
+settings Crossplane applies only when creating a new managed resource.  
+Crossplane ignores settings defined in the
+{{<hover label="initProvider" line="7">}}initProvider{{</hover>}}
+field that change after creation.
+
+{{<hint "note" >}}
+Settings in `forProvider` are always enforced by Crossplane. Crossplane reverts
+any changes to a `forProvider` field in the external resource.
+
+Settings in `initProvider` aren't enforced by Crossplane. Crossplane ignores any
+changes to a `initProvider` field in the external resource.
+{{</hint >}}
+
+Using `initProvider` is useful for setting initial values that a Provider may
+automatically change, like an auto scaling group.
+
+For example, creating a
+{{<hover label="initProvider" line="2">}}NodeGroup{{</hover>}}
+with an initial
+{{<hover label="initProvider" line="9">}}desiredSize{{</hover>}}.  
+Crossplane doesn't change the
+{{<hover label="initProvider" line="9">}}desiredSize{{</hover>}}
+setting back when an autoscaler scales the Node Group external resource.
+
+{{< hint "tip" >}}
+Crossplane recommends configuring
+{{<hover label="initProvider" line="6">}}managementPolicies{{</hover>}} without
+`LateInitialize` to avoid conflicts with `initProvider` settings.
+{{< /hint >}}
 
 ```yaml {label="initProvider",copy-lines="none"}
 apiVersion: eks.aws.upbound.io/v1beta1
@@ -341,9 +304,77 @@ spec:
         minSize: 1
 ```
 
-It's suggested to use a combination of `managementPolicies` without the
-`LateInitialize` action when using `initProvider` to avoid late initialization
-of fields in `forProvider`. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
+<!-- vale off -->
+### managementPolicies
+<!-- vale on --> 
+
+{{<hint "important" >}}
+The managed resource `managementPolicies` option is an alpha feature. 
+
+Enable `managementPolicies` in a provider with `--enable-management-policies` 
+in a 
+[ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
+{{< /hint >}}
+
+Crossplane
+{{<hover label="managementPol1" line="4">}}managementPolicies{{</hover>}}
+determine which actions Crossplane can take on a
+managed resource and its corresponding external resource.  
+Apply one or more
+{{<hover label="managementPol1" line="4">}}managementPolicies{{</hover>}}
+to a managed resource to determine what permissions
+Crossplane has over the resource.
+
+For example, give Crossplane permission to create and delete an external resource,
+but not make any changes set the policies to
+{{<hover label="managementPol1" line="4">}}["Create", "Delete"]{{</hover>}}.
+
+```yaml {label="managementPol1"}
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Subnet
+spec:
+  managementPolicies: ["Create", "Delete"]
+  forProvider:
+    # Removed for brevity
+```
+
+The default policy grants Crossplane full control over the resources.  
+Defining the `managementPolicies` field with an empty array [pauses](#paused)
+the resource.
+
+{{<hint "important" >}}
+The Provider determines support for management policies.  
+Refer to the Provider's documentation to see if the Provider supports
+management policies.
+{{< /hint >}}
+
+Crossplane supports the following policies:
+{{<table "table table-sm table-hover">}}
+| Policy | Description |
+| --- | --- |
+| `*` | _Default policy_. Crossplane has full control over a resource. |
+| `Create` | If the external resource doesn't exist, Crossplane creates it based on the managed resource settings. |
+| `Delete` | Crossplane can delete the external resource when deleting the managed resource. |
+| `LateInitialize` | Crossplane imports some external resource settings not defined in the `spec.forProvider` of the managed resource. |
+| `Observe` | Crossplane only observes the resource and doesn't make any changes. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+| `Update` | Crossplane changes the external resource when changing the managed resource. |
+{{</table >}}
+
+The following is a list of common policy combinations:
+{{<table "table table-sm table-hover table-striped-columns" >}}
+| Create | Delete | LateInitialize | Observe | Update | Description |
+| :---:  | :---:  | :---:          | :---:   | :---:  | ---         |
+| ✔️      | ✔️      | ✔️              | ✔️       | ✔️      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
+| ✔️      | ✔️      | ✔️              | ✔️       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
+| ✔️      | ✔️      |                | ✔️       | ✔️      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
+| ✔️      | ✔️      |                | ✔️       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
+| ✔️      |        | ✔️              | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. |
+| ✔️      |        | ✔️              | ✔️       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
+| ✔️      |        |                | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
+| ✔️      |        |                | ✔️       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
+|        |        |                | ✔️       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+|        |        |                |         |        | No policy set. An alternative method for [pausing](#paused) a resource.                                                                                              |
+{{< /table >}}
 
 <!-- vale off -->
 ### providerConfigRef

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -61,11 +61,10 @@ Provider deletes the managed resource but doesn't delete the external resource.
 #### Interaction with management policies
 
 If a resource configures a Crossplane
-[management policy](#managementpolicies) and the related management policy alpha
-feature is enabled, the management policy takes precedence over the
-`deletionPolicy` setting, unless it's the default management policy.
+[management policy](#managementpolicies), the management policy takes precedence 
+over the `deletionPolicy` setting, unless it's the default management policy.
 
-{{< table >}}
+{{< table "table table-sm table-hover">}}
 | managementPolicies          | deletionPolicy   | result  |
 |-----------------------------|------------------|---------|
 | "*" (default)               | Delete (default) | Delete  |
@@ -114,7 +113,7 @@ inside a Provider's web console, Crossplane reverts that change back to what's
 configured in the `forProvider` setting. 
 {{< /hint >}}
 
-#### Late Initialization
+#### Late initialization
 
 After the external resource creation, providers add some provider defaulted
 settings not manually set to the `forProvider` field of the created managed

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -211,37 +211,111 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
  
 
 <!-- vale off -->
-### managementPolicy
+### managementPolicies
 <!-- vale on --> 
 
 {{<hint "important" >}}
-The managed resource `managementPolicy` option is an alpha feature. 
+The managed resource `managementPolicies` option is an alpha feature. 
 
-Enable the `managementPolicy` in a provider with `--enable-management-policies` 
+Enable the `managementPolicies` in a provider with `--enable-management-policies` 
 in a 
 [ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
 {{< /hint >}}
 
-A `managementPolicy` determines if Crossplane can make changes to managed
-resources. The `ObserveOnly` policy imports existing external resources not 
-originally created by Crossplane.  
-This allows new managed resources to reference 
-the `ObserveOnly` resource, for example, a shared database or network. 
-The `ObserveOnly` policy can also place existing resources under the control of
+Granular `managementPolicies` determine what actions Crossplane can take on a 
+managed and its external resource. `managementPolicies` is an array of actions
+(`Observe`, `Create`, `Update`, `Delete`, `LateInitialize`, `*`), and there are
+multiple combinations that Crossplane supports based on the use case. For 
+example, setting `["Observe"]` makes Crossplane treat the resource as an
+`ObserveOnly` resource, importing the external resources not originally created
+by Crossplane. This allows new managed resources to reference the `ObserveOnly`
+resource, for example, a shared database or network. 
+The `["Observe"]` policy can also place existing resources under the control of
 Crossplane.  
 
 {{< hint "tip" >}}
 Read the [Import Existing Resources]({{<ref "/knowledge-base/guides/import-existing-resources" >}}) 
 guide for more
-information on using the `managementPolicy` to import existing resources.
+information on using the `managementPolicies` to import existing resources.
 {{< /hint >}}
 
-#### Options
-* `managementPolicy: FullControl` - **Default** - Crossplane can create, change
-  and delete the managed resource. 
-* `managementPolicy: ObserveOnly` - Crossplane only imports the details of the
-  external resource, but doesn't make any changes to the managed resource. 
+Furthermore, granular `managementPolicies` can be used to skip the late 
+initialization of the managed resource, by not including `LateInitialize` in the
+`managementPolicies`, which is useful when there are conflicting fields between
+the managed resource and the external resource, due to some external resource
+field being controlled externally. 
 
+{{< hint "tip" >}}
+Read the [initProvider]({{<ref "./managed-resources#initprovider" >}}) section
+for more info about how we can use `LateInitialize` and `initProvider` together
+to ignore changes to fields that are controlled externally.
+{{< /hint >}}
+
+The `"Delete"` action replaces the [deletionPolicy]({{<ref "./managed-resources#deletionpolicy" >}})
+field in the managed resource. For now the `deletionPolicy` is still supported,
+but only if it's set to a non default value, which is `Orphan`. If it's set to
+`Orphan`, and the `managementPolicies` is set to `["*"]`, which is default,
+then the external resource will be orphaned when the managed resource is
+deleted. In other cases, non default `managementPolicies` take precedence over
+the `deletionPolicy` field.
+
+#### Options
+* `*` - ** Default ** - Crossplane can observe, create, change, delete the 
+   external resource and update the managed resource object with late init
+   parameters.
+* `Observe` - managed resource `status.atProvider` will be updated with the 
+   external resource state.
+* `Create` - external resource will be created using the managed resource
+   `spec.initProvider` and `spec.forProvider`.
+* `Update` - external resource will be updated using the managed resource
+   `spec.forProvider`.
+* `Delete` - the external resource will be deleted when the managed resource is
+   deleted.
+* `LateInitialize` - select fields of the managed resource 
+   `spec.forProvider` will be updated with the external resource state.
+
+<!-- vale off -->
+### initProvider
+<!-- vale on -->
+
+{{<hint "important" >}}
+The managed resource `initProvider` option is an alpha feature related to 
+[managementPolicies]({{<ref "./managed-resources#managementpolicies" >}}).
+
+Enable the `initProvider` in a provider with `--enable-management-policies`
+in a
+[ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
+{{< /hint >}}
+
+The `spec.initProvider` is a subset of the `spec.forProvider` fields that
+Crossplane merges with `forProvider` to create the external resource, but
+ignores when updating it. This allows users to create a resource with all the
+required fields which may then be controlled externally. For example, a user may
+want to create a `NodeGroup` with the required `desiredSize` field, but then
+let an autoscaler control the field. If the `desiredSize` field is included
+in the`forProvider` field, Crossplane will attempt to update the field, which
+will conflict with the autoscaler.
+
+```yaml {label="initProvider",copy-lines="none"}
+apiVersion: eks.aws.upbound.io/v1beta1
+kind: NodeGroup
+metadata:
+  name: sample-eks-ng
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "Delete"]
+  initProvider:
+    scalingConfig:
+      - desiredSize: 1
+  forProvider:
+    region: us-west-1
+    scalingConfig:
+      - maxSize: 4
+        minSize: 1
+```
+
+It's suggested to use a combination of `managementPolicies` without 
+`LateInitialize` with `initProvider` to avoid late initialization of fields 
+in `forProvider`.
 
 <!-- vale off -->
 ### providerConfigRef

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -56,7 +56,7 @@ Provider deletes the managed resource but doesn't delete the external resource.
 
 #### Options
 * `deletionPolicy: Delete` - **Default** - Delete the external resource when deleting the managed resource.
-* `deletionPolicy: Orphan` - Leave the external resource when deleting the managed resource. 
+* `deletionPolicy: Orphan` - Leave the external resource when deleting the managed resource.
 
 #### Interaction with management policies
 
@@ -65,7 +65,7 @@ If a resource configures a Crossplane
 feature is enabled, the management policy takes precedence over the
 `deletionPolicy` setting, unless it's the default management policy.
 
-{{< table >}}
+{{< table "table table-sm table-hover">}}
 | managementPolicies          | deletionPolicy   | result  |
 |-----------------------------|------------------|---------|
 | "*" (default)               | Delete (default) | Delete  |
@@ -113,13 +113,6 @@ made to an external resource outside of Crossplane. If a user makes a change
 inside a Provider's web console, Crossplane reverts that change back to what's
 configured in the `forProvider` setting. 
 {{< /hint >}}
-
-#### Late Initialization
-
-After the external resource creation, providers add some provider defaulted
-settings not manually set to the `forProvider` field of the created managed
-resource object into their respected `forProvider` fields.
-Use `kubectl describe <managed_resource>` to view the applied values.
 
 #### Referencing other resources
 
@@ -229,6 +222,19 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
 `delete`.
 <!-- vale write-good.Passive = YES -->
 {{< /hint >}}
+
+#### Late initialization
+
+For some of the optional fields, users rely on the default that the cloud
+provider chooses for them. Since Crossplane treats the managed resource as the
+source of the truth, values of those fields need to exist in `spec` of the
+managed resource. In each reconciliation, Crossplane will fill the value of
+a field that's left empty by the user but is assigned a value by the provider.
+For example, there could be two fields like `region` and `availabilityZone` and
+you might want to give only `region` and leave the availability zone to be
+chosen by the cloud provider. In that case, if the provider assigns an
+availability zone, Crossplane gets that value and fills `availabilityZone`. Note
+that if the field is already filled, the controller won't override its value.
 
 <!-- vale off -->
 ### initProvider
@@ -557,7 +563,6 @@ Read the
 [Vault as an External Secrets Store]({{<ref "knowledge-base/integrations/vault-as-secret-store">}})
 guide for details on using StoreConfig objects.
 {{< /hint >}}
-
 
 ## Annotations
 

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -216,8 +216,8 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
 For some of the optional fields, users rely on the default that the cloud
 provider chooses for them. Since Crossplane treats the managed resource as the
 source of the truth, values of those fields need to exist in `spec` of the
-managed resource. So, in each reconciliation, Crossplane will fill the value of
-a field that is left empty by the user but is assigned a value by the provider.
+managed resource. In each reconciliation, Crossplane will fill the value of
+a field that's left empty by the user but is assigned a value by the provider.
 For example, there could be two fields like `region` and `availabilityZone` and
 you might want to give only `region` and leave the availability zone to be
 chosen by the cloud provider. In that case, if the provider assigns an
@@ -245,7 +245,7 @@ For example, setting just `["Observe"]` makes Crossplane treat the resource as
 a read-only resource, importing the external resources not originally created
 by Crossplane. This allows other managed resources to reference the read-only
 resource, for example, a shared database or network. Importing a resource as
-read-only is convenient since Crossplane will not attempt to take control and
+read-only is convenient since Crossplane wont attempt to take control and
 only identifier parameters are needed to be specified in the managed resource.
 
 {{< hint "tip" >}}
@@ -283,8 +283,8 @@ if the management policy alpha feature is enabled. To sum it up in a table:
 | "*" (default)               | Orphan           | Orphan  |
 | contains "Delete"           | Delete (default) | Delete  |
 | contains "Delete"           | Orphan           | Delete  |
-| does not contain "Delete"   | Delete (default) | Orphan  |
-| does not contain "Delete"   | Orphan           | Orphan  |
+| doesn't contain "Delete"    | Delete (default) | Orphan  |
+| doesn't contain "Delete"    | Orphan           | Orphan  |
 {{< /table >}}
 
 #### Options
@@ -299,7 +299,7 @@ if the management policy alpha feature is enabled. To sum it up in a table:
   `spec.forProvider`.
 * `Delete` - the external resource will be deleted when the managed resource is
   deleted.
-* `LateInitialize` - Unprovided spec fields are late-initialized to
+* `LateInitialize` - Unprovided spec fields are late initialized to
   `spec.forProvider` with the default values from the cloud provider. This
   enables Crossplane to take full control of the external resource, even those 
   values not provided by the user upfront. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -208,7 +208,21 @@ resource object is deleted from Kubernetes and the `deletionPolicy` is
 `delete`.
 <!-- vale write-good.Passive = YES -->
 {{< /hint >}}
- 
+
+<!-- vale off -->
+#### Late Initialization
+<!-- vale on --> 
+
+For some of the optional fields, users rely on the default that the cloud
+provider chooses for them. Since Crossplane treats the managed resource as the
+source of the truth, values of those fields need to exist in `spec` of the
+managed resource. So, in each reconciliation, Crossplane will fill the value of
+a field that is left empty by the user but is assigned a value by the provider.
+For example, there could be two fields like `region` and `availabilityZone` and
+you might want to give only `region` and leave the availability zone to be
+chosen by the cloud provider. In that case, if the provider assigns an
+availability zone, Crossplane gets that value and fills `availabilityZone`. Note
+that if the field is already filled, the controller won't override its value.
 
 <!-- vale off -->
 ### managementPolicies
@@ -225,13 +239,14 @@ in a
 Granular `managementPolicies` determine what actions Crossplane can take on a
 managed and its external resource. `managementPolicies` is an array of actions
 (`Observe`, `Create`, `Update`, `Delete`, `LateInitialize`, `*`), and there are
-multiple combinations that Crossplane supports based on the use case. For
-example, setting `["Observe"]` makes Crossplane treat the resource as an
-`ObserveOnly` resource, importing the external resources not originally created
-by Crossplane. This allows new managed resources to reference the `ObserveOnly`
-resource, for example, a shared database or network.
-The `["Observe"]` policy can also place existing resources under the control of
-Crossplane.  
+multiple combinations that Crossplane supports based on the use case.
+
+For example, setting just `["Observe"]` makes Crossplane treat the resource as 
+a read-only resource, importing the external resources not originally created
+by Crossplane. This allows other managed resources to reference the read-only
+resource, for example, a shared database or network. Importing a resource as
+read-only is convenient since Crossplane will not attempt to take control and
+only identifier parameters are needed to be specified in the managed resource.
 
 {{< hint "tip" >}}
 Read the [Import Existing Resources]({{<ref "/knowledge-base/guides/import-existing-resources" >}}) 
@@ -239,16 +254,17 @@ guide for more
 information on using the `managementPolicies` to import existing resources.
 {{< /hint >}}
 
-Furthermore, granular `managementPolicies` can be used to skip the late
-initialization of the managed resource, by not including `LateInitialize` in the
-`managementPolicies`, which is useful when there are conflicting fields between
-the managed resource and the external resource, due to some external resource
-field being controlled externally.
+Another application of `managementPolicies` is to skip the [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
+of the managed resource, by not including `LateInitialize` in the
+`managementPolicies`, which is useful when there are fields in the resource,
+that we would not like Crossplane to control, but would usually be filled in
+by Late Initialization.
 
 {{< hint "tip" >}}
 Read the [initProvider]({{<ref "./managed-resources#initprovider" >}}) section
-for more info about how we can use `LateInitialize` and `initProvider` together
-to ignore changes to fields that are controlled externally.
+for more info about how we can use management policies without `LateInitialize`
+and `initProvider` together to ignore changes to fields that are controlled
+externally.
 {{< /hint >}}
 
 The `"Delete"` action replaces the [deletionPolicy]({{<ref "./managed-resources#deletionpolicy" >}}) 
@@ -257,11 +273,23 @@ but only if it's set to a non default value, which is `Orphan`. If it's set to
 `Orphan`, and the `managementPolicies` is set to `["*"]`, which is default, 
 then the external resource will be orphaned when the managed resource is
 deleted. In other cases, non default `managementPolicies` take precedence over
-the `deletionPolicy` field.
+the `deletionPolicy` field. Keep in mind that this behavior is only applicable
+if the management policy alpha feature is enabled. To sum it up in a table:
+
+{{< table >}}
+| managementPolicies          | deletionPolicy   | result  |
+|-----------------------------|------------------|---------|
+| "*" (default)               | Delete (default) | Delete  |
+| "*" (default)               | Orphan           | Orphan  |
+| contains "Delete"           | Delete (default) | Delete  |
+| contains "Delete"           | Orphan           | Delete  |
+| does not contain "Delete"   | Delete (default) | Orphan  |
+| does not contain "Delete"   | Orphan           | Orphan  |
+{{< /table >}}
 
 #### Options
 * `*` - ** Default ** - Crossplane can observe, create, change, delete the
-  external resource and update the managed resource object with late init
+  external resource and update the managed resource spec with late init
   parameters.
 * `Observe` - managed resource `status.atProvider` will be updated with the
   external resource state.
@@ -271,8 +299,10 @@ the `deletionPolicy` field.
   `spec.forProvider`.
 * `Delete` - the external resource will be deleted when the managed resource is
   deleted.
-* `LateInitialize` - select fields of the managed resource
-  `spec.forProvider` will be updated with the external resource state.
+* `LateInitialize` - Unprovided spec fields are late-initialized to
+  `spec.forProvider` with the default values from the cloud provider. This
+  enables Crossplane to take full control of the external resource, even those 
+  values not provided by the user upfront. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
 
 
 <!-- vale off -->
@@ -314,9 +344,9 @@ spec:
         minSize: 1
 ```
 
-It's suggested to use a combination of `managementPolicies` without
-`LateInitialize` with `initProvider` to avoid late initialization of fields
-in `forProvider`.
+It's suggested to use a combination of `managementPolicies` without the
+`LateInitialize` action when using `initProvider` to avoid late initialization
+of fields in `forProvider`. Read more about [Late Initialization]({{<ref "./managed-resources#late-initialization" >}})
 
 <!-- vale off -->
 ### providerConfigRef

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -62,8 +62,8 @@ Provider deletes the managed resource but doesn't delete the external resource.
 
 If a resource configures a Crossplane
 [management policy](#managementpolicies) and the related management policy alpha
-feature is enabled, the managment policy takes precedence over the
-`deletionPolicy` setting, unless it is the default management policy.
+feature is enabled, the management policy takes precedence over the
+`deletionPolicy` setting, unless it's the default management policy.
 
 {{< table >}}
 | managementPolicies          | deletionPolicy   | result  |

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -122,4 +122,11 @@
             }
         }
     }
+
+    //Striped table font color
+    .table-striped-columns > :not(caption) > tr > :nth-child(even){
+        color: inherit !important;
+    }
 }
+
+

--- a/utils/vale/styles/Crossplane/allowed-jargon.txt
+++ b/utils/vale/styles/Crossplane/allowed-jargon.txt
@@ -54,3 +54,4 @@ kube-controller-manager
 kube-apiserver
 cluster-wide
 autoscaler
+DatabaseInstance

--- a/utils/vale/styles/Crossplane/allowed-jargon.txt
+++ b/utils/vale/styles/Crossplane/allowed-jargon.txt
@@ -53,3 +53,4 @@ CLI
 kube-controller-manager
 kube-apiserver
 cluster-wide
+autoscaler

--- a/utils/vale/styles/Crossplane/crossplane-words.txt
+++ b/utils/vale/styles/Crossplane/crossplane-words.txt
@@ -53,3 +53,4 @@ composition.yaml
 managementPolicies
 deletionPolicy
 initProvider
+LateInitialize

--- a/utils/vale/styles/Crossplane/crossplane-words.txt
+++ b/utils/vale/styles/Crossplane/crossplane-words.txt
@@ -50,3 +50,6 @@ InactivePackageRevision
 crossplane.yaml
 definition.yaml
 composition.yaml
+managementPolicies
+deletionPolicy
+initProvider


### PR DESCRIPTION
Late update for the management policies alpha feature. 

Replaces the old `managementPolicy` to `managementPolicies`, updates the Importing guide and adds a section for `spec.initProvider`. 

Fixes: #497 