### PR TITLE
docs: renaming kubectl plugin to crossplane CLI

### DIFF
--- a/content/knowledge-base/guides/troubleshoot.md
+++ b/content/knowledge-base/guides/troubleshoot.md
@@ -4,11 +4,11 @@ weight: 306
 ---
 ## Requested Resource Not Found
 
-If you use the kubectl Crossplane plugin to install a `Provider` or
-`Configuration` (e.g. `kubectl crossplane install provider
+If you use the Crossplane CLI to install a `Provider` or
+`Configuration` (e.g. `crossplane install provider
 xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
 could not find the requested resource` error, more often than not, that is an
-indicator that the kubectl Crossplane you're using is outdated. In other words
+indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
 plugin is not aware of this change.
 

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -136,7 +136,7 @@ To build a Provider package, navigate to the package root directory and execute
 the following command:
 
 ```
-kubectl crossplane build provider
+crossplane build provider
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -187,7 +187,7 @@ To build a Configuration package, navigate to the package root directory and
 execute the following command:
 
 ```
-kubectl crossplane build configuration
+crossplane build configuration
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -201,13 +201,13 @@ registry is not specified they will be pushed to Docker Hub.
 To push a Provider package, execute the following command:
 
 ```
-kubectl crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To push a Configuration package, execute the following command:
 
 ```
-kubectl crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 > Note: Both of the above commands assume a single `.xpkg` file exists in the
@@ -222,13 +222,13 @@ Packages can be installed into a Crossplane cluster using the Crossplane CLI.
 To install a Provider package, execute the following command:
 
 ```
-kubectl crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To install a Configuration package, execute the following command:
 
 ```
-kubectl crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 Packages can also be installed manually by creating a `Provider` or

--- a/content/v1.11/concepts/packages.md
+++ b/content/v1.11/concepts/packages.md
@@ -132,7 +132,7 @@ To build a Provider package, navigate to the package root directory and execute
 the following command:
 
 ```
-kubectl crossplane build provider
+crossplane build provider
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -183,7 +183,7 @@ To build a Configuration package, navigate to the package root directory and
 execute the following command:
 
 ```
-kubectl crossplane build configuration
+crossplane build configuration
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -197,13 +197,13 @@ registry is not specified they will be pushed to Docker Hub.
 To push a Provider package, execute the following command:
 
 ```
-kubectl crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To push a Configuration package, execute the following command:
 
 ```
-kubectl crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 > Note: Both of the above commands assume a single `.xpkg` file exists in the
@@ -218,13 +218,13 @@ Packages can be installed into a Crossplane cluster using the Crossplane CLI.
 To install a Provider package, execute the following command:
 
 ```
-kubectl crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To install a Configuration package, execute the following command:
 
 ```
-kubectl crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 Packages can also be installed manually by creating a `Provider` or

--- a/content/v1.11/getting-started/provider-aws-part-3.md
+++ b/content/v1.11/getting-started/provider-aws-part-3.md
@@ -599,14 +599,14 @@ extension.
 wget "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 chmod +x install.sh
 ./install.sh
-sudo mv kubectl-crossplane /usr/bin
+sudo mv crossplane /usr/local/bin
 ```
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -619,11 +619,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` CLI to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-aws-quickstart/ --name="crossplane-aws-quickstart"
+crossplane build configuration -f crossplane-aws-quickstart/ --name="crossplane-aws-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-aws-quickstart` directory.

--- a/content/v1.11/getting-started/provider-azure-part-3.md
+++ b/content/v1.11/getting-started/provider-azure-part-3.md
@@ -768,16 +768,17 @@ extension.
 wget "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 chmod +x install.sh
 ./install.sh
+sudo mv crossplane /usr/local/bin
 ```
 
-Follow the directions and move the `kubectl-crossplane` binary to the correct
+Follow the directions and move the `crossplane` binary to the correct
 directory. 
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell {copy-lines="1"}
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -790,11 +791,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` CLI to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-azure-quickstart/ --name="crossplane-azure-quickstart"
+crossplane build configuration -f crossplane-azure-quickstart/ --name="crossplane-azure-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-azure-quickstart` directory.

--- a/content/v1.11/getting-started/provider-gcp-part-3.md
+++ b/content/v1.11/getting-started/provider-gcp-part-3.md
@@ -619,14 +619,14 @@ extension.
 wget "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 chmod +x install.sh
 ./install.sh
-sudo mv kubectl-crossplane /usr/bin
+sudo mv crossplane /usr/local/bin
 ```
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -639,11 +639,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` CLI to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-gcp-quickstart/ --name="crossplane-gcp-quickstart"
+crossplane build configuration -f crossplane-gcp-quickstart/ --name="crossplane-gcp-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-gcp-quickstart` directory.

--- a/content/v1.12/concepts/packages.md
+++ b/content/v1.12/concepts/packages.md
@@ -132,7 +132,7 @@ To build a Provider package, navigate to the package root directory and execute
 the following command:
 
 ```
-kubectl crossplane build provider
+crossplane build provider
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -183,7 +183,7 @@ To build a Configuration package, navigate to the package root directory and
 execute the following command:
 
 ```
-kubectl crossplane build configuration
+crossplane build configuration
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -197,13 +197,13 @@ registry is not specified they will be pushed to Docker Hub.
 To push a Provider package, execute the following command:
 
 ```
-kubectl crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To push a Configuration package, execute the following command:
 
 ```
-kubectl crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 > Note: Both of the above commands assume a single `.xpkg` file exists in the
@@ -218,13 +218,13 @@ Packages can be installed into a Crossplane cluster using the Crossplane CLI.
 To install a Provider package, execute the following command:
 
 ```
-kubectl crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To install a Configuration package, execute the following command:
 
 ```
-kubectl crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 Packages can also be installed manually by creating a `Provider` or

--- a/content/v1.12/getting-started/provider-aws-part-3.md
+++ b/content/v1.12/getting-started/provider-aws-part-3.md
@@ -612,14 +612,14 @@ extension.
 ```shell
 curl "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 ./install.sh
-sudo mv kubectl-crossplane /usr/bin
+sudo mv crossplane /usr/local/bin
 ```
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -632,11 +632,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` CLI to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-aws-quickstart/ --name="crossplane-aws-quickstart"
+crossplane build configuration -f crossplane-aws-quickstart/ --name="crossplane-aws-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-aws-quickstart` directory.

--- a/content/v1.12/getting-started/provider-azure-part-3.md
+++ b/content/v1.12/getting-started/provider-azure-part-3.md
@@ -768,16 +768,17 @@ extension.
 wget "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 chmod +x install.sh
 ./install.sh
+sudo mv crossplane /usr/local/bin
 ```
 
-Follow the directions and move the `kubectl-crossplane` binary to the correct
+Follow the directions and move the `crossplane` binary to the correct
 directory. 
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell {copy-lines="1"}
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -790,11 +791,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` CLI to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-azure-quickstart/ --name="crossplane-azure-quickstart"
+crossplane build configuration -f crossplane-azure-quickstart/ --name="crossplane-azure-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-azure-quickstart` directory.

--- a/content/v1.12/getting-started/provider-gcp-part-3.md
+++ b/content/v1.12/getting-started/provider-gcp-part-3.md
@@ -619,14 +619,14 @@ extension.
 wget "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh"
 chmod +x install.sh
 ./install.sh
-sudo mv kubectl-crossplane /usr/bin
+sudo mv crossplane /usr/local/bin
 ```
 
-Verify the Crossplane command-line installed with `kubectl crossplane --help`
+Verify the Crossplane command-line installed with `crossplane --help`
 
 ```shell
-kubectl crossplane --help
-Usage: kubectl crossplane <command>
+crossplane --help
+Usage: crossplane <command>
 
 A command line tool for interacting with Crossplane.
 
@@ -639,11 +639,11 @@ Flags:
 
 ### Build a configuration package
 
-Use the `kubectl crossplane` command to create an `.xpkg` file containing the
+Use the `crossplane` command to create an `.xpkg` file containing the
 custom APIs and Crossplane configuration.
 
 ```shell
-kubectl crossplane build configuration -f crossplane-gcp-quickstart/ --name="crossplane-gcp-quickstart"
+crossplane build configuration -f crossplane-gcp-quickstart/ --name="crossplane-gcp-quickstart"
 ```
 
 Now an `.xpkg` OCI image is inside the `crossplane-gcp-quickstart` directory.

--- a/content/v1.13/concepts/packages.md
+++ b/content/v1.13/concepts/packages.md
@@ -136,7 +136,7 @@ To build a Provider package, navigate to the package root directory and execute
 the following command:
 
 ```
-kubectl crossplane build provider
+crossplane build provider
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -187,7 +187,7 @@ To build a Configuration package, navigate to the package root directory and
 execute the following command:
 
 ```
-kubectl crossplane build configuration
+crossplane build configuration
 ```
 
 If the Provider package is valid, you will see a file with the `.xpkg`
@@ -201,13 +201,13 @@ registry is not specified they will be pushed to Docker Hub.
 To push a Provider package, execute the following command:
 
 ```
-kubectl crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane push provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To push a Configuration package, execute the following command:
 
 ```
-kubectl crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane push configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 > Note: Both of the above commands assume a single `.xpkg` file exists in the
@@ -222,13 +222,13 @@ Packages can be installed into a Crossplane cluster using the Crossplane CLI.
 To install a Provider package, execute the following command:
 
 ```
-kubectl crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+crossplane install provider xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
 ```
 
 To install a Configuration package, execute the following command:
 
 ```
-kubectl crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
+crossplane install configuration xpkg.upbound.io/crossplane-contrib/my-org-infra:v0.1.0
 ```
 
 Packages can also be installed manually by creating a `Provider` or


### PR DESCRIPTION
Related to https://github.com/crossplane/crossplane/pull/4719 and https://github.com/crossplane/crossplane/issues/4697.

I hope I updated all places.