### PR TITLE
feat(examples): use providerConfigRef.name instead of deprecated and …

### DIFF
--- a/content/v1.12/concepts/managed-resources.md
+++ b/content/v1.12/concepts/managed-resources.md
@@ -267,7 +267,8 @@ kind: Instance
 spec:
   forProvider:
     # Removed for brevity
-  providerConfigRef: user-keys
+  providerConfigRef:
+    name: user-keys
 ```
 
 ```yaml {label="pc"}

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -418,7 +418,8 @@ kind: Instance
 spec:
   forProvider:
     # Removed for brevity
-  providerConfigRef: user-keys
+  providerConfigRef:
+    name: user-keys
 ```
 
 ```yaml {label="pc"}

--- a/content/v1.14/concepts/managed-resources.md
+++ b/content/v1.14/concepts/managed-resources.md
@@ -403,7 +403,8 @@ kind: Instance
 spec:
   forProvider:
     # Removed for brevity
-  providerConfigRef: user-keys
+  providerConfigRef:
+    name: user-keys
 ```
 
 ```yaml {label="pc"}


### PR DESCRIPTION
…removed providerConfigRef

fix #609