### PR TITLE
Fix example for format transform

### DIFF
--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -1535,8 +1535,7 @@ patches:
       - type: string
         string:
           type: Format
-          format:
-            fmt: "the-field-%s"
+          fmt: "the-field-%s"
 ```
 
 #### Regular expression type

--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -1534,8 +1534,7 @@ patches:
       - type: string
         string:
           type: Format
-          format:
-            fmt: "the-field-%s"
+          fmt: "the-field-%s"
 ```
 
 #### Regular expression type


### PR DESCRIPTION
This PR fixes example for format transform on master and for v1.13. It is correct in [older versions](https://docs.crossplane.io/v1.12/concepts/composition/#transform-types) already.

Currently, it is documented as:

```yaml
patches:
  - type: FromCompositeFieldPath
    fromFieldPath: spec.field1
    toFieldPath: metadata.annotations["stringAnnotation"]
    transforms:
      - type: string
        string:
          type: Format
          format:
            fmt: "the-field-%s"
```

Which fails as:

```
Composition in version "v1" cannot be handled as a Composition: strict decoding error: unknown field "spec.resources[0].patches[0].transforms[0].string.format"
```

The correct version of it should be:

```yaml
patches:
  - type: FromCompositeFieldPath
    fromFieldPath: spec.field1
    toFieldPath: metadata.annotations["stringAnnotation"]
    transforms:
      - type: string
        string:
          type: Format
          fmt: "the-field-%s"
```