### PR TITLE
Fix issue with API folder on /latest

### DIFF
--- a/themes/geekboot/layouts/partials/crds.html
+++ b/themes/geekboot/layouts/partials/crds.html
@@ -14,7 +14,7 @@
     <div id="crd-rows-container">
     {{/* Each level is a map with the key being the directory name */}}
     {{/* $Site.Data.crds /$version/crds/yaml */}}
-    {{ range index $.Site.Data.crds (printf "v%s" .Page.Params.version) "api" "yaml" }}
+    {{ range index $.Site.Data.crds .Section "api" "yaml" }}
 
         {{ $kind := .spec.names.kind }}
         {{ $group := .spec.group }}


### PR DESCRIPTION
The API page doesn't render in /latest. /latest is the entry point for search engines.

The reason is that the existing code looks for a version number that doesn't exist. This changes the logic to use the current directory instead of the version parameter. 

Verified by creating a /latest content dir and removing the version number.