### PR TITLE
correct use of helm --set

### DIFF
--- a/content/knowledge-base/guides/multi-tenant.md
+++ b/content/knowledge-base/guides/multi-tenant.md
@@ -283,7 +283,7 @@ Crossplane with the flag to automatically install a Configuration package
 alongside it.
 
 ```
-helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --set configuration.packages={"registry.upbound.io/xp/getting-started-with-aws:latest"}
+helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --set configuration.packages='{"registry.upbound.io/xp/getting-started-with-aws:latest"}'
 ```
 
 ### Control Plane of Control Planes

--- a/content/master/concepts/composition-functions.md
+++ b/content/master/concepts/composition-functions.md
@@ -53,9 +53,9 @@ Enable support for Composition Functions by enabling the alpha feature flag in C
 ```shell
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane \
     --create-namespace \
-    --set "args={--debug,--enable-composition-functions}" \
+    --set "args='{--debug,--enable-composition-functions}'" \
     --set "xfn.enabled=true" \
-    --set "xfn.args={--debug}"
+    --set "xfn.args='{--debug}'"
 ```
 
 The preceding Helm command installs Crossplane with the Composition Functions

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -86,7 +86,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages={xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}
+--set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install from a private repository

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -274,7 +274,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args=["--enable-composition-functions","--enable-composition-webhook-schema-validation"]`.
+args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
 
 ### Install pre-release Crossplane versions
 Install a pre-release versions of Crossplane from the `master` Crossplane Helm channel.

--- a/content/v1.11/concepts/providers.md
+++ b/content/v1.11/concepts/providers.md
@@ -85,7 +85,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages={xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}
+--set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install from a private repository

--- a/content/v1.11/software/install.md
+++ b/content/v1.11/software/install.md
@@ -274,7 +274,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args={"--enable-composition-functions","--enable-composition-webhook-schema-validation"}`.
+args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
 
 ### Install pre-release Crossplane versions
 Install a pre-release versions of Crossplane from the `master` Crossplane Helm channel.

--- a/content/v1.12/concepts/providers.md
+++ b/content/v1.12/concepts/providers.md
@@ -85,7 +85,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages={xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}
+--set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install from a private repository

--- a/content/v1.12/software/install.md
+++ b/content/v1.12/software/install.md
@@ -274,7 +274,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args=["--enable-composition-functions","--enable-composition-webhook-schema-validation"]`.
+args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
 
 ### Install pre-release Crossplane versions
 Install a pre-release versions of Crossplane from the `master` Crossplane Helm channel.

--- a/content/v1.13/concepts/composition-functions.md
+++ b/content/v1.13/concepts/composition-functions.md
@@ -53,9 +53,9 @@ Enable support for Composition Functions by enabling the alpha feature flag in C
 ```shell
 helm install crossplane --namespace crossplane-system crossplane-stable/crossplane \
     --create-namespace \
-    --set "args={--debug,--enable-composition-functions}" \
+    --set "args='{--debug,--enable-composition-functions}'" \
     --set "xfn.enabled=true" \
-    --set "xfn.args={--debug}"
+    --set "xfn.args='{--debug}'"
 ```
 
 The preceding Helm command installs Crossplane with the Composition Functions

--- a/content/v1.13/concepts/providers.md
+++ b/content/v1.13/concepts/providers.md
@@ -86,7 +86,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages={xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}
+--set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install from a private repository

--- a/content/v1.13/software/install.md
+++ b/content/v1.13/software/install.md
@@ -274,7 +274,7 @@ at the table below.
 
 Set these flags either in the `values.yaml` file or at install time using the
 `--set` flag, for example: `--set
-args=["--enable-composition-functions","--enable-composition-webhook-schema-validation"]`.
+args='{"--enable-composition-functions","--enable-composition-webhook-schema-validation"}'`.
 
 ### Install pre-release Crossplane versions
 Install a pre-release versions of Crossplane from the `master` Crossplane Helm channel.


### PR DESCRIPTION
Multiple uses of `--set args=` in install docs use brackets instead of braces and fail to quote the braces. This corrects it across the docs. 