### PR TITLE
remove reference to management policies flag

### DIFF
--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -245,9 +245,8 @@ at the table below.
 {{< table caption="Feature flags" >}}
 | Status | Flag | Description |
 | --- | --- | --- |
-| Beta | `--enable-composition-revisions` |Enable support for CompositionRevisions |
+| Beta | `--enable-composition-revisions` | Enable support for CompositionRevisions. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
-| Beta | `--enable-deployment-runtime-configs` |Enable support for Deployment Runtime Configs. |
 | Alpha | `--enable-composition-functions` | Enable support for Composition Functions. |
 | Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |

--- a/content/v1.14/software/install.md
+++ b/content/v1.14/software/install.md
@@ -247,7 +247,6 @@ at the table below.
 | --- | --- | --- |
 | Beta | `--enable-composition-revisions` | Enable support for CompositionRevisions. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
-| Beta | `--enable-management-policies` | Enable managed resource management policies. | 
 | Alpha | `--enable-composition-functions` | Enable support for Composition Functions. |
 | Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |


### PR DESCRIPTION
During the update of GMP to beta the `--enable-management-policies` flag was incorrectly added to the options for the Crossplane pod. 

This removes that reference. 

 Fixes #605