### PR TITLE
add RSS support for release notes. Resolves #629

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,16 @@ uglyurls: false
 disableKinds:
   - taxonomy
   - term
-  - RSS
+
+outputs:
+  home:
+  - html
+  section:
+  - html
+  - rss
+  taxonomy:
+  term:
+
 
 ignoreFiles:
 - README.md

--- a/content/v1.14/release-notes/docs.md
+++ b/content/v1.14/release-notes/docs.md
@@ -12,6 +12,11 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## November 30, 2023
+
+### New features 🎉
+* Added RSS support for Crossplane release notes. 
+
 ## November 1, 2023
 
 ### New content 🎉

--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -173,3 +173,6 @@ h3, h4, h5, h6 {
   margin-top: 0 !important;
 }
 
+.rss-icon {
+  fill: var(--rss-icon-fill);
+}

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -4,6 +4,7 @@
     --body-font-color: #{$fog-0};
     --content-link-color: #{$aqua-400};
     --anchor-link-color: #{$fog-400};
+    --rss-icon-fill: #{$aqua-500};
 
     // Single code lines inside text. Code blocks are in _code_theme_dark.scss
     --code-background: #{$fog-0}30;
@@ -109,17 +110,17 @@
         &:not(.nav-link){
           border-bottom: 2px solid #{$fog-800};
         }
-    
+
         // Active tab style
         .active, .active:hover {
           color: #{$aqua-400} !important;
           border-bottom: 2px solid #{$aqua-400} !important;
         }
-    
+
         // Dim the text of non-active tabs
         .nav-link {
             color: #{$fog-400};
-    
+
             // Make the text light on hover
             &:hover{
                 color: #{$fog-0};

--- a/themes/geekboot/assets/scss/light-mode.scss
+++ b/themes/geekboot/assets/scss/light-mode.scss
@@ -4,6 +4,7 @@
     --body-font-color: #{$fog-1000};
     --content-link-color: #{$aqua-700};
     --anchor-link-color: #{$fog-600};
+    --rss-icon-fill: #{$aqua-600};
 
     // Add underline to light mode small font links due to being similar color to main text
     p > a, .admonition-content > a, li > a, td > a, .home-link-description > a {
@@ -105,7 +106,7 @@
 
     // Tab Colors
     .nav-tabs{
-        
+
         &:not(.nav-link){
             border-bottom: 2px solid #{$fog-200};
         }

--- a/themes/geekboot/layouts/_default/section.rss.xml
+++ b/themes/geekboot/layouts/_default/section.rss.xml
@@ -1,0 +1,39 @@
+{{/* Based on default Hugo RSS template. https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml */}}
+
+{{- $pctx := . }}
+
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+    {{- $pages = $pctx.RegularPages }}
+{{- else }}
+    {{- $pages = $pctx.Pages }}
+{{- end }}
+
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.LanguageCode }}</language>
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Page.Params.released | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.HTMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/themes/geekboot/layouts/partials/header.html
+++ b/themes/geekboot/layouts/partials/header.html
@@ -56,3 +56,7 @@
 {{ partialCached "favicons" . }}
 
 {{ partial "social" . }}
+
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -23,7 +23,13 @@
               {{ partial "version-dropdown-menu" . }}
             {{ end }}
           </div>
-          <h1 class="bd-title mb-0" id="content">{{ .Title | markdownify }}</h1>
+          <h1 class="bd-title mb-0" id="content">{{ .Title | markdownify }}
+            {{ if eq .Page.Title "Release Notes" }}
+              {{ with .OutputFormats.Get "rss" -}}
+                <a href="{{.Permalink}}"><svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" class="rss-icon" viewBox="0 0 448 512"><path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zM96 136c0-13.3 10.7-24 24-24c137 0 248 111 248 248c0 13.3-10.7 24-24 24s-24-10.7-24-24c0-110.5-89.5-200-200-200c-13.3 0-24-10.7-24-24zm0 96c0-13.3 10.7-24 24-24c83.9 0 152 68.1 152 152c0 13.3-10.7 24-24 24s-24-10.7-24-24c0-57.4-46.6-104-104-104c-13.3 0-24-10.7-24-24zm0 120a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg></a>
+              {{ end }}
+            {{ end }}
+          </h1>
         </div>
         {{ if .Page.Params.state }}
           {{ partial "feature-state-alert" . }}

--- a/utils/vale/styles/Crossplane/allowed-jargon.txt
+++ b/utils/vale/styles/Crossplane/allowed-jargon.txt
@@ -48,6 +48,7 @@ proselint
 RBAC
 RPC
 RPCs
+RSS
 SCSS
 SDK
 SDKs


### PR DESCRIPTION
Publishes an RSS feed for the release notes page and adds an icon and header meta tag for the RSS feed.