### PR TITLE
GMP promote to beta

### DIFF
--- a/content/knowledge-base/guides/import-existing-resources.md
+++ b/content/knowledge-base/guides/import-existing-resources.md
@@ -5,7 +5,7 @@ weight: 200
 
 If you have resources that are already provisioned in a Provider,
 you can import them as managed resources and let Crossplane manage them.
-A managed resource's [`managementPolicy`]({{<ref "/v1.12/concepts/managed-resources#managementpolicy">}}) 
+A managed resource's [`managementPolicies`]({{<ref "/v1.13/concepts/managed-resources#managementpolicies">}}) 
 field enables importing external resources into Crossplane.
 
 Crossplane can import resources either [manually]({{<ref "#import-resources-manually">}})
@@ -90,11 +90,11 @@ Crossplane imports observe only resources but never changes or deletes the
 resources.
 
 {{<hint "important" >}}
-The managed resource `managementPolicies` option is an alpha feature. 
+The managed resource `managementPolicies` option is a beta feature. 
 
-Enable `managementPolicies` in a provider with `--enable-management-policies` 
-in a 
-[ControllerConfig]({{<ref "/v1.12/concepts/providers#controller-configuration" >}}).
+The Provider determines support for management policies.  
+Refer to the Provider's documentation to see if the Provider supports
+management policies.
 {{< /hint >}}
 
 <!-- vale off -->

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -250,25 +250,10 @@ the `managementPolicies` list.
 <!-- vale on -->
 
 {{<hint "important" >}}
-The managed resource `initProvider` option is an alpha feature related to
+The managed resource `initProvider` option is a beta feature related to
 [managementPolicies]({{<ref "./managed-resources#managementpolicies" >}}).
 
 {{< /hint >}}
-
-Enable the `initProvider` in a provider with `--enable-management-policies`
-in a
-[ControllerConfig]({{<ref "./providers#controller-configuration" >}}) as an
-argument in the `spec`.
-
-```yaml {copy-lines="all"}
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
-metadata:
-  name: example-config
-spec:
-  args: 
-    - --enable-management-policies
-```
 
 The
 {{<hover label="initProvider" line="7">}}initProvider{{</hover>}} defines
@@ -326,9 +311,9 @@ spec:
 {{<hint "important" >}}
 The managed resource `managementPolicies` option is an alpha feature.
 
-Enable `managementPolicies` in a provider with `--enable-management-policies`
-in a
-[ControllerConfig]({{<ref "./providers#controller-configuration" >}}).
+The Provider determines support for management policies.  
+Refer to the Provider's documentation to see if the Provider supports
+management policies.
 {{< /hint >}}
 
 Crossplane


### PR DESCRIPTION
GMP is being promoted to BETA, so changing the alpha -> beta in the docs.

Changed the "enable in ControllerConfig" to "check if your Provider supports it" because it depends on the provider, and the providers that support it should have it on by default.