### PR TITLE
s/seperated/separated

### DIFF
--- a/content/contribute/code-style-guide.md
+++ b/content/contribute/code-style-guide.md
@@ -170,7 +170,7 @@ metadata:
 ```
 ````
 
-Combining copying and highlighting in a single comma-seperated annotation. 
+Combining copying and highlighting in a single comma-separated annotation. 
 ````yaml {copy-lines="2-5", hl_lines="2-3"}
 ```yaml {copy-lines="2-5", hl_lines="2-3"}
 apiVersion: pkg.crossplane.io/v1

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -193,7 +193,7 @@ crossplane-stable/crossplane \
 --set image.pullPolicy=Always
 ```
 
-Helm supports comma-seperated arguments.
+Helm supports comma-separated arguments.
 
 For example, to change the image pull policy and number of replicas:
 

--- a/content/v1.12/software/install.md
+++ b/content/v1.12/software/install.md
@@ -212,7 +212,7 @@ crossplane-stable/crossplane \
 --set image.pullPolicy=Always
 ```
 
-Helm supports comma-seperated arguments.
+Helm supports comma-separated arguments.
 
 For example, to change the image pull policy and number of replicas:
 

--- a/content/v1.13/software/install.md
+++ b/content/v1.13/software/install.md
@@ -212,7 +212,7 @@ crossplane-stable/crossplane \
 --set image.pullPolicy=Always
 ```
 
-Helm supports comma-seperated arguments.
+Helm supports comma-separated arguments.
 
 For example, to change the image pull policy and number of replicas:
 

--- a/content/v1.14/cli/command-reference.md
+++ b/content/v1.14/cli/command-reference.md
@@ -135,7 +135,7 @@ For example, to install version 0.42.0 of the
 | ------------ | -------------                                    | ------------------------------                                                                  |
 |              | `--runtime-config=<runtime config name>`         | Install the package with a runtime configuration.                                               |
 | `-m`         | `--manual-activation`                            | Set the `revisionActiviationPolicy` to `Manual`.                                                |
-|              | `--package-pull-secrets=<list of secrets>`       | A comma-seperated list of Kubernetes secrets to use for authenticating to the package registry. |
+|              | `--package-pull-secrets=<list of secrets>`       | A comma-separated list of Kubernetes secrets to use for authenticating to the package registry. |
 | `-r`         | `--revision-history-limit=<number of revisions>` | Set the `revisionHistoryLimit`. Defaults to `1`.                                                |
 | `-w`         | `--wait=<number of seconds>`                     | Number of seconds to wait for a package to install.                                             |
 

--- a/content/v1.14/software/install.md
+++ b/content/v1.14/software/install.md
@@ -193,7 +193,7 @@ crossplane-stable/crossplane \
 --set image.pullPolicy=Always
 ```
 
-Helm supports comma-seperated arguments.
+Helm supports comma-separated arguments.
 
 For example, to change the image pull policy and number of replicas:
 


### PR DESCRIPTION
Fix multiple "separated" typos. 