### PR TITLE
fix links for moved platform ref files

### DIFF
--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -244,7 +244,7 @@ This abbreviated example is from the Upbound
 [AWS Reference Platform](https://github.com/upbound/platform-ref-aws).
 
 View the complete Compositions in the reference platform's 
-[package directory](https://github.com/upbound/platform-ref-aws/blob/main/package/cluster/composition.yaml).
+[package directory](https://github.com/upbound/platform-ref-aws/blob/main/apis/cluster/composition.yaml).
 {{</hint >}}
 
 #### Cross-resource references

--- a/content/v1.13/concepts/compositions.md
+++ b/content/v1.13/concepts/compositions.md
@@ -244,7 +244,7 @@ This abbreviated example is from the Upbound
 [AWS Reference Platform](https://github.com/upbound/platform-ref-aws).
 
 View the complete Compositions in the reference platform's 
-[package directory](https://github.com/upbound/platform-ref-aws/blob/main/package/cluster/composition.yaml).
+[package directory](https://github.com/upbound/platform-ref-aws/blob/main/apis/cluster/composition.yaml).
 {{</hint >}}
 
 #### Cross-resource references


### PR DESCRIPTION
The AWS platform ref was recently refactored moving the location of files referenced in the docs.

This updates the links to point to the new URLs