### PR TITLE
Fix incorrect string format example in documentation

### DIFF
--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -1535,8 +1535,7 @@ patches:
       - type: string
         string:
           type: Format
-          format:
-            fmt: "the-field-%s"
+          fmt: "the-field-%s"
 ```
 
 #### Regular expression type

--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -1534,8 +1534,7 @@ patches:
       - type: string
         string:
           type: Format
-          format:
-            fmt: "the-field-%s"
+          fmt: "the-field-%s"
 ```
 
 #### Regular expression type


### PR DESCRIPTION
In the current Crossplane documentation, there is an incorrect example for the string formatting. This mistake might cause confusion for developers trying to write composition patches.

The incorrect example is given as:

patches:
  - type: FromCompositeFieldPath
    fromFieldPath: spec.field1
    toFieldPath: metadata.annotations["stringAnnotation"]
    transforms:
      - type: string
        string:
          type: Format
          format:
            fmt: "the-field-%s"

However, the correct format syntax should eliminate the format key, as shown below:

patches:
  - type: FromCompositeFieldPath
    fromFieldPath: spec.field1
    toFieldPath: metadata.annotations["stringAnnotation"]
    transforms:
      - type: string
        string:
          type: Format
          fmt: "the-field-%s"