### PR TITLE
Fix broken links to snippets

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -181,7 +181,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/v1.10/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/media/snippets/compose/claim-aws-new.yaml
+++ b/content/media/snippets/compose/claim-aws-new.yaml
@@ -1,0 +1,14 @@
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  parameters:
+    storageGB: 20
+  compositionSelector:
+    matchLabels:
+      provider: aws
+      vpc: new
+  writeConnectionSecretToRef:
+    name: db-conn

--- a/content/media/snippets/compose/claim-aws.yaml
+++ b/content/media/snippets/compose/claim-aws.yaml
@@ -1,0 +1,13 @@
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  parameters:
+    storageGB: 20
+  compositionSelector:
+    matchLabels:
+      provider: aws
+  writeConnectionSecretToRef:
+    name: db-conn

--- a/content/media/snippets/compose/claim-azure.yaml
+++ b/content/media/snippets/compose/claim-azure.yaml
@@ -1,0 +1,13 @@
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  parameters:
+    storageGB: 20
+  compositionSelector:
+    matchLabels:
+      provider: azure
+  writeConnectionSecretToRef:
+    name: db-conn

--- a/content/media/snippets/compose/claim-gcp.yaml
+++ b/content/media/snippets/compose/claim-gcp.yaml
@@ -1,0 +1,13 @@
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  parameters:
+    storageGB: 20
+  compositionSelector:
+    matchLabels:
+      provider: gcp
+  writeConnectionSecretToRef:
+    name: db-conn

--- a/content/media/snippets/compose/pod.yaml
+++ b/content/media/snippets/compose/pod.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: see-db
+  namespace: default
+spec:
+  containers:
+  - name: see-db
+    image: postgres:12
+    command: ['psql']
+    args: ['-c', 'SELECT current_database();']
+    env:
+    - name: PGDATABASE
+      value: postgres
+    - name: PGHOST
+      valueFrom:
+        secretKeyRef:
+          name: db-conn
+          key: endpoint
+    - name: PGUSER
+      valueFrom:
+        secretKeyRef:
+          name: db-conn
+          key: username
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: db-conn
+          key: password
+    - name: PGPORT
+      valueFrom:
+        secretKeyRef:
+          name: db-conn
+          key: port

--- a/content/media/snippets/configure/aws/providerconfig.yaml
+++ b/content/media/snippets/configure/aws/providerconfig.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-creds
+      key: creds

--- a/content/media/snippets/configure/aws/setup.sh
+++ b/content/media/snippets/configure/aws/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# This is a helper script that uses ~/.aws/credentials and ~/.aws/config
+# to build an aws provider object
+#
+# aws configuration (credentials and default region) is required for this
+# script
+
+set -e -o pipefail
+
+# change to script directory
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}")" && pwd )"
+
+aws_profile=
+
+while (( "$#" )); do
+  if test -z "$2"; then
+    echo "invalid value for $1 option"
+    exit -1
+  fi
+  case "$1" in
+    -p|--profile)
+      aws_profile=$2
+      shift 2
+      ;;
+    *) 
+      shift
+      ;;
+  esac
+done
+
+# make sure kubectl is configured
+kubectl cluster-info > /dev/null || echo "KUBECONFIG is not configured properly"
+
+# if aws_profile is not provided, use default
+aws_profile="${aws_profile:-default}"
+
+# retrieve aws profile credentials, save it under 'default' profile, and base64 encode it
+AWS_CREDS_BASE64=$(echo -e "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $aws_profile)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $aws_profile)" | base64  | tr -d "\n")
+
+if test -z "$AWS_CREDS_BASE64"; then
+  echo "error reading credentials from aws config"
+  exit 1
+fi
+
+echo "apiVersion: v1
+data:
+  creds: $AWS_CREDS_BASE64
+kind: Secret
+metadata:
+  name: aws-creds
+  namespace: crossplane-system
+type: Opaque" | kubectl apply -f -

--- a/content/media/snippets/configure/azure/providerconfig.yaml
+++ b/content/media/snippets/configure/azure/providerconfig.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: azure.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: azure-creds
+      key: creds

