### PR TITLE
Fix snippets location in github

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -181,7 +181,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -177,7 +177,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/v1.12/concepts/packages.md
+++ b/content/v1.12/concepts/packages.md
@@ -177,7 +177,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:

--- a/content/v1.13/concepts/packages.md
+++ b/content/v1.13/concepts/packages.md
@@ -181,7 +181,7 @@ provided constraints.
 > Dependency resolution is a `beta` feature and depends on the `v1beta1`
 > [`Lock` API][lock-api].
 
-For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/media/snippets/package/gcp).
+For an example Configuration package, see [getting-started-with-gcp](https://github.com/crossplane/docs/tree/master/content/media/snippets/package/gcp).
 
 To build a Configuration package, navigate to the package root directory and
 execute the following command:


### PR DESCRIPTION
The update in #512 used an incomplete path for the snippets location and it couldn't be tested until it was pushed.

This corrects the paths for the snippets. 