### PR TITLE
fix sidebar colors in mobile darkmode

### DIFF
--- a/themes/geekboot/assets/scss/_sidebar.scss
+++ b/themes/geekboot/assets/scss/_sidebar.scss
@@ -72,12 +72,12 @@
 
         svg.sidebar-icon.plus {
           display: block !important;
-          filter: var(--btn-close-filter);
+          color: var(--body-font-color);
           opacity: 1;
         }
         svg.sidebar-icon.x {
           display: none !important;
-          filter: var(--btn-close-filter);
+          color: var(--body-font-color);
           opacity: 1;
         }
       }
@@ -85,12 +85,12 @@
 
         svg.sidebar-icon.plus {
           display: none !important;
-          filter: var(--btn-close-filter);
+          color: var(--body-font-color);
           opacity: 1;
         }
         svg.sidebar-icon.x {
           display: block !important;
-          filter: var(--btn-close-filter);
+          color: var(--body-font-color);
           opacity: 1;
         }
       }

--- a/themes/geekboot/assets/scss/_sidebar.scss
+++ b/themes/geekboot/assets/scss/_sidebar.scss
@@ -6,8 +6,13 @@
     position: sticky;
   }
 
-  .btn-close {
-    filter: var(--btn-close-color)!important;
+  .offcanvas-title{
+    color: var(--body-font-color) !important;
+  }
+
+  .btn-close{
+    filter: var(--btn-close-filter) !important;
+    opacity: 1;
   }
 
 }
@@ -17,7 +22,7 @@
 
   a.bd-links{
     text-decoration: none !important;
-    color: var(--body-color) !important;
+    color: var(--body-font-color) !important;
   }
 
   @include media-breakpoint-down(lg) {
@@ -38,7 +43,7 @@
 
     a {
       text-decoration: none !important;
-      color: var(--body-color) !important;
+      color: var(--body-font-color) !important;
     }
 
     &.active-parent {
@@ -67,18 +72,26 @@
 
         svg.sidebar-icon.plus {
           display: block !important;
+          filter: var(--btn-close-filter);
+          opacity: 1;
         }
         svg.sidebar-icon.x {
           display: none !important;
+          filter: var(--btn-close-filter);
+          opacity: 1;
         }
       }
       &:not(.collapsed){
 
         svg.sidebar-icon.plus {
           display: none !important;
+          filter: var(--btn-close-filter);
+          opacity: 1;
         }
         svg.sidebar-icon.x {
           display: block !important;
+          filter: var(--btn-close-filter);
+          opacity: 1;
         }
       }
     }

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -19,7 +19,6 @@
     // Sidebar nav
     --nav-highlight-color: #{$aqua-900};
     --btn-close-color:     #{$fog-0};
-    --btn-close-filter:    invert(1) grayscale(100%) brightness(200%);
 
     //Version dropdown
     --dropdown-highlight: #{$fog-900};

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -19,6 +19,7 @@
     // Sidebar nav
     --nav-highlight-color: #{$aqua-900};
     --btn-close-color:     #{$fog-0};
+    --btn-close-filter:    invert(1) grayscale(100%) brightness(200%);
 
     //Version dropdown
     --dropdown-highlight: #{$fog-900};


### PR DESCRIPTION
Recent restyling of the color theme missed some colors in the nav, on mobile, in dark mode.

This updates the colors of the expand/collapse buttons, close buttons and link colors on the dark mode mobile nav. 