### PR TITLE
docs(transforms): note that map fails on missing keys

### DIFF
--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -1223,7 +1223,7 @@ If Crossplane finds the value, Crossplane puts
 the mapped value in the {{<hover label="map" line="4">}}toFieldPath{{</hover>}}.
 
 {{<hint "note" >}}
-Crossplane ignores the patch if the value isn't found.
+Crossplane throws an error for the patch if the value isn't found.
 {{< /hint >}}
 
 {{<hover label="map" line="3">}}spec.field1{{</hover>}} is the string

--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -1169,7 +1169,7 @@ If Crossplane finds the value, Crossplane puts
 the mapped value in the {{<hover label="map" line="4">}}toFieldPath{{</hover>}}.
 
 {{<hint "note" >}}
-Crossplane ignores the patch if the value isn't found.
+Crossplane throws an error for the patch if the value isn't found.
 {{< /hint >}}
 
 {{<hover label="map" line="3">}}spec.field1{{</hover>}} is the string

--- a/content/v1.14/concepts/patch-and-transform.md
+++ b/content/v1.14/concepts/patch-and-transform.md
@@ -1223,7 +1223,7 @@ If Crossplane finds the value, Crossplane puts
 the mapped value in the {{<hover label="map" line="4">}}toFieldPath{{</hover>}}.
 
 {{<hint "note" >}}
-Crossplane ignores the patch if the value isn't found.
+Crossplane throws an error for the patch if the value isn't found.
 {{< /hint >}}
 
 {{<hover label="map" line="3">}}spec.field1{{</hover>}} is the string


### PR DESCRIPTION
When you're missing the key, it does in fact fail and does not ignore the patch:

```
cannot apply the "CombineFromComposite" patch at index 0: transform at index 0 returned error: map transform could not resolve: key default/queue-sample is not found in map
```

Relevant [slack thread](https://crossplane.slack.com/archives/CEG3T90A1/p1701979187893449).

I took a look at the code and in all "live" versions we return an error from `ResolveMap` that gets propagated without special treatment that would allow it to be ignored, so I changed the note in all applicable versions (1.12 has no note I could find, but please let me know if would be nice if there was one).