### PR TITLE
Minor color improvements

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -157,7 +157,6 @@ h3, h4, h5, h6 {
   color: var(--font-body-color);
   // Override bootstrap defaults to support dark mode
   --bs-table-hover-color: var(--font-body-color);
-  --bs-table-hover-bg: var(--nav-highlight-color);
 }
 
 .ga-tag{

--- a/themes/geekboot/assets/scss/_footer.scss
+++ b/themes/geekboot/assets/scss/_footer.scss
@@ -11,7 +11,7 @@
     text-align: left;
 
     a {
-      color: $turquoise;
+      color: #{$aqua-500};
     }
   }
 

--- a/themes/geekboot/assets/scss/_home.scss
+++ b/themes/geekboot/assets/scss/_home.scss
@@ -30,8 +30,8 @@
 /* purgecss start ignore */
 #tooltip {
     display: inline-block;
-    background: $brightSun;
-    color: $slate;
+    background: #{$sun-500};
+    color: #{$fog-700};
     font-weight: bold;
     padding: 5px 10px;
     font-size: 16px;

--- a/themes/geekboot/assets/scss/_home.scss
+++ b/themes/geekboot/assets/scss/_home.scss
@@ -30,8 +30,8 @@
 /* purgecss start ignore */
 #tooltip {
     display: inline-block;
-    background: #{$sun-500};
-    color: #{$fog-700};
+    background: #{$aqua-400};
+    color: #{$fog-1000};
     font-weight: bold;
     padding: 5px 10px;
     font-size: 16px;

--- a/themes/geekboot/assets/scss/_search-button.scss
+++ b/themes/geekboot/assets/scss/_search-button.scss
@@ -28,7 +28,7 @@
         &:active,
         &:focus,
         &:hover {
-            border-color: $brightSun;
+            border-color: #{$sun-500};
         }
     }
 
@@ -41,7 +41,7 @@
         &:active,
         &:focus,
         &:hover {
-            border-color: $brightSun;
+            border-color: #{$sun-500};
             color: var(--bs-btn-hover-color);
             background-color: var(--bs-btn-hover-bg);
         }

