### PR TITLE
Update link and wording for comp function guide

### DIFF
--- a/content/v1.14/concepts/composition-functions.md
+++ b/content/v1.14/concepts/composition-functions.md
@@ -452,10 +452,8 @@ $ crossplane xpkg push -f package/*.xpkg crossplane-contrib/function-example:v0.
 ```
 
 {{<hint "tip">}}
-Crossplane has
-[language specific guides]({{<ref "../../knowledge-base/guides">}}) to writing
-a composition function. Refer to the guide for your preferred language for a
-more detailed guide to writing a function.
+Crossplane has a 
+[guide to writing a composition function in Go]({{<ref "../../knowledge-base/guides">}}). 
 {{</hint>}}
 
 When you're writing a composition function it's useful to know how composition

--- a/content/v1.14/concepts/composition-functions.md
+++ b/content/v1.14/concepts/composition-functions.md
@@ -453,7 +453,7 @@ $ crossplane xpkg push -f package/*.xpkg crossplane-contrib/function-example:v0.
 
 {{<hint "tip">}}
 Crossplane has a 
-[guide to writing a composition function in Go]({{<ref "../../knowledge-base/guides">}}). 
+[guide to writing a composition function in Go]({{<ref "../../knowledge-base/guides/write-a-composition-function-in-go">}}). 
 {{</hint>}}
 
 When you're writing a composition function it's useful to know how composition


### PR DESCRIPTION
Changes the wording to only reference the existing Go function guide and links directly to it. 

Resolves #648 