### PR TITLE
Release Note Support

### DIFF
--- a/content/v1.13/release-notes/1.13.0.md
+++ b/content/v1.13/release-notes/1.13.0.md
@@ -1,0 +1,27 @@
+---
+title: v1.13.0
+released: July 27, 2023
+---
+
+The v1.13.0 release is a regular quarterly Crossplane release that focuses on security, quality, and investing in key feature areas to push the project forward in its maturity and reliability. Some highlights of this release include Ignore Changes, E2E Testing Framework, Security Audit performed by Ada Logic and facilitated by OSTIF, and sponsored by CNCF. See the report for more details.
+
+More details about this release can be read in the Crossplane v1.13 blog post.
+
+<!--more--> 
+
+### WARNINGS
+Warning
+Upgrades from older versions are broken. Use v1.13.2 instead.
+
+CompositionRevision v1alpha1 was dropped in this release, so upgrades from older versions, or on clusters that had older versions installed at some point in the past, could fail with errors similar to: status.storedVersions[1]: Invalid value: "v1": must appear in spec.versions.
+
+### New Features
+Ignore Changes alpha feature introduced by @lsviben. With supporting providers, you can now ignore certain changes that external systems may be making to the resources managed by Crossplane. This is an evolution of the Observe Only Resources API as it continues to mature towards Beta.
+
+### Notable changes
+Introduced a new E2E testing framework and an initial set of test cases to ensure we don’t introduce regressions with future changes.
+Security Audit is finished and issues found during this process are fixed.
+Introduced resolve and resolution policies to Compositions’ environment (spec.environment.policy), allowing to ignore missing EnvironmentConfigs or use new ones added after the initial resolving of the environment selectors.
+
+### Breaking changes
+BREAKING CHANGE: EnvironmentConfig label selection default behaviour is now to error out in case of multiple configs matching, old behaviour can be achieved by setting the selector mode to Multiple and maxMatch to 1.

--- a/content/v1.13/release-notes/1.13.1.md
+++ b/content/v1.13/release-notes/1.13.1.md
@@ -1,0 +1,14 @@
+---
+title: v1.13.1
+released: July 31, 2023
+---
+
+Just a quick follow-up patch release, mainly to address an issue for users upgrading from older versions.
+
+<!-- more --> 
+
+## Notable changes
+Automatically migrate old CompositionRevisions that are stored as v1alpha1 in etcd.
+Set up the logger correctly even if not in debug mode to prevent misleading errors from being printed on startup.
+Ensure proper propagation of compositionRevisionRef from Claim to Composite resource with compositionUpdatePolicy set to Manual.
+

--- a/content/v1.13/release-notes/1.13.2.md
+++ b/content/v1.13/release-notes/1.13.2.md
@@ -1,0 +1,11 @@
+---
+title: v1.13.2
+released: August 9, 2023
+---
+
+v1.13.2 is another quick follow-up release addressing a few minor issues.
+
+## Notable Changes
+Hashing transforms of strings were previously computed including quotes, we now properly handle strings.
+Automatically migrate old Locks that are stored as v1alpha1 in etcd, if needed.
+XRDs now properly copy top level descriptions and x-kubernetes-validation to the generated CRDs.

--- a/content/v1.13/release-notes/_index.md
+++ b/content/v1.13/release-notes/_index.md
@@ -1,0 +1,9 @@
+---
+title: Release Notes
+weight: 20
+description: "Crossplane release notes"
+product: "Release Notes"
+cascade: 
+    releaseNotes: true
+---
+

--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -137,13 +137,13 @@ h3, h4, h5, h6 {
   padding-left: 16px;
   padding-right: 16px;
   padding-top: 8px;
-  padding-bottom: 8px;   
+  padding-bottom: 8px;
 }
 .table.table-sm td {
   padding-left: 16px;
   padding-right: 16px;
   padding-top: 8px;
-  padding-bottom: 8px;  
+  padding-bottom: 8px;
 }
 
 
@@ -162,4 +162,9 @@ h3, h4, h5, h6 {
 .ga-tag{
   color: var(--toc-font-color);
 
+}
+
+.rn-summary-meta,.rn-page-meta{
+  margin-top: -1.5rem !important;
+  margin-bottom: 1.5rem !important;
 }

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -71,7 +71,32 @@
               {{ partialCached "old-version-alert" . .Section }}
             {{ end }}
           {{ end }}
-          {{ .Content }}
+
+          {{ if eq $.Params.Product "Release Notes" }}
+            {{ range .Pages.Reverse }}
+              {{ if not .Page.Params.released }}
+                {{ errorf (printf "Release Notes Page %q requires 'released' Front Matter." .Page.File.Path ) }}
+              {{ end }}
+              {{ if not .Page.Params.Title }}
+                {{ errorf (printf "Release Notes Page %q requires 'released' Front Matter." .Page.File.Path ) }}
+              {{ end }}
+              <h2>{{ .Title}}</h2>
+              <div class="rn-summary-meta">
+                Released: {{ .Page.Params.released }} -
+                <a href="https://github.com/crossplane/crossplane/releases/tag/{{.Title}}">GitHub</a>
+              </div>
+              {{ .Summary | markdownify }}
+              <a href="{{.Permalink}}">Full {{.Title}} release notes</a>
+            {{ end }}
+          {{ else }}
+            {{ if $.Params.releaseNotes }}
+            <div class="rn-page-meta">
+              Released: {{ .Page.Params.released }} -
+              <a href="https://github.com/crossplane/crossplane/releases/tag/{{.Title}}">GitHub</a>
+            </div>
+            {{ end }}
+            {{ .Content }}
+          {{ end }}
         </div>
     </main>
   </div>


### PR DESCRIPTION
This is a proposal for how we can publish release notes in the Crossplane docs.

Each version would have a 

* [Release note summary page](https://deploy-preview-571--crossplane.netlify.app/v1.13/release-notes/) containing a summary of each release of that version.
* [Individual release pages](https://deploy-preview-571--crossplane.netlify.app/v1.13/release-notes/1.13.0/) containing the full release note information for a specific version. 

The summary page is auto-generated from the markdown files in the release-notes folder. 

Signed-off-by: Pete Lumbis <pete@upbound.io>