--- a/content/media/snippets/configure/gcp/credentials.sh
+++ b/content/media/snippets/configure/gcp/credentials.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# This is a helper script to create a project, service account, and credentials.json
+# file for use in Crossplane GCP examples
+#
+# gcloud is required for use and must be configured with privileges to perform these tasks
+#
+set -e -o pipefail
+ROLES=(roles/iam.serviceAccountUser roles/cloudsql.admin roles/container.admin roles/redis.admin roles/compute.networkAdmin roles/storage.admin)
+SERVICES=(container.googleapis.com sqladmin.googleapis.com redis.googleapis.com compute.googleapis.com servicenetworking.googleapis.com)
+KEYFILE=crossplane-gcp-provider-key.json
+RAND=$RANDOM
+
+if ! command -v gcloud > /dev/null; then
+	echo "Please install gcloud: https://cloud.google.com/sdk/install"
+	exit 1
+fi
+
+tab () { sed 's/^/    /' ; }
+# list your organizations (if applicable), take note of the specific organization ID you want to use
+# if you have more than one organization (not common)
+gcloud organizations list --format '[box]' 2>&1 | tab
+
+ORGANIZATION_ID=$(gcloud organizations list --format 'value(ID)' --limit 1)
+read -e -p "Choose an Organization ID [$ORGANIZATION_ID]: " PROMPT_ORGANIZATION_ID
+ORGANIZATION_ID=${PROMPT_ORGANIZATION_ID:-$ORGANIZATION_ID}
+
+gcloud projects list --format '[box]' 2>&1 | tab
+
+# create a new id
+EXAMPLE_PROJECT_ID="crossplane-example-$RAND"
+read -e -p "Choose or create a Project ID [$EXAMPLE_PROJECT_ID]: " PROMPT_EXAMPLE_PROJECT_ID
+EXAMPLE_PROJECT_ID=${PROMPT_EXAMPLE_PROJECT_ID:-$EXAMPLE_PROJECT_ID}
+
+EXAMPLE_PROJECT_ID_FOUND=$(gcloud projects list --filter PROJECT_ID="$EXAMPLE_PROJECT_ID" --format="value(PROJECT_ID)")
+
+if [[ -z $EXAMPLE_PROJECT_ID_FOUND ]]; then
+	ACCOUNT_ID=$(gcloud beta billing accounts list --format 'value(ACCOUNT_ID)' --limit 1)
+	gcloud beta billing accounts list --format '[box]' 2>&1 | tab
+	read -e -p "Choose a Billing Account ID [$ACCOUNT_ID]: " PROMPT_ACCOUNT_ID
+	ACCOUNT_ID=${PROMPT_ACCOUNT_ID:-$ACCOUNT_ID}
+
+	echo -e "\n* Creating Project $EXAMPLE_PROJECT_ID ... "
+	gcloud projects create $EXAMPLE_PROJECT_ID --enable-cloud-apis --organization $ORGANIZATION_ID 2>&1 | tab
+
+	echo "* Linking Billing Account $ACCOUNT_ID with Project $EXAMPLE_PROJECT_ID ... "
+	gcloud beta billing projects link $EXAMPLE_PROJECT_ID --billing-account=$ACCOUNT_ID 2>&1 | tab
+else
+	echo -n "\n* Using Project $EXAMPLE_PROJECT_NAME ... $EXAMPLE_PROJECT_ID"
+fi
+
+# enable Kubernetes API
+for service in "${SERVICES[@]}"; do
+	# enable Google API
+	echo "* Enabling Service $service on $EXAMPLE_PROJECT_ID"
+	gcloud --project $EXAMPLE_PROJECT_ID services enable $service 2>&1 | tab
+done
+
+# create service account
+SA_NAME="example-$RAND"
+echo " * Creating a Service Account"
+gcloud --project $EXAMPLE_PROJECT_ID iam service-accounts create $SA_NAME --display-name "Crossplane Example" 2>&1 | tab
+# export service account email
+EXAMPLE_SA="${SA_NAME}@${EXAMPLE_PROJECT_ID}.iam.gserviceaccount.com"
+
+# assign roles
+for role in "${ROLES[@]}"; do
+	echo "* Adding Role $role to $EXAMPLE_SA on $EXAMPLE_PROJECT_ID"
+	gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAccount:$EXAMPLE_SA" --role="$role" 2>&1 | tab
+done
+
+# create service account key (this will create a `crossplane-gcp-provider-key.json` file in your current working directory)
+echo " * Creating $EXAMPLE_SA Key File $KEYFILE"
+gcloud --project $EXAMPLE_PROJECT_ID iam service-accounts keys create --iam-account $EXAMPLE_SA $KEYFILE 2>&1 | tab
+
+cat <<EOS
+#
+# Run the following for the variables that are used throughout the GCP example projects
+#
+export ORGANIZATION_ID=$ORGANIZATION_ID
+export PROJECT_ID=$EXAMPLE_PROJECT_ID
+export EXAMPLE_SA=$EXAMPLE_SA
+export BASE64ENCODED_GCP_PROVIDER_CREDS=\$(base64 $KEYFILE | tr -d "\n")
+EOS

