### PR TITLE
fix expand box bottom corners on expand

### DIFF
--- a/themes/geekboot/layouts/shortcodes/expand.html
+++ b/themes/geekboot/layouts/shortcodes/expand.html
@@ -10,7 +10,7 @@
       </button>
     </h2>
     <div id="{{$id}}-Content" class="accordion-collapse collapse" aria-labelledby="{{$id}}" data-bs-parent="#{{$id}}-Parent">
-      <div class="accordion-body">
+      <div class="accordion-body rounded-bottom">
         {{ .Inner | .Page.RenderString }}
       </div>
     </div>


### PR DESCRIPTION
As called out by @jbw976 in [another PR](https://github.com/crossplane/docs/pull/522#discussion_r1287425327) there is a problem with the bottom corners of expanded accordion/expand shortcode elements.

Looks like this may be issue [Bootstrap #38830](https://github.com/twbs/bootstrap/issues/38830).

This adds the workaround styling to the expand shortcode. 