### PR TITLE
Remove included pages from local search and search engines

### DIFF
--- a/content/master/getting-started/install-crossplane-include.md
+++ b/content/master/getting-started/install-crossplane-include.md
@@ -1,5 +1,6 @@
 ---
 tocHidden: true
+searchExclude: true
 ---
 
 ## Install Crossplane

--- a/content/v1.13/getting-started/install-crossplane-include.md
+++ b/content/v1.13/getting-started/install-crossplane-include.md
@@ -1,5 +1,6 @@
 ---
 tocHidden: true
+searchExclude: true
 ---
 
 ## Install Crossplane

--- a/themes/geekboot/layouts/_default/sitemap.xml
+++ b/themes/geekboot/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range where .Site.Pages "Section" "latest" }}
+  {{ range where (where .Site.Pages "Section" "latest") ".Params.searchExclude" "ne" "true" }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}


### PR DESCRIPTION
Pages that are part of an `include` still exist as standalone Hugo pages, they are just hidden from the ToC. 

These pages are being included in the sitemap, which is used for indexing the docs for both local search and search engines. 

This adds a front matter setting, `searchExclude`, that when `true` will exclude the page from the sitemap. It also sets the front matter on the existing include pages.

Signed-off-by: Pete Lumbis <pete@upbound.io>