### PR TITLE
Document MatchTrue, MatchFalse and MatchCondition readiness checks

### DIFF
--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -1000,6 +1000,7 @@ Compositions support matching resource fields by:
  * [integer match](#match-an-integer)
  * [non-empty match](#match-that-a-field-exists)
  * [always ready](#always-consider-a-resource-ready)
+ * [condition match](#match-a-condition)
 
 #### Match a string
 
@@ -1125,6 +1126,34 @@ spec:
         # Removed for brevity
       readinessChecks:
         - type: None
+```
+
+#### Match a Condition
+{{<hover label="condition" line="11">}}Condition{{</hover>}} considers the composed
+resource to be ready when it finds the expected condition type, with the
+expected status for it in its `status.conditions`.
+
+For example, consider 
+{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which will be marked
+as ready if there is a condition of type 
+{{<hover label="condition" line="13">}}MyType{{</hover>}} with a status of
+{{<hover label="condition" line="14">}}Success{{</hover>}}.
+
+```yaml {label="condition",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  resources:
+  # Removed for Brevity
+    - name: my-resource
+      base:
+        # Removed for brevity
+      readinessChecks:
+        - type: MatchCondition
+          matchCondition:
+            type: MyType
+            status: Success
 ```
 
 ## Verify a Composition

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -1001,6 +1001,7 @@ Compositions support matching resource fields by:
  * [non-empty match](#match-that-a-field-exists)
  * [always ready](#always-consider-a-resource-ready)
  * [condition match](#match-a-condition)
+ * [boolean match](#match-a-boolean)
 
 #### Match a string
 
@@ -1155,6 +1156,72 @@ spec:
             type: MyType
             status: Success
 ```
+
+#### Match a Boolean
+
+Two types of checks exist for matching boolean fields:
+ * `MatchTrue`
+ * `MatchFalse`
+
+`MatchTrue` considers the composed resource to be ready when the value of a 
+field within that resource is `true`.
+
+`MatchFalse` considers the composed resource to be ready when the value of a 
+field within that resource is `false`.
+
+For example, consider 
+{{<hover label="matchTrue" line="7">}}my-resource{{</hover>}}, which will be marked
+as ready if 
+{{<hover label="matchTrue" line="12">}} status.atProvider.manifest.status.ready{{</hover>}}
+is {{<hover label="matchTrue" line="11">}}true{{</hover>}}.
+
+```yaml {label="matchTrue",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  resources:
+  # Removed for Brevity
+    - name: my-resource
+      base:
+        # Removed for brevity
+      readinessChecks:
+        - type: MatchTrue
+          fieldPath: status.atProvider.manifest.status.ready
+```
+{{<hint "tip" >}}
+Checking {{<hover label="matchTrue" line="11">}}MatchTrue{{</hover>}} doesn't
+require a `match` field.
+{{< /hint >}} 
+
+Alternatively, `MatchFalse` can be used for fields that express readiness with
+negative polarity.
+
+For example, consider 
+{{<hover label="matchFalse" line="7">}}my-resource{{</hover>}}, which will be marked
+as ready if 
+{{<hover label="matchFalse" line="12">}} status.atProvider.manifest.status.pending{{</hover>}}
+is {{<hover label="matchFalse" line="11">}}false{{</hover>}}.
+
+```yaml {label="matchFalse",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  resources:
+  # Removed for Brevity
+    - name: my-resource
+      base:
+        # Removed for brevity
+      readinessChecks:
+        - type: MatchFalse
+          fieldPath: status.atProvider.manifest.status.pending
+```
+
+{{<hint "tip" >}}
+Checking {{<hover label="matchFalse" line="11">}}MatchFalse{{</hover>}} doesn't
+require a `match` field.
+{{< /hint >}} 
 
 ## Verify a Composition
 

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -1129,14 +1129,14 @@ spec:
         - type: None
 ```
 
-#### Match a Condition
+#### Match a condition
 {{<hover label="condition" line="11">}}Condition{{</hover>}} considers the composed
 resource to be ready when it finds the expected condition type, with the
 expected status for it in its `status.conditions`.
 
 For example, consider 
-{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which will be marked
-as ready if there is a condition of type 
+{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which is
+ready if there is a condition of type 
 {{<hover label="condition" line="13">}}MyType{{</hover>}} with a status of
 {{<hover label="condition" line="14">}}Success{{</hover>}}.
 
@@ -1157,7 +1157,7 @@ spec:
             status: Success
 ```
 
-#### Match a Boolean
+#### Match a boolean
 
 Two types of checks exist for matching boolean fields:
  * `MatchTrue`
@@ -1170,8 +1170,8 @@ field within that resource is `true`.
 field within that resource is `false`.
 
 For example, consider 
-{{<hover label="matchTrue" line="7">}}my-resource{{</hover>}}, which will be marked
-as ready if 
+{{<hover label="matchTrue" line="7">}}my-resource{{</hover>}}, which is
+ready if 
 {{<hover label="matchTrue" line="12">}} status.atProvider.manifest.status.ready{{</hover>}}
 is {{<hover label="matchTrue" line="11">}}true{{</hover>}}.
 
@@ -1194,12 +1194,11 @@ Checking {{<hover label="matchTrue" line="11">}}MatchTrue{{</hover>}} doesn't
 require a `match` field.
 {{< /hint >}} 
 
-Alternatively, `MatchFalse` can be used for fields that express readiness with
-negative polarity.
+`MatchFalse` matches fields that express readiness with the value `false`.
 
 For example, consider 
-{{<hover label="matchFalse" line="7">}}my-resource{{</hover>}}, which will be marked
-as ready if 
+{{<hover label="matchFalse" line="7">}}my-resource{{</hover>}}, is
+ready if 
 {{<hover label="matchFalse" line="12">}} status.atProvider.manifest.status.pending{{</hover>}}
 is {{<hover label="matchFalse" line="11">}}false{{</hover>}}.
 

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -1164,10 +1164,10 @@ Two types of checks exist for matching boolean fields:
  * `MatchFalse`
 
 `MatchTrue` considers the composed resource to be ready when the value of a 
-field within that resource is `true`.
+field inside that resource is `true`.
 
 `MatchFalse` considers the composed resource to be ready when the value of a 
-field within that resource is `false`.
+field inside that resource is `false`.
 
 For example, consider 
 {{<hover label="matchTrue" line="7">}}my-resource{{</hover>}}, which is

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -1102,7 +1102,7 @@ spec:
 
 {{<hint "tip" >}}
 Checking {{<hover label="NonEmpty" line="11">}}NonEmpty{{</hover>}} doesn't
-require a `match` field.
+require setting any other fields.
 {{< /hint >}} 
 
 #### Always consider a resource ready
@@ -1191,7 +1191,7 @@ spec:
 ```
 {{<hint "tip" >}}
 Checking {{<hover label="matchTrue" line="11">}}MatchTrue{{</hover>}} doesn't
-require a `match` field.
+require setting any other fields.
 {{< /hint >}} 
 
 `MatchFalse` matches fields that express readiness with the value `false`.
@@ -1219,7 +1219,7 @@ spec:
 
 {{<hint "tip" >}}
 Checking {{<hover label="matchFalse" line="11">}}MatchFalse{{</hover>}} doesn't
-require a `match` field.
+require setting any other fields.
 {{< /hint >}} 
 
 ## Verify a Composition

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -1003,6 +1003,7 @@ Compositions support matching resource fields by:
  * [integer match](#match-an-integer)
  * [non-empty match](#match-that-a-field-exists)
  * [always ready](#always-consider-a-resource-ready)
+ * [condition match](#match-a-condition)
 
 #### Match a string
 
@@ -1128,6 +1129,34 @@ spec:
         # Removed for brevity
       readinessChecks:
         - type: None
+```
+
+#### Match a Condition
+{{<hover label="condition" line="11">}}Condition{{</hover>}} considers the composed
+resource to be ready when it finds the expected condition type, with the
+expected status for it in its `status.conditions`.
+
+For example, consider 
+{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which will be marked
+as ready if there is a condition of type 
+{{<hover label="condition" line="13">}}MyType{{</hover>}} with a status of
+{{<hover label="condition" line="14">}}Success{{</hover>}}.
+
+```yaml {label="condition",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  resources:
+  # Removed for Brevity
+    - name: my-resource
+      base:
+        # Removed for brevity
+      readinessChecks:
+        - type: MatchCondition
+          matchCondition:
+            type: MyType
+            status: Success
 ```
 
 ## Verify a Composition

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -1104,7 +1104,7 @@ spec:
 
 {{<hint "tip" >}}
 Checking {{<hover label="NonEmpty" line="11">}}NonEmpty{{</hover>}} doesn't
-require a `match` field.
+require setting any other fields.
 {{< /hint >}} 
 
 #### Always consider a resource ready

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -1131,14 +1131,14 @@ spec:
         - type: None
 ```
 
-#### Match a Condition
+#### Match a condition
 {{<hover label="condition" line="11">}}Condition{{</hover>}} considers the composed
 resource to be ready when it finds the expected condition type, with the
 expected status for it in its `status.conditions`.
 
 For example, consider 
-{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which will be marked
-as ready if there is a condition of type 
+{{<hover label="condition" line="7">}}my-resource{{</hover>}}, which is
+ready if there is a condition of type 
 {{<hover label="condition" line="13">}}MyType{{</hover>}} with a status of
 {{<hover label="condition" line="14">}}Success{{</hover>}}.
 


### PR DESCRIPTION
Companion for https://github.com/crossplane/crossplane/pull/4399

I noticed MatchCondition was not yet documented. If this was intentional or if you'd rather it in a separate PR just let me know :-)