### PR TITLE
Fix example configuration that uses an unsupported managementPolicy

### DIFF
--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -326,14 +326,14 @@ to a managed resource to determine what permissions
 Crossplane has over the resource.
 
 For example, give Crossplane permission to create and delete an external resource,
-but not make any changes set the policies to
-{{<hover label="managementPol1" line="4">}}["Create", "Delete"]{{</hover>}}.
+but not make any changes, set the policies to
+{{<hover label="managementPol1" line="4">}}["Create", "Delete", "Observe"]{{</hover>}}.
 
 ```yaml {label="managementPol1"}
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Subnet
 spec:
-  managementPolicies: ["Create", "Delete"]
+  managementPolicies: ["Create", "Delete", "Observe"]
   forProvider:
     # Removed for brevity
 ```

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -342,14 +342,14 @@ to a managed resource to determine what permissions
 Crossplane has over the resource.
 
 For example, give Crossplane permission to create and delete an external resource,
-but not make any changes set the policies to
-{{<hover label="managementPol1" line="4">}}["Create", "Delete"]{{</hover>}}.
+but not make any changes, set the policies to
+{{<hover label="managementPol1" line="4">}}["Create", "Delete", "Observe"]{{</hover>}}.
 
 ```yaml {label="managementPol1"}
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Subnet
 spec:
-  managementPolicies: ["Create", "Delete"]
+  managementPolicies: ["Create", "Delete", "Observe"]
   forProvider:
     # Removed for brevity
 ```


### PR DESCRIPTION
I added "Observe" management policy to "Create" and "Delete" policies, because it is required in all configurations except when pausing a resource.

v1.11 and v1.12 don't have this updated example, so they didn't change.