### PR TITLE
Update guidlines on envConfigs and patching to XRs

### DIFF
--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -598,7 +598,7 @@ spec:
 <!-- these two sections are duplicated in the environment-configs doc --> 
 
 ##### Patch a composite resource
-To patch the composite resource use
+To patch between the composite resource and the in-memory environment use
 {{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -135,7 +135,7 @@ the external resource name.
 #### Template a ProviderConfig
 
 Compositions can define a ProviderConfig like it defines managed resources.
-Generating a ProviderConfig can provide unique credentials to
+Generating a ProviderConfig may be useful in providing unique credentials to
 each deployment.
 
 
@@ -240,7 +240,8 @@ Composition, the resources defined by the
 the EKS {{<hover label="xcluster" line="13">}}cluster{{</hover >}}. 
 
 {{<hint "note" >}}
-This abbreviated example is from the Upbound [AWS Reference Platform](https://github.com/upbound/platform-ref-aws).
+This abbreviated example is from the Upbound 
+[AWS Reference Platform](https://github.com/upbound/platform-ref-aws).
 
 View the complete Compositions in the reference platform's 
 [package directory](https://github.com/upbound/platform-ref-aws/blob/main/package/cluster/composition.yaml).
@@ -445,9 +446,10 @@ Most Compositions require customizing the fields of the resources. This can
 include applying unique passwords, modifying where to deploy resources,
 or applying labels or annotations. 
 
-The primary method to change resources is using a resource [patch and transform]({{<ref "./patch-and-transform" >}}). Patch and transforms allow
-matching specific input fields, modifying them and applying them to the managed
-resource. 
+The primary method to change resources is using a resource 
+[patch and transform]({{<ref "./patch-and-transform" >}}). Patch and transforms 
+allow matching specific input fields, modifying them and applying them to the 
+managed resource. 
 
 {{<hint "important" >}}
 The details of creating patch and transforms and their options are in the 
@@ -594,7 +596,41 @@ spec:
   # Removed for Brevity
 ```
 
-Inside the {{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
+<!-- these two sections are duplicated in the environment-configs doc --> 
+
+##### Patch a composite resource
+To patch the composite resource use the 
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of the 
+{{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
+
+Use the 
+{{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
+data from the EnvironmentConfig to the composite resource.  
+Use the 
+{{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
+data from the composite resource to the EnvironmentConfig.
+
+```yaml {label="xrpatch",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  environment:
+  # Removed for Brevity
+      patches:
+      - type: ToCompositeFieldPath
+        fromFieldPath: tags
+        toFieldPath: metadata.labels[envTag]
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.name
+        toFieldPath: newEnvironmentKey
+```
+
+Individual resources can use any data written to the EnvironmentConfig.
+
+##### Patch an individual resource
+To patch an individual resource, inside the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
 data from the resource to the EnvironmentConfig.  
@@ -890,7 +926,8 @@ Read the
 for more information on restricting secret keys.
 {{< /hint >}}
 
-For more information on connection secrets read the [Connection Secrets knowledge base article]({{<ref "/knowledge-base/guides/connection-details">}}).
+For more information on connection secrets read the 
+[Connection Secrets knowledge base article]({{<ref "/knowledge-base/guides/connection-details">}}).
 
 {{<hint "warning">}}
 You can't change the 

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -550,8 +550,8 @@ spec:
 
 #### Patch with EnvironmentConfigs 
 
-Crossplane uses EnvironmentConfigs as an in-memory data store. Compositions can
-read and write from this data store as part of the patch process. 
+Crossplane uses EnvironmentConfigs to create in-memory data stores. Compositions 
+can read and write from this data store as part of the patch process. 
 
 {{<hint "important" >}}
 EnvironmentConfigs are an alpha feature. Alpha features aren't enabled by
@@ -559,7 +559,7 @@ default.
 {{< /hint >}}
 
  EnvironmentConfigs can predefine data that Compositions can use
- or a Composite Resource can write data to the EnvironmentConfig for other
+ or a Composite Resource can write data to their in-memory environment for other
  resources to read. 
 
 <!-- vale off -->
@@ -569,10 +569,9 @@ Read the [EnvironmentConfigs]({{<ref "./environment-configs" >}}) page for
 more information on using EnvironmentConfigs.
 {{< /hint >}}
 
-To apply a patch using EnvironmentConfigs, first define which EnvironmentConfig
+To apply a patch using EnvironmentConfigs, first define which EnvironmentConfigs
 to use with 
-{{<hover label="envselect"
-line="6">}}environment.environmentConfigs{{</hover>}}. 
+{{<hover label="envselect" line="6">}}environment.environmentConfigs{{</hover>}}. 
 
 <!-- vale Google.Quotes = NO -->
 <!-- vale gitlab.SentenceLength = NO -->
@@ -580,7 +579,7 @@ line="6">}}environment.environmentConfigs{{</hover>}}.
 Use either a
 [reference]({{<ref "./managed-resources#matching-by-name-reference" >}})
 or a [selector]({{<ref "./managed-resources#matching-by-selector" >}}) to
-identify the EnvironmentConfig to use.
+identify the EnvironmentConfigs to use.
 <!-- vale Google.Quotes = YES -->
 
 ```yaml {label="envselect",copy-lines="none"}
@@ -599,16 +598,16 @@ spec:
 <!-- these two sections are duplicated in the environment-configs doc --> 
 
 ##### Patch a composite resource
-To patch the composite resource use the 
-{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of the 
+To patch the composite resource use
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 
 Use the 
 {{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
-data from the EnvironmentConfig to the composite resource.  
+data from the in-memory environment to the composite resource.  
 Use the 
 {{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
-data from the composite resource to the EnvironmentConfig.
+data from the composite resource to the in-memory environment.
 
 ```yaml {label="xrpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1
@@ -626,16 +625,16 @@ spec:
         toFieldPath: newEnvironmentKey
 ```
 
-Individual resources can use any data written to the EnvironmentConfig.
+Individual resources can use any data written to their in-memory environment.
 
 ##### Patch an individual resource
 To patch an individual resource, inside the 
-{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
-data from the resource to the EnvironmentConfig.  
+data from the resource to the in-memory environment.  
 Use {{<hover label="envpatch" line="20">}}FromEnvironmentFieldPath{{</hover>}}
-to copy data to the resource from the EnvironmentConfig.
+to copy data to the resource from the in-memory environment.
 
 ```yaml {label="envpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1

--- a/content/master/concepts/environment-configs.md
+++ b/content/master/concepts/environment-configs.md
@@ -6,24 +6,25 @@ alphaVersion: "1.11"
 description: "Environment Configurations or EnvironmentConfigs are an in-memory datastore used in patching Compositions"
 ---
 
-A Crossplane EnvironmentConfig is an in-memory data store. Composition 
-patches can read from and write to an environment.
+A Crossplane EnvironmentConfig is a cluster scoped 
+[ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) used
+by Compositions. Compositions can use the environment to store information from
+individual resources or to apply [patches]({{<ref "patch-and-transform">}}).
 
 Crossplane supports multiple EnvironmentConfigs, each acting as a unique
 data store. 
 
-A Composition defines access to one or more EnvironmentConfigs.  
-
-When Crossplane creates a composite resource, Crossplane creates a unique copy
-of the defined EnvironmentConfigs for that composite resource.  
+When Crossplane creates a composite resource, Crossplane merges all the 
+EnvironmentConfigs referenced in the associated Composition and creates a unique
+in-memory environment for that composite resource.
 
 The composite resource can read and write data to their unique 
-EnvironmentConfig.
+in-memory environment.
 
 {{<hint "important" >}}
-EnvironmentConfigs are unique to each composite resource.  
-A composite resource can't read data in an EnvironmentConfig written by another
-composite resource.
+The in-memory environment is unique to each composite resource.  
+A composite resource can't read data in another composite resource's
+environment. 
 {{< /hint >}}
 
 ## Enable EnvironmentConfigs
@@ -93,7 +94,7 @@ data:
 ## Select an EnvironmentConfig
 <!-- vale Google.Headings = YES -->
 
-Select the EnvironmentConfig to use
+Select the EnvironmentConfigs to use
 inside a Composition's 
 {{<hover label="comp" line="6">}}environment{{</hover>}} field.
 
@@ -316,8 +317,8 @@ TODO: Add Policies
 
 ## Patching with EnvironmentConfigs
 
-When Crossplane creates a composite resource, Crossplane creates a unique copy  
-of the EnvironmentConfig for the composite resource. 
+When Crossplane creates or updates a composite resource, Crossplane 
+merges all the specified EnvironmentConfigs into an in-memory environment.
 
 The composite resource can read or write data between the EnvironmentConfig and
 composite resource or between the EnvironmentConfig and individual resources
@@ -330,19 +331,17 @@ Read about EnvironmentConfig patch types in the
 
 <!-- these two sections are duplicated in the compositions doc --> 
 
-### Patching a composite resource
-
-To patch a composite resource use the 
-{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of a
-Composition's 
+##### Patch a composite resource
+To patch the composite resource use
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 
 Use the 
 {{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
-data from the EnvironmentConfig to the composite resource.  
+data from the in-memory environment to the composite resource.  
 Use the 
 {{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
-data from the composite resource to the EnvironmentConfig.
+data from the composite resource to the in-memory environment.
 
 ```yaml {label="xrpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1
@@ -360,17 +359,16 @@ spec:
         toFieldPath: newEnvironmentKey
 ```
 
-Individual resources can use any data written to the EnvironmentConfig.
+Individual resources can use any data written to the in-memory environment.
 
 ##### Patch an individual resource
-
 To patch an individual resource, inside the 
-{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
-data from the resource to the EnvironmentConfig.  
+data from the resource to the in-memory environment.  
 Use {{<hover label="envpatch" line="20">}}FromEnvironmentFieldPath{{</hover>}}
-to copy data to the resource from the EnvironmentConfig.
+to copy data to the resource from the in-memory environment.
 
 ```yaml {label="envpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1

--- a/content/master/concepts/environment-configs.md
+++ b/content/master/concepts/environment-configs.md
@@ -12,6 +12,20 @@ patches can read from and write to an environment.
 Crossplane supports multiple EnvironmentConfigs, each acting as a unique
 data store. 
 
+A Composition defines access to one or more EnvironmentConfigs.  
+
+When Crossplane creates a composite resource, Crossplane creates a unique copy
+of the defined EnvironmentConfigs for that composite resource.  
+
+The composite resource can read and write data to their unique 
+EnvironmentConfig.
+
+{{<hint "important" >}}
+EnvironmentConfigs are unique to each composite resource.  
+A composite resource can't read data in an EnvironmentConfig written by another
+composite resource.
+{{< /hint >}}
+
 ## Enable EnvironmentConfigs
 EnvironmentConfigs are an alpha feature. Alpha features aren't enabled by
 default.
@@ -75,19 +89,16 @@ data:
     - item2
 ```
 
-## Patching with EnvironmentConfigs
+<!-- vale Google.Headings = NO -->
+## Select an EnvironmentConfig
+<!-- vale Google.Headings = YES -->
 
-To patch data from or to an EnvironmentConfig, reference the EnvironmentConfig
+Select the EnvironmentConfig to use
 inside a Composition's 
 {{<hover label="comp" line="6">}}environment{{</hover>}} field.
 
 The {{<hover label="comp" line="7">}}environmentConfigs{{</hover>}} field is a
 list of environments this Composition can use. 
-
-{{<hint "tip" >}}
-Read about EnvironmentConfig patch types in the 
-[Patch and Transform]({{<ref "./patch-and-transform">}}) documentation.
-{{< /hint >}}
 
 Select an environment by 
 {{<hover label="comp" line="8">}}Reference{{</hover>}} or 
@@ -196,89 +207,15 @@ spec:
     - type: Selector
       selector: 
         matchLabels:
-          - key: my-first-label-key
+          - key: my-label-key
             type: Value
-            value: my-first-label-value
-          - key: my-second-label-key
+            value: my-label-value
+          - key: my-label-key
             type: FromCompositeFieldPath
             valueFromFieldPath: spec.parameters.deploy
   resources:
   # Removed for brevity
 ```
-
-By default, Crossplane errors out if a
-{{<hover label="byLabel" line="16">}}valueFromFieldPath{{</hover>}}
-field doesn't exist in the composite resource at runtime.  
-Set the
-{{<hover label="byLabelOptional" line="17">}}fromFieldPathPolicy{{</hover>}}
-field to `Optional` to ignore fields that don't exist. 
-
-```yaml {label="byLabelOptional",copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
-kind: Composition
-metadata:
-  name: example-composition
-spec:
-  environment:
-    environmentConfigs:
-      - type: Selector
-        selector:
-          matchLabels:
-            - key: my-first-label-key
-              type: Value
-              value: my-first-label-value
-            - key: my-second-label-key
-              type: FromCompositeFieldPath
-              valueFromFieldPath: spec.parameters.deploy
-              fromFieldPathPolicy: Optional
-  resources:
-  # Removed for brevity
-```
-
-Set a default value for an optional label by setting the
-{{<hover label="byLabelOptionalDefault" line="15">}}value{{</hover>}} for the
-{{<hover label="byLabelOptionalDefault" line="14">}}key{{</hover>}} first, then
-define the
-{{<hover label="byLabelOptionalDefault" line="20">}}Optional{{</hover>}} label.
-
-For example, this Composition defines
-{{<hover label="byLabelOptionalDefault" line="16">}}value: my-default-value{{</hover>}}
-for the key {{<hover label="byLabelOptionalDefault" line="14">}}my-second-label-key{{</hover>}}.
-If the label
-{{<hover label="byLabelOptionalDefault" line="17">}}my-second-label-key{{</hover>}}
-exists, Crossplane uses the value from the label instead.
-
-```yaml {label="byLabelOptionalDefault",copy-lines="all"}
-apiVersion: apiextensions.crossplane.io/v1
-kind: Composition
-metadata:
-  name: example-composition
-spec:
-  environment:
-    environmentConfigs:
-      - type: Selector
-        selector:
-          matchLabels:
-            - key: my-first-label-key
-              type: Value
-              value: my-label-value
-            - key: my-second-label-key
-              type: Value
-              value: my-default-value
-            - key: my-second-label-key
-              type: FromCompositeFieldPath
-              valueFromFieldPath: spec.parameters.deploy
-              fromFieldPathPolicy: Optional
-  resources:
-  # Removed for brevity
-```
-
-{{<hint "warning" >}}
-Crossplane applies values in order. The value of the last key defined always takes precedence.
-
-Defining the default value _after_ the label always overwrites the label
-value.
-{{< /hint >}}
 
 #### Manage selector results
 
@@ -371,7 +308,94 @@ The environments selected by
 {{<hover label="maxMatch" line="18">}}matchLabels{{</hover>}} are then merged
 into any other environments listed in the 
 {{<hover label="maxMatch" line="7">}}environmentConfigs{{</hover>}}.
+
 <!--
 TODO: Add Policies
-TODO: Add webhook validations
 -->
+
+
+## Patching with EnvironmentConfigs
+
+When Crossplane creates a composite resource, Crossplane creates a unique copy  
+of the EnvironmentConfig for the composite resource. 
+
+The composite resource can read or write data between the EnvironmentConfig and
+composite resource or between the EnvironmentConfig and individual resources
+defined inside the composite resource. 
+
+{{<hint "tip" >}}
+Read about EnvironmentConfig patch types in the 
+[Patch and Transform]({{<ref "./patch-and-transform">}}) documentation.
+{{< /hint >}}
+
+<!-- these two sections are duplicated in the compositions doc --> 
+
+### Patching a composite resource
+
+To patch a composite resource use the 
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of a
+Composition's 
+{{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
+
+Use the 
+{{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
+data from the EnvironmentConfig to the composite resource.  
+Use the 
+{{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
+data from the composite resource to the EnvironmentConfig.
+
+```yaml {label="xrpatch",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  environment:
+  # Removed for Brevity
+      patches:
+      - type: ToCompositeFieldPath
+        fromFieldPath: tags
+        toFieldPath: metadata.labels[envTag]
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.name
+        toFieldPath: newEnvironmentKey
+```
+
+Individual resources can use any data written to the EnvironmentConfig.
+
+##### Patch an individual resource
+
+To patch an individual resource, inside the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
+resource, use 
+{{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
+data from the resource to the EnvironmentConfig.  
+Use {{<hover label="envpatch" line="20">}}FromEnvironmentFieldPath{{</hover>}}
+to copy data to the resource from the EnvironmentConfig.
+
+```yaml {label="envpatch",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  environment:
+  # Removed for Brevity
+  resources:
+  # Removed for Brevity
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: VPC
+        spec:
+          forProvider:
+            cidrBlock: 172.16.0.0/16
+      patches:
+        - type: ToEnvironmentFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: vpcId
+        - type: FromEnvironmentFieldPath
+          fromFieldPath: tags
+          toFieldPath: spec.forProvider.tags
+```
+
+The [Patch and Transform]({{<ref "./patch-and-transform">}}) documentation has
+more information on patching individual resources.

--- a/content/master/concepts/environment-configs.md
+++ b/content/master/concepts/environment-configs.md
@@ -7,7 +7,8 @@ description: "Environment Configurations or EnvironmentConfigs are an in-memory 
 ---
 
 A Crossplane EnvironmentConfig is a cluster scoped 
-[ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) used
+[ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)-like 
+resource used
 by Compositions. Compositions can use the environment to store information from
 individual resources or to apply [patches]({{<ref "patch-and-transform">}}).
 

--- a/content/master/concepts/environment-configs.md
+++ b/content/master/concepts/environment-configs.md
@@ -6,6 +6,11 @@ alphaVersion: "1.11"
 description: "Environment Configurations or EnvironmentConfigs are an in-memory datastore used in patching Compositions"
 ---
 
+<!--
+TODO: Add Policies
+-->
+
+
 A Crossplane EnvironmentConfig is a cluster scoped 
 [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)-like 
 resource used
@@ -311,10 +316,83 @@ The environments selected by
 into any other environments listed in the 
 {{<hover label="maxMatch" line="7">}}environmentConfigs{{</hover>}}.
 
-<!--
-TODO: Add Policies
--->
+#### Optional selector labels
+By default, Crossplane issues an error if a
+{{<hover label="byLabelOptional" line="16">}}valueFromFieldPath{{</hover>}}
+field doesn't exist in the composite resource.  
 
+Add
+{{<hover label="byLabelOptional" line="17">}}fromFieldPathPolicy{{</hover>}}
+as {{<hover label="byLabelOptional" line="17">}}Optional{{</hover>}} 
+to ignore a field if it doesn't exist.
+
+```yaml {label="byLabelOptional",copy-lines="all"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-composition
+spec:
+  environment:
+    environmentConfigs:
+      - type: Selector
+        selector:
+          matchLabels:
+            - key: my-first-label-key
+              type: Value
+              value: my-first-label-value
+            - key: my-second-label-key
+              type: FromCompositeFieldPath
+              valueFromFieldPath: spec.parameters.deploy
+              fromFieldPathPolicy: Optional
+  resources:
+  # Removed for brevity
+```
+
+
+Set a default value for an optional label by setting the default
+{{<hover label="byLabelOptionalDefault" line="15">}}value{{</hover>}} for the
+{{<hover label="byLabelOptionalDefault" line="14">}}key{{</hover>}} first, then
+define the
+{{<hover label="byLabelOptionalDefault" line="20">}}Optional{{</hover>}} label.
+
+For example, this Composition defines
+{{<hover label="byLabelOptionalDefault" line="16">}}value: my-default-value{{</hover>}}
+for the key {{<hover label="byLabelOptionalDefault" line="14">}}my-second-label-key{{</hover>}}.
+If the label
+{{<hover label="byLabelOptionalDefault" line="17">}}my-second-label-key{{</hover>}}
+exists, Crossplane uses the value from the label instead.
+
+```yaml {label="byLabelOptionalDefault",copy-lines="all"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: example-composition
+spec:
+  environment:
+    environmentConfigs:
+      - type: Selector
+        selector:
+          matchLabels:
+            - key: my-first-label-key
+              type: Value
+              value: my-label-value
+            - key: my-second-label-key
+              type: Value
+              value: my-default-value
+            - key: my-second-label-key
+              type: FromCompositeFieldPath
+              valueFromFieldPath: spec.parameters.deploy
+              fromFieldPathPolicy: Optional
+  resources:
+  # Removed for brevity
+```
+
+{{<hint "warning" >}}
+Crossplane applies values in order. The value of the last key defined always takes precedence.
+
+Defining the default value _after_ the label always overwrites the label
+value.
+{{< /hint >}}
 
 ## Patching with EnvironmentConfigs
 
@@ -330,9 +408,9 @@ Read about EnvironmentConfig patch types in the
 [Patch and Transform]({{<ref "./patch-and-transform">}}) documentation.
 {{< /hint >}}
 
-<!-- these two sections are duplicated in the compositions doc --> 
+<!-- these two sections are duplicated in the compositions doc with different header depths --> 
 
-##### Patch a composite resource
+### Patch a composite resource
 To patch the composite resource use
 {{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
@@ -362,7 +440,7 @@ spec:
 
 Individual resources can use any data written to the in-memory environment.
 
-##### Patch an individual resource
+### Patch an individual resource
 To patch an individual resource, inside the 
 {{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
 resource, use 
@@ -398,3 +476,5 @@ spec:
 
 The [Patch and Transform]({{<ref "./patch-and-transform">}}) documentation has
 more information on patching individual resources.
+
+<!-- End duplicated content -->

--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -81,8 +81,7 @@ object, including the `metadata`, `spec` or `status` fields.
 Field selectors can be a string matching a field name or an array index, in
 brackets. Field names may use a `.` character to select child elements.
 
-
-{{< expand "Example field selectors" >}}
+#### Example field selectors
 Here are some example selectors from a composite resource object.
 {{<table "table" >}}
 | Selector | Selected element | 
@@ -118,7 +117,6 @@ spec:
     name: my-example-claim-978mh-rv5nm
   # Removed for brevity
 ```
-{{< /expand >}}
 
 ## Reuse a patch
 
@@ -296,6 +294,17 @@ Labels:       crossplane.io/composite=my-example-claim-jp7rx
 ## Types of patches
 Crossplane supports multiple patch types, each using a different source for data
 and applying the patch to a different location. 
+
+{{<hint "important" >}}
+
+This section describes patches applied to individual resources inside a
+Composition.  
+
+For information about applying patches to an entire composite resource with a
+Composition's `environment.patches` read the 
+[Environment Configurations]({{<ref "environment-configs" >}}) documentation.
+
+{{< /hint >}}
 
 Summary of Crossplane patches
 {{< table "table table-hover" >}}
@@ -797,10 +806,6 @@ For example, use the desired
 apply it as the environment's
 {{<hover label="toEnvField" line="14">}}key1{{</hover>}}.
 
-{{< hint "important" >}}
-The environment's key must already exist. Patches can't create new environment
-keys. 
-{{< /hint >}}
 
 ```yaml {label="toEnvField",copy-lines="9-11"}
 apiVersion: apiextensions.crossplane.io/v1
@@ -1562,6 +1567,9 @@ converts the input based on one of the following conversion types:
 * `ToSha1` - Create a SHA-1 hash of the input string.
 * `ToSha256` - Create a SHA-256 hash of the input string.
 * `ToSha512` - Create a SHA-512 hash of the input string.
+* `ToSha512` - Create a SHA-512 hash of the input string.
+* `ToAdler32` - Create an Adler32 hash of the input string.
+* `ToSha512` - Create a SHA-512 hash of the input string. 
 * `ToAdler32` - Create an Adler32 hash of the input string.
 
 ```yaml {label="stringConvert"}

--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -1567,9 +1567,6 @@ converts the input based on one of the following conversion types:
 * `ToSha1` - Create a SHA-1 hash of the input string.
 * `ToSha256` - Create a SHA-256 hash of the input string.
 * `ToSha512` - Create a SHA-512 hash of the input string.
-* `ToSha512` - Create a SHA-512 hash of the input string.
-* `ToAdler32` - Create an Adler32 hash of the input string.
-* `ToSha512` - Create a SHA-512 hash of the input string. 
 * `ToAdler32` - Create an Adler32 hash of the input string.
 
 ```yaml {label="stringConvert"}

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -598,7 +598,7 @@ spec:
 <!-- these two sections are duplicated in the environment-configs doc --> 
 
 ##### Patch a composite resource
-To patch the composite resource use
+To patch between the composite resource and the in-memory environment use
 {{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -596,7 +596,41 @@ spec:
   # Removed for Brevity
 ```
 
-Inside the {{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
+<!-- these two sections are duplicated in the environment-configs doc --> 
+
+##### Patch a composite resource
+To patch the composite resource use the 
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of the 
+{{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
+
+Use the 
+{{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
+data from the EnvironmentConfig to the composite resource.  
+Use the 
+{{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
+data from the composite resource to the EnvironmentConfig.
+
+```yaml {label="xrpatch",copy-lines="none"}
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+# Removed for Brevity
+spec:
+  environment:
+  # Removed for Brevity
+      patches:
+      - type: ToCompositeFieldPath
+        fromFieldPath: tags
+        toFieldPath: metadata.labels[envTag]
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.name
+        toFieldPath: newEnvironmentKey
+```
+
+Individual resources can use any data written to the EnvironmentConfig.
+
+##### Patch an individual resource
+To patch an individual resource, inside the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
 data from the resource to the EnvironmentConfig.  

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -550,8 +550,8 @@ spec:
 
 #### Patch with EnvironmentConfigs 
 
-Crossplane uses EnvironmentConfigs as an in-memory data store. Compositions can
-read and write from this data store as part of the patch process. 
+Crossplane uses EnvironmentConfigs to create in-memory data stores. Compositions 
+can read and write from this data store as part of the patch process. 
 
 {{<hint "important" >}}
 EnvironmentConfigs are an alpha feature. Alpha features aren't enabled by
@@ -559,7 +559,7 @@ default.
 {{< /hint >}}
 
  EnvironmentConfigs can predefine data that Compositions can use
- or a Composite Resource can write data to the EnvironmentConfig for other
+ or a Composite Resource can write data to their in-memory environment for other
  resources to read. 
 
 <!-- vale off -->
@@ -569,10 +569,9 @@ Read the [EnvironmentConfigs]({{<ref "./environment-configs" >}}) page for
 more information on using EnvironmentConfigs.
 {{< /hint >}}
 
-To apply a patch using EnvironmentConfigs, first define which EnvironmentConfig
+To apply a patch using EnvironmentConfigs, first define which EnvironmentConfigs
 to use with 
-{{<hover label="envselect"
-line="6">}}environment.environmentConfigs{{</hover>}}. 
+{{<hover label="envselect" line="6">}}environment.environmentConfigs{{</hover>}}. 
 
 <!-- vale Google.Quotes = NO -->
 <!-- vale gitlab.SentenceLength = NO -->
@@ -580,7 +579,7 @@ line="6">}}environment.environmentConfigs{{</hover>}}.
 Use either a
 [reference]({{<ref "./managed-resources#matching-by-name-reference" >}})
 or a [selector]({{<ref "./managed-resources#matching-by-selector" >}}) to
-identify the EnvironmentConfig to use.
+identify the EnvironmentConfigs to use.
 <!-- vale Google.Quotes = YES -->
 
 ```yaml {label="envselect",copy-lines="none"}
@@ -599,16 +598,16 @@ spec:
 <!-- these two sections are duplicated in the environment-configs doc --> 
 
 ##### Patch a composite resource
-To patch the composite resource use the 
-{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of the 
+To patch the composite resource use
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 
 Use the 
 {{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
-data from the EnvironmentConfig to the composite resource.  
+data from the in-memory environment to the composite resource.  
 Use the 
 {{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
-data from the composite resource to the EnvironmentConfig.
+data from the composite resource to the in-memory environment.
 
 ```yaml {label="xrpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1
@@ -626,16 +625,16 @@ spec:
         toFieldPath: newEnvironmentKey
 ```
 
-Individual resources can use any data written to the EnvironmentConfig.
+Individual resources can use any data written to their in-memory environment.
 
 ##### Patch an individual resource
 To patch an individual resource, inside the 
-{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
-data from the resource to the EnvironmentConfig.  
+data from the resource to the in-memory environment.  
 Use {{<hover label="envpatch" line="20">}}FromEnvironmentFieldPath{{</hover>}}
-to copy data to the resource from the EnvironmentConfig.
+to copy data to the resource from the in-memory environment.
 
 ```yaml {label="envpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1

--- a/content/v1.13/concepts/environment-configs.md
+++ b/content/v1.13/concepts/environment-configs.md
@@ -14,16 +14,17 @@ data store.
 
 A Composition defines access to one or more EnvironmentConfigs.  
 
-When Crossplane creates a composite resource, Crossplane creates a unique copy
-of the defined EnvironmentConfigs for that composite resource.  
+When Crossplane creates a composite resource, Crossplane merges all referenced
+EnvironmentConfigs and creates a unique in-memory environment
+for that composite resource.  
 
 The composite resource can read and write data to their unique 
-EnvironmentConfig.
+in-memory environment.
 
 {{<hint "important" >}}
-EnvironmentConfigs are unique to each composite resource.  
-A composite resource can't read data in an EnvironmentConfig written by another
-composite resource.
+The in-memory environment is unique to each composite resource.  
+A composite resource can't read data in another composite resource's
+environment. 
 {{< /hint >}}
 
 ## Enable EnvironmentConfigs
@@ -330,19 +331,17 @@ Read about EnvironmentConfig patch types in the
 
 <!-- these two sections are duplicated in the compositions doc --> 
 
-### Patching a composite resource
-
-To patch a composite resource use the 
-{{< hover label="xrpatch" line="7">}}patches{{</hover>}} object inside of a
-Composition's 
+##### Patch a composite resource
+To patch the composite resource use
+{{< hover label="xrpatch" line="7">}}patches{{</hover>}} inside of the 
 {{< hover label="xrpatch" line="5">}}environment{{</hover>}}.
 
 Use the 
 {{< hover label="xrpatch" line="5">}}ToCompositeFieldPath{{</hover>}} to copy
-data from the EnvironmentConfig to the composite resource.  
+data from the in-memory environment to the composite resource.  
 Use the 
 {{< hover label="xrpatch" line="5">}}FromCompositeFieldPath{{</hover>}} to copy
-data from the composite resource to the EnvironmentConfig.
+data from the composite resource to the in-memory environment.
 
 ```yaml {label="xrpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1
@@ -360,17 +359,16 @@ spec:
         toFieldPath: newEnvironmentKey
 ```
 
-Individual resources can use any data written to the EnvironmentConfig.
+Individual resources can use any data written to the in-memory environment.
 
 ##### Patch an individual resource
-
 To patch an individual resource, inside the 
-{{<hover label="envpatch" line="16">}}patches{{</hover>}} object of the 
+{{<hover label="envpatch" line="16">}}patches{{</hover>}} of the 
 resource, use 
 {{<hover label="envpatch" line="17">}}ToEnvironmentFieldPath{{</hover>}} to copy
-data from the resource to the EnvironmentConfig.  
+data from the resource to the in-memory environment.  
 Use {{<hover label="envpatch" line="20">}}FromEnvironmentFieldPath{{</hover>}}
-to copy data to the resource from the EnvironmentConfig.
+to copy data to the resource from the in-memory environment.
 
 ```yaml {label="envpatch",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1

--- a/content/v1.13/concepts/environment-configs.md
+++ b/content/v1.13/concepts/environment-configs.md
@@ -6,17 +6,18 @@ alphaVersion: "1.11"
 description: "Environment Configurations or EnvironmentConfigs are an in-memory datastore used in patching Compositions"
 ---
 
-A Crossplane EnvironmentConfig is an in-memory data store. Composition 
-patches can read from and write to an environment.
+A Crossplane EnvironmentConfig is a cluster scoped 
+[ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)-like 
+resource used
+by Compositions. Compositions can use the environment to store information from
+individual resources or to apply [patches]({{<ref "patch-and-transform">}}).
 
 Crossplane supports multiple EnvironmentConfigs, each acting as a unique
 data store. 
 
-A Composition defines access to one or more EnvironmentConfigs.  
-
-When Crossplane creates a composite resource, Crossplane merges all referenced
-EnvironmentConfigs and creates a unique in-memory environment
-for that composite resource.  
+When Crossplane creates a composite resource, Crossplane merges all the 
+EnvironmentConfigs referenced in the associated Composition and creates a unique
+in-memory environment for that composite resource.
 
 The composite resource can read and write data to their unique 
 in-memory environment.
@@ -94,7 +95,7 @@ data:
 ## Select an EnvironmentConfig
 <!-- vale Google.Headings = YES -->
 
-Select the EnvironmentConfig to use
+Select the EnvironmentConfigs to use
 inside a Composition's 
 {{<hover label="comp" line="6">}}environment{{</hover>}} field.
 
@@ -317,8 +318,8 @@ TODO: Add Policies
 
 ## Patching with EnvironmentConfigs
 
-When Crossplane creates a composite resource, Crossplane creates a unique copy  
-of the EnvironmentConfig for the composite resource. 
+When Crossplane creates or updates a composite resource, Crossplane 
+merges all the specified EnvironmentConfigs into an in-memory environment.
 
 The composite resource can read or write data between the EnvironmentConfig and
 composite resource or between the EnvironmentConfig and individual resources

--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -81,8 +81,7 @@ object, including the `metadata`, `spec` or `status` fields.
 Field selectors can be a string matching a field name or an array index, in
 brackets. Field names may use a `.` character to select child elements.
 
-
-{{< expand "Example field selectors" >}}
+#### Example field selectors
 Here are some example selectors from a composite resource object.
 {{<table "table" >}}
 | Selector | Selected element | 
@@ -118,7 +117,6 @@ spec:
     name: my-example-claim-978mh-rv5nm
   # Removed for brevity
 ```
-{{< /expand >}}
 
 ## Reuse a patch
 
@@ -296,6 +294,17 @@ Labels:       crossplane.io/composite=my-example-claim-jp7rx
 ## Types of patches
 Crossplane supports multiple patch types, each using a different source for data
 and applying the patch to a different location. 
+
+{{<hint "important" >}}
+
+This section describes patches applied to individual resources inside a
+Composition.  
+
+For information about applying patches to an entire composite resource with a
+Composition's `environment.patches` read the 
+[Environment Configurations]({{<ref "environment-configs" >}}) documentation.
+
+{{< /hint >}}
 
 Summary of Crossplane patches
 {{< table "table table-hover" >}}
@@ -797,10 +806,6 @@ For example, use the desired
 apply it as the environment's
 {{<hover label="toEnvField" line="14">}}key1{{</hover>}}.
 
-{{< hint "important" >}}
-The environment's key must already exist. Patches can't create new environment
-keys. 
-{{< /hint >}}
 
 ```yaml {label="toEnvField",copy-lines="9-11"}
 apiVersion: apiextensions.crossplane.io/v1


### PR DESCRIPTION
Currently there are no docs on patching to an XR using an environment config using `spec.environment.patches` of a Composition. 

This adds details on this and removes an incorrect statement about the EC key needing to exist before writing to it. 