--- a/content/media/snippets/package/aws-with-vpc/composition.yaml
+++ b/content/media/snippets/package/aws-with-vpc/composition.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: vpcpostgresqlinstances.aws.database.example.org
+  labels:
+    provider: aws
+    guide: quickstart
+    vpc: new
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: database.example.org/v1alpha1
+    kind: XPostgreSQLInstance
+  resources:
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: VPC
+        spec:
+          forProvider:
+            region: us-east-1
+            cidrBlock: 192.168.0.0/16
+            enableDnsSupport: true
+            enableDnsHostNames: true
+    - name: subnet-a
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-east-1a
+        spec:
+          forProvider:
+            region: us-east-1
+            cidrBlock: 192.168.64.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-east-1a
+    - name: subnet-b
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-east-1b
+        spec:
+          forProvider:
+            region: us-east-1
+            cidrBlock: 192.168.128.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-east-1b
+    - name: subnet-c
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          labels:
+            zone: us-east-1c
+        spec:
+          forProvider:
+            region: us-east-1
+            cidrBlock: 192.168.192.0/18
+            vpcIdSelector:
+              matchControllerRef: true
+            availabilityZone: us-east-1c
+    - name: dbsubnetgroup
+      base:
+        apiVersion: database.aws.crossplane.io/v1beta1
+        kind: DBSubnetGroup
+        spec:
+          forProvider:
+            region: us-east-1
+            description: An excellent formation of subnetworks.
+            subnetIdSelector:
+              matchControllerRef: true
+    - name: internetgateway
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: InternetGateway
+        spec:
+          forProvider:
+            region: us-east-1
+            vpcIdSelector:
+              matchControllerRef: true
+    - name: routetable
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: RouteTable
+        spec:
+          forProvider:
+            region: us-east-1
+            vpcIdSelector:
+              matchControllerRef: true
+            routes:
+              - destinationCidrBlock: 0.0.0.0/0
+                gatewayIdSelector:
+                  matchControllerRef: true
+            associations:
+              - subnetIdSelector:
+                  matchLabels:
+                    zone: us-east-1a
+              - subnetIdSelector:
+                  matchLabels:
+                    zone: us-east-1b
+              - subnetIdSelector:
+                  matchLabels:
+                    zone: us-east-1c
+    - name: securitygroup
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        spec:
+          forProvider:
+            region: us-east-1
+            vpcIdSelector:
+              matchControllerRef: true
+            groupName: crossplane-getting-started
+            description: Allow access to PostgreSQL
+            ingress:
+              - fromPort: 5432
+                toPort: 5432
+                ipProtocol: tcp
+                ipRanges:
+                  - cidrIp: 0.0.0.0/0
+                    description: Everywhere
+    - name: rdsinstance
+      base:
+        apiVersion: database.aws.crossplane.io/v1beta1
+        kind: RDSInstance
+        spec:
+          forProvider:
+            region: us-east-1
+            dbSubnetGroupNameSelector:
+              matchControllerRef: true
+            vpcSecurityGroupIDSelector:
+              matchControllerRef: true
+            dbInstanceClass: db.t2.small
+            masterUsername: masteruser
+            engine: postgres
+            engineVersion: "12"
+            skipFinalSnapshotBeforeDeletion: true
+            publiclyAccessible: true
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.allocatedStorage"
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - fromConnectionSecretKey: port

