### PR TITLE
Highlight possibility of feature drop only for alpha features

### DIFF
--- a/themes/geekboot/layouts/partials/feature-state-alert.html
+++ b/themes/geekboot/layouts/partials/feature-state-alert.html
@@ -9,6 +9,7 @@
             {{- errorf "\n\nNo \"alphaVersion\" front matter in page %q\n\n\n" .Page.File.Path -}}
             {{- end -}}
             This is an alpha feature.
+            Crossplane may change or drop this feature at any time. <br />
             {{ end }}
             {{ if eq .Page.Params.state "beta" }}
                 {{- if not .Page.Params.alphaVersion -}}
@@ -29,7 +30,6 @@
             This feature graduated to beta status in v{{.Page.Params.betaVersion}}.
             {{ end }}
             <br /><br />
-            Crossplane may change or drop this feature at any time. <br />
             For more information read the <a href="{{.Site.BaseURL}}knowledge-base/guides/feature-lifecycle/">Crossplane feature lifecycle</a>.
         </p>
     </div>


### PR DESCRIPTION
* Feature can be dropped only at alpha level
* Do not confuse beta features users with the statement that can block adoption