### PR TITLE
Fix font loading in deploy previews

### DIFF
--- a/netlify_build.sh
+++ b/netlify_build.sh
@@ -12,5 +12,5 @@ cat config.yaml
 if [ "$CONTEXT" = "production" ]; then
 hugo --minify --baseURL https://docs.crossplane.io/
 else
-hugo --minify --baseURL $DEPLOY_URL/
+hugo --minify --baseURL https://deploy-preview-$REVIEW_ID--crossplane.netlify.app/
 fi


### PR DESCRIPTION
The current build script generates a hugo config with a baseURL of the commit ID, not the PR number. 

Since deploy URLs are based on the PR number the baseURL doesn't match the PR and some files won't load properly because of browser and netlify security rules. 

This changes the base URL to be based on the PR number instead of the commit ID so everything aligns.