--- a/content/media/snippets/package/aws-with-vpc/crossplane.yaml
+++ b/content/media/snippets/package/aws-with-vpc/crossplane.yaml
@@ -1,0 +1,29 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: getting-started-with-aws-with-vpc
+  annotations:
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane/crossplane
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      An introductory example to Crossplane and Composition for AWS.
+    meta.crossplane.io/readme: |
+      An introductory example to Crossplane and Composition for AWS.
+      This will enable provisioning of an RDS database instance.
+      The example also illustrates how to specify a non-default VPC.
+      
+      [Install & 
+      Configure](https://crossplane.io/docs/master/getting-started/install-configure.html)
+
+      [Provision a PostgreSQL RDS 
+      Database](https://crossplane.io/docs/master/getting-started/provision-infrastructure.html)
+    guide: quickstart
+    provider: aws
+    vpc: new
+spec:
+  crossplane:
+    version: ">=v1.8.0-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-aws
+      version: ">=v0.24.1"

--- a/content/media/snippets/package/aws-with-vpc/definition.yaml
+++ b/content/media/snippets/package/aws-with-vpc/definition.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "The OpenAPIV3Schema of this Composite Resource Definition."
+            properties:
+              parameters:
+                type: object
+                properties:
+                  storageGB:
+                    type: integer
+                    description: "The desired storage capacity of the database, in GB."
+                required:
+                  - storageGB
+            required:
+              - parameters

--- a/content/media/snippets/package/aws/composition.yaml
+++ b/content/media/snippets/package/aws/composition.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresqlinstances.aws.database.example.org
+  labels:
+    provider: aws
+    guide: quickstart
+    vpc: default
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: database.example.org/v1alpha1
+    kind: XPostgreSQLInstance
+  resources:
+    - name: rdsinstance
+      base:
+        apiVersion: database.aws.crossplane.io/v1beta1
+        kind: RDSInstance
+        spec:
+          forProvider:
+            region: us-east-1
+            dbInstanceClass: db.t2.small
+            masterUsername: masteruser
+            engine: postgres
+            engineVersion: "12"
+            skipFinalSnapshotBeforeDeletion: true
+            publiclyAccessible: true
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.allocatedStorage"
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - fromConnectionSecretKey: port

--- a/content/media/snippets/package/aws/crossplane.yaml
+++ b/content/media/snippets/package/aws/crossplane.yaml
@@ -1,0 +1,29 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: getting-started-with-aws
+  annotations:
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane/crossplane
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      An introductory example to Crossplane and Composition for AWS.
+    meta.crossplane.io/readme: |
+      An introductory example to Crossplane and Composition for AWS.
+      This will enable provisioning of an RDS database instance.
+
+      [Install & 
+      Configure](https://crossplane.io/docs/master/getting-started/install-configure.html)
+
+      [Provision a PostgreSQL RDS 
+      Database](https://crossplane.io/docs/master/getting-started/provision-infrastructure.html)
+  labels:
+    guide: quickstart
+    provider: aws
+    vpc: default
+spec:
+  crossplane:
+    version: ">=v1.8.0-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-aws
+      version: ">=v0.24.1"

--- a/content/media/snippets/package/aws/definition.yaml
+++ b/content/media/snippets/package/aws/definition.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "The OpenAPIV3Schema of this Composite Resource Definition."
+            properties:
+              parameters:
+                type: object
+                properties:
+                  storageGB:
+                    type: integer
+                    description: "The desired storage capacity of the database, in GB."
+                required:
+                  - storageGB
+            required:
+              - parameters

--- a/content/media/snippets/package/azure/composition.yaml
+++ b/content/media/snippets/package/azure/composition.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresqlinstances.azure.database.example.org
+  labels:
+    provider: azure
+    guide: quickstart
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: database.example.org/v1alpha1
+    kind: XPostgreSQLInstance
+  resources:
+    - name: resourcegroup
+      base:
+        apiVersion: azure.crossplane.io/v1alpha3
+        kind: ResourceGroup
+        spec:
+          location: West US 2
+    - name: postgresqlserver
+      base:
+        apiVersion: database.azure.crossplane.io/v1beta1
+        kind: PostgreSQLServer
+        spec:
+          forProvider:
+            administratorLogin: myadmin
+            resourceGroupNameSelector:
+              matchControllerRef: true
+            location: West US 2
+            sslEnforcement: Disabled
+            version: "11"
+            storageProfile:
+              storageMB: 5120            
+            sku:
+              tier: GeneralPurpose
+              capacity: 2
+              family: Gen5
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.storageProfile.storageMB"
+          transforms:
+            - type: math
+              math:
+                multiply: 1024
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - type: FromValue
+          name: port
+          value: "5432"
+    - name: firewallrule
+      base:
+        apiVersion: database.azure.crossplane.io/v1alpha3
+        kind: PostgreSQLServerFirewallRule
+        spec:
+          forProvider:
+            serverNameSelector:
+              matchControllerRef: true
+            resourceGroupNameSelector:
+              matchControllerRef: true
+            properties:
+              startIpAddress: 0.0.0.0
+              endIpAddress: 255.255.255.254

--- a/content/media/snippets/package/azure/crossplane.yaml
+++ b/content/media/snippets/package/azure/crossplane.yaml
@@ -1,0 +1,27 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: getting-started-with-azure
+  annotations:
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane/crossplane
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      An introductory example to Crossplane and Composition for Azure.
+    meta.crossplane.io/readme: |
+      An introductory example to Crossplane and Composition for Azure.
+      This will enable provisioning of an Azure SQL database instance.
+
+      [Install & 
+      Configure](https://crossplane.io/docs/master/getting-started/install-configure.html)
+
+      [Provision a PostgreSQL Azure SQL 
+      Database](https://crossplane.io/docs/master/getting-started/provision-infrastructure.html)
+    guide: quickstart
+    provider: azure
+spec:
+  crossplane:
+    version: ">=v1.8.0-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-azure
+      version: ">=v0.18.1"

--- a/content/media/snippets/package/azure/definition.yaml
+++ b/content/media/snippets/package/azure/definition.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "The OpenAPIV3Schema of this Composite Resource Definition."
+            properties:
+              parameters:
+                type: object
+                properties:
+                  storageGB:
+                    type: integer
+                    description: "The desired storage capacity of the database, in GB."
+                required:
+                  - storageGB
+            required:
+              - parameters

--- a/content/media/snippets/package/definition.yaml
+++ b/content/media/snippets/package/definition.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              parameters:
+                type: object
+                properties:
+                  storageGB:
+                    type: integer
+                required:
+                  - storageGB
+            required:
+              - parameters

--- a/content/media/snippets/package/gcp/composition.yaml
+++ b/content/media/snippets/package/gcp/composition.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresqlinstances.gcp.database.example.org
+  labels:
+    provider: gcp
+    guide: quickstart
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: database.example.org/v1alpha1
+    kind: XPostgreSQLInstance
+  resources:
+    - name: cloudsqlinstance
+      base:
+        apiVersion: database.gcp.crossplane.io/v1beta1
+        kind: CloudSQLInstance
+        spec:
+          forProvider:
+            databaseVersion: POSTGRES_12
+            region: us-central1
+            settings:
+              tier: db-custom-1-3840
+              dataDiskType: PD_SSD
+              ipConfiguration:
+                ipv4Enabled: true
+                authorizedNetworks:
+                  - value: "0.0.0.0/0"
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.storageGB"
+          toFieldPath: "spec.forProvider.settings.dataDiskSizeGb"
+      connectionDetails:
+        - fromConnectionSecretKey: username
+        - fromConnectionSecretKey: password
+        - fromConnectionSecretKey: endpoint
+        - type: FromValue
+          name: port
+          value: "5432"

--- a/content/media/snippets/package/gcp/crossplane.yaml
+++ b/content/media/snippets/package/gcp/crossplane.yaml
@@ -1,0 +1,27 @@
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: getting-started-with-gcp
+  annotations:
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane/crossplane
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      An introductory example to Crossplane and Composition for GCP.
+    meta.crossplane.io/readme: |
+      An introductory example to Crossplane and Composition for GCP.
+      This will enable provisioning of a Cloud SQL database instance.
+
+      [Install & 
+      Configure](https://crossplane.io/docs/master/getting-started/install-configure.html)
+
+      [Provision a PostgreSQL Cloud SQL 
+      Database](https://crossplane.io/docs/master/getting-started/provision-infrastructure.html)
+    guide: quickstart
+    provider: gcp
+spec:
+  crossplane:
+    version: ">=v1.8.0-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-gcp
+      version: ">=v0.20.0"

--- a/content/media/snippets/package/gcp/definition.yaml
+++ b/content/media/snippets/package/gcp/definition.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.example.org
+spec:
+  group: database.example.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - username
+    - password
+    - endpoint
+    - port
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "The OpenAPIV3Schema of this Composite Resource Definition."
+            properties:
+              parameters:
+                type: object
+                properties:
+                  storageGB:
+                    type: integer
+                    description: "The desired storage capacity of the database, in GB."
+                required:
+                  - storageGB
+            required:
+              - parameters

--- a/content/media/snippets/provision/aws.yaml
+++ b/content/media/snippets/provision/aws.yaml
@@ -1,0 +1,16 @@
+apiVersion: database.aws.crossplane.io/v1beta1
+kind: RDSInstance
+metadata:
+  name: rdspostgresql
+spec:
+  forProvider:
+    region: us-east-1
+    dbInstanceClass: db.t2.small
+    masterUsername: masteruser
+    allocatedStorage: 20
+    engine: postgres
+    engineVersion: "12"
+    skipFinalSnapshotBeforeDeletion: true
+  writeConnectionSecretToRef:
+    namespace: crossplane-system
+    name: aws-rdspostgresql-conn

--- a/content/media/snippets/provision/azure.yaml
+++ b/content/media/snippets/provision/azure.yaml
@@ -1,0 +1,28 @@
+apiVersion: azure.crossplane.io/v1alpha3
+kind: ResourceGroup
+metadata:
+  name: sqlserverpostgresql-rg
+spec:
+  location: West US 2
+---
+apiVersion: database.azure.crossplane.io/v1beta1
+kind: PostgreSQLServer
+metadata:
+  name: sqlserverpostgresql
+spec:
+  forProvider:
+    administratorLogin: myadmin
+    resourceGroupNameRef:
+      name: sqlserverpostgresql-rg
+    location: West US 2
+    sslEnforcement: Disabled
+    version: "11"
+    sku:
+      tier: GeneralPurpose
+      capacity: 2
+      family: Gen5
+    storageProfile:
+      storageMB: 20480
+  writeConnectionSecretToRef:
+    namespace: crossplane-system
+    name: sqlserverpostgresql-conn

--- a/content/media/snippets/provision/gcp.yaml
+++ b/content/media/snippets/provision/gcp.yaml
@@ -1,0 +1,15 @@
+apiVersion: database.gcp.crossplane.io/v1beta1
+kind: CloudSQLInstance
+metadata:
+  name: cloudsqlpostgresql
+spec:
+  forProvider:
+    databaseVersion: POSTGRES_12
+    region: us-central1
+    settings:
+      tier: db-custom-1-3840
+      dataDiskType: PD_SSD
+      dataDiskSizeGb: 10
+  writeConnectionSecretToRef:
+    namespace: crossplane-system
+    name: cloudsqlpostgresql-conn

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -177,7 +177,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/v1.10/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/v1.12/concepts/packages.md
+++ b/content/v1.12/concepts/packages.md
@@ -177,7 +177,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/v1.10/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/v1.13/concepts/packages.md
+++ b/content/v1.13/concepts/packages.md
@@ -181,7 +181,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/v1.10/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:


### PR DESCRIPTION
The new weekly CI run for external links found references to files in the v1.10 folder that were deleted with the latest release. 

This restores the snippets folder until the packages page is rewritten and updates the links. 

Signed-off-by: Pete Lumbis <pete@upbound.io>