--- a/themes/geekboot/assets/scss/_search-results.scss
+++ b/themes/geekboot/assets/scss/_search-results.scss
@@ -5,7 +5,7 @@
     .DocSearch-SearchBar{
 
         .DocSearch-Form{
-            box-shadow: inset 0 0 0 .75px $brightSun;
+            box-shadow: inset 0 0 0 .75px #{$sun-500};
             background: var(--search-box-background);
 
             .DocSearch-MagnifierLabel{

--- a/themes/geekboot/assets/scss/_variables.scss
+++ b/themes/geekboot/assets/scss/_variables.scss
@@ -10,9 +10,7 @@ $font-size-base:              1.125rem !default;
 $body-font-size:              16px !default;
 
 
-// New color variables are below. The previous color variable found at the bottom of this file will be translated to these or removed once these new colors have been applied to enough of the docs content.
-
-// Grayscale palette. These are equivalent to varying opacities of the darkest shade over white (e.g. $fog-500 is equivalent to $fog-1000 at 50% opacity over white).
+// Grayscale palette. These are equivalent to varying opacities of the darkest shade over white (e.g. $fog-500 is the equivalent to $fog-1000 at 50% opacity over white).
 $fog-0:                     #FFFFFF !default;
 $fog-25:                    #F9F9F9 !default;
 $fog-50:                    #F3F3F3 !default;
@@ -33,7 +31,7 @@ $fog-1000:                  #0A1111 !default;
 
 // Colored palettes. Spectrums gradually transition into white with numbers below "-500" and transition into $fog-1000 on numbers after "-500".
 
-// $Aqua-500 is the teal color pulled from the Crossplane popsicle logo. This is the primary color to be used for actions.
+// $Aqua-500 is the teal color pulled from the Crossplane popsicle logo. Aqua is the primary color hue to be used for actions.
 $aqua-25:                    #F5FDFB !default;
 $aqua-50:                    #EAFAF8 !default;
 $aqua-75:                    #E1F8F5 !default;
@@ -118,20 +116,6 @@ $salmon-850:                   #503331 !default;
 $salmon-900:                   #392827 !default;
 $salmon-950:                   #221C1C !default;
 
-
-// Older color variables are below, should be avoided moving forward
-$aquaMarine:                #3de2cb !default;
-$aquarius:                  #37ccb7 !default;
-$fillBlackBlack:            #183b56 !default;
-$redPrimary:                #ff4f52 !default;
-$slate:                     #505a72 !default;
-$linkWater:                 #D3E7F7 !default;
-$nileBlue:                  #183d54 !default;
-$bayOfMany:                 #215373 !default;
-$turquoise:                 #35d0ba !default;
-$brightSun:                 #ffcd3c !default;
-$froly:                     #f3807b !default;
-$blueBayoux:                #5A7184 !default;
 
 $navbar-background-color:   #{$fog-1000} !default;
 $navbar-link-color:         #{$fog-0} !default;

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -86,10 +86,14 @@
     }
     .table {
         border: 1px solid #{$fog-700};
+        --bs-table-hover-bg: #{$fog-1000};
     }
-    .table-striped > tbody > tr:nth-of-type(odd) > * {
+    .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
         --bs-table-accent-bg: #{$fog-950};
         color: #{$fog-0};
+    }
+    .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
+        --bs-table-hover-bg: #{$fog-1000} !important;
     }
 
     // Add border to top nav and footer

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -51,7 +51,7 @@
 
     // Override Bootstrap accordion colors in the body
     .accordion {
-        --bs-accordion-border-color: #{$fog-800};
+        --bs-accordion-border-color: #{$fog-500};
         --bs-accordion-active-bg: #{$fog-1000};
         --bs-accordion-btn-focus-border-color: #{$fog-600};
         --bs-accordion-button-focus-border-color: #{$fog-600};
@@ -64,7 +64,7 @@
     }
     // Add hover border over clickable area
     .accordion-button:hover, .accordion-button:not(.collapsed):hover {
-        outline: 2px solid #{$fog-600};
+        outline: 2px solid #{$fog-0};
     }
     // Color text and background
     .accordion-button {
@@ -75,9 +75,9 @@
         background-color: #{$fog-1000};
         color: #{$fog-0};
     }
-    // Load chevron svg as manually-inputed $fog-400 hex code
+    // Load chevron svg as manually-inputed $fog-0 hex code
     .accordion-button::after {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%239DA0A0'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
+        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
     }
 
     // Tables

--- a/themes/geekboot/assets/scss/light-mode.scss
+++ b/themes/geekboot/assets/scss/light-mode.scss
@@ -93,10 +93,14 @@
     }
     .table {
         border: 1px solid #{$fog-200};
+        --bs-table-hover-bg: #{$fog-0};
     }
-    .table-striped > tbody > tr:nth-of-type(odd) > * {
+    .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
         --bs-table-accent-bg: #{$fog-50};
         color: #{$fog-1000};
+    }
+    .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
+        --bs-table-hover-bg: #{$fog-0} !important;
     }
 
     // Tab Colors

--- a/themes/geekboot/assets/scss/light-mode.scss
+++ b/themes/geekboot/assets/scss/light-mode.scss
@@ -59,7 +59,7 @@
 
     // Override Bootstrap accordion colors in the body
     .accordion {
-        --bs-accordion-border-color: #{$fog-200};
+        --bs-accordion-border-color: #{$fog-400};
         --bs-accordion-active-bg: #{$fog-0};
         --bs-accordion-btn-focus-border-color: #{$fog-400};
         --bs-accordion-button-focus-border-color: #{$fog-400};
@@ -71,7 +71,7 @@
     }
     // Add hover border over clickable area
     .accordion-button:hover, .accordion-button:not(.collapsed):hover {
-        outline: 2px solid #{$fog-400};
+        outline: 2px solid #{$fog-1000};
     }
     // Color text and background
     .accordion-button {
@@ -82,9 +82,9 @@
         background-color: #{$fog-0};
         color: #{$fog-1000};
     }
-    // Load chevron svg as manually-inputed $fog-600 hex code
+    // Load chevron svg as manually-inputed $fog-1000 hex code
     .accordion-button::after {
-        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%236C7070'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
+        background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23051513'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
     }
 
     // Tables


### PR DESCRIPTION
- Improve contrast for accordions/expandable blocks
- Improve coloring for "Join the Crossplane Slack" home page tooltip
- Replaced all old color variables with the new palette variables
- Fix dark mode coloring for vertical striped tables
- Remove table aqua background hover states