### PR TITLE
Fixed formatting of annotation table in managed-resources.md.

### DIFF
--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -594,8 +594,7 @@ resources.
 | Annotation | Definition | 
 | --- | --- | 
 | `crossplane.io/external-name` | The name of the managed resource inside the Provider. |
-| `crossplane.io/external-create-pending` | The timestamp of when Crossplane
-began creating a new managed resource. | 
+| `crossplane.io/external-create-pending` | The timestamp of when Crossplane began creating the managed resource. | 
 | `crossplane.io/external-create-succeeded` | The timestamp of when the Provider successfully created the managed resource. | 
 | `crossplane.io/external-create-failed` | The timestamp of when the Provider failed to create the managed resource. | 
 | `crossplane.io/paused` | Indicates Crossplane isn't reconciling this resource. Read the [Pause Annotation](#paused) for more details. |

--- a/content/v1.11/concepts/managed-resources.md
+++ b/content/v1.11/concepts/managed-resources.md
@@ -445,8 +445,7 @@ resources.
 | Annotation | Definition | 
 | --- | --- | 
 | `crossplane.io/external-name` | The name of the managed resource inside the Provider. |
-| `crossplane.io/external-create-pending` | The timestamp of when Crossplane
-began creating a new managed resource. | 
+| `crossplane.io/external-create-pending` | The timestamp of when Crossplane began creating the managed resource. | 
 | `crossplane.io/external-create-succeeded` | The timestamp of when the Provider successfully created the managed resource. | 
 | `crossplane.io/external-create-failed` | The timestamp of when the Provider failed to create the managed resource. | 
 | `crossplane.io/paused` | Indicates Crossplane isn't reconciling this resource. Read the [Pause Annotation](#paused) for more details. |

--- a/content/v1.12/concepts/managed-resources.md
+++ b/content/v1.12/concepts/managed-resources.md
@@ -445,8 +445,7 @@ resources.
 | Annotation | Definition | 
 | --- | --- | 
 | `crossplane.io/external-name` | The name of the managed resource inside the Provider. |
-| `crossplane.io/external-create-pending` | The timestamp of when Crossplane
-began creating a new managed resource. | 
+| `crossplane.io/external-create-pending` | The timestamp of when Crossplane began creating the managed resource. | 
 | `crossplane.io/external-create-succeeded` | The timestamp of when the Provider successfully created the managed resource. | 
 | `crossplane.io/external-create-failed` | The timestamp of when the Provider failed to create the managed resource. | 
 | `crossplane.io/paused` | Indicates Crossplane isn't reconciling this resource. Read the [Pause Annotation](#paused) for more details. |

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -595,8 +595,7 @@ resources.
 | Annotation | Definition | 
 | --- | --- | 
 | `crossplane.io/external-name` | The name of the managed resource inside the Provider. |
-| `crossplane.io/external-create-pending` | The timestamp of when Crossplane
-began creating a new managed resource. | 
+| `crossplane.io/external-create-pending` | The timestamp of when Crossplane began creating the managed resource. | 
 | `crossplane.io/external-create-succeeded` | The timestamp of when the Provider successfully created the managed resource. | 
 | `crossplane.io/external-create-failed` | The timestamp of when the Provider failed to create the managed resource. | 
 | `crossplane.io/paused` | Indicates Crossplane isn't reconciling this resource. Read the [Pause Annotation](#paused) for more details. |


### PR DESCRIPTION
The text "began creating a new managed resource." was in a table row by itself. Also, changed article from "a" to "the" for consistency with other rows, and removed the word "new" as it is redundant.