### PR TITLE
add support for matching pages when the page title changes

### DIFF
--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -143,3 +143,18 @@ more.
 To hide a page from the left-hand navigation use `tocHidden: true` in the front
 matter of the page. The docs website skips pages with `tocHidden:true` when
 building the menu.
+
+### Changing page titles
+
+The version dropdown list that links the same page in different versions 
+together looks for pages with a matching title.
+
+If a page title changes use the front matter value `altTitle:` and a value of 
+the old page title.
+
+For example, if an older title was "Original Title" the new page would use:
+
+```yaml
+title: New Title
+altTitle: Original Title
+```

--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -149,12 +149,12 @@ building the menu.
 The version dropdown list that links the same page in different versions 
 together looks for pages with a matching title.
 
-If a page title changes use the front matter value `altTitle:` and a value of 
+If a page title changes use the front matter value `matchTitle:` and a value of 
 the old page title.
 
 For example, if an older title was "Original Title" the new page would use:
 
 ```yaml
 title: New Title
-altTitle: Original Title
+matchTitle: Original Title
 ```

--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -12,8 +12,8 @@ Clone the documentation and use [Hugo](https://gohugo.io/) to
 build the Crossplane documentation site locally for development and testing. 
 
 ### Clone the docs repository
-Clone the [Crossplane docs
-repository](https://github.com/crossplane/docs) with
+Clone the 
+[Crossplane docs repository](https://github.com/crossplane/docs) with
 
 ```command
 git clone https://github.com/crossplane/docs.git

--- a/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -39,8 +39,8 @@
         {{/*  Iterate over the ordered list of available versions. */}}
         {{ range $sorted_list }}
             {{ $matchingTitle := $.Title }}
-            {{ if $.Params.altTitle }}
-                {{ $matchingTitle = $.Params.altTitle }}
+            {{ if $.Params.matchTitle }}
+                {{ $matchingTitle = $.Params.matchTitle }}
             {{ end }}
             {{/*  For a version, see if there is a page with an identical title to the page we're on. If not use the page at /content/v<version>  */}}
             {{ $versionPage :=  index (where (where $.Site.Pages "Title" $matchingTitle) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}

--- a/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -38,8 +38,12 @@
         {{ $master_url := replaceRE "v[0-9].[0-9]" "master" .Permalink }}
         {{/*  Iterate over the ordered list of available versions. */}}
         {{ range $sorted_list }}
+            {{ $matchingTitle := $.Title }}
+            {{ if $.Params.altTitle }}
+                {{ $matchingTitle = $.Params.altTitle }}
+            {{ end }}
             {{/*  For a version, see if there is a page with an identical title to the page we're on. If not use the page at /content/v<version>  */}}
-            {{ $versionPage :=  index (where (where $.Site.Pages "Title" $.Title) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}
+            {{ $versionPage :=  index (where (where $.Site.Pages "Title" $matchingTitle) ".Page.Params.version" .) 0 | default ($.Site.GetPage (printf "v%s" .)) }}
             {{/*  If the version is master get the master page since "vmaster" doesn't exist  */}}
             {{ if not $versionPage }}
                 {{ $versionPage = $.Site.GetPage "master" }}


### PR DESCRIPTION
The dropdown menu with the version numbers builds links to the same page in another version if the Page title is the same. 

Because Hugo doesn't (directly) care about filenames and prefers focusing on file/page metadata it's much more difficult to match on file names than titles. 

This adds support for an optional frontMatter `altTitle` to allow authors to reference the older/original title. 

There are more flexible ways to do this but not without major build performance impact required to iterate over all pages multiple times. 