### PR TITLE
Composite Resources: fix snippet on `compositionRevisionRef`

### DIFF
--- a/content/master/concepts/composite-resources.md
+++ b/content/master/concepts/composite-resources.md
@@ -234,7 +234,9 @@ kind: xMyDatabase
 metadata:
   name: my-composite-resource
 spec:
-  compositionRevisionRef: my-composition-b5aa1eb
+  compositionUpdatePolicy: Manual
+  compositionRevisionRef:
+    name: my-composition-b5aa1eb
   # Removed for brevity
 ```
 

--- a/content/v1.13/concepts/composite-resources.md
+++ b/content/v1.13/concepts/composite-resources.md
@@ -235,7 +235,9 @@ kind: xMyDatabase
 metadata:
   name: my-composite-resource
 spec:
-  compositionRevisionRef: my-composition-b5aa1eb
+  compositionUpdatePolicy: Manual
+  compositionRevisionRef:
+    name: my-composition-b5aa1eb
   # Removed for brevity
 ```
 


### PR DESCRIPTION
Current snippet does not match actual behavior, and also what is documented in the KB: https://github.com/crossplane/docs/blob/daaa7ec019bf91dc75c474d45e67900a9a990e2d/content/knowledge-base/guides/composition-revisions-example.md#manual-update-policy

1. `compositionRevisionRef` is of type `Object`, not `String`.
2. `compositionUpdatePolicy` must be set to `Manual`, otherwise `compositionRevisionRef` is ignored (from my observations)