### PR TITLE
Fix typo of Manager in install.md files

### DIFF
--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -99,7 +99,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manger design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options

--- a/content/v1.11/software/install.md
+++ b/content/v1.11/software/install.md
@@ -99,7 +99,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manger design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options

--- a/content/v1.12/software/install.md
+++ b/content/v1.12/software/install.md
@@ -99,7 +99,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manger design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options

--- a/content/v1.13/software/install.md
+++ b/content/v1.13/software/install.md
@@ -99,7 +99,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manger design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options


### PR DESCRIPTION
Hey, This must be a typo because there is no any reference to `manger`.