### PR TITLE
Update GCP and AWS Quickstarts to no-fork providers

### DIFF
--- a/content/master/getting-started/install-crossplane-include.md
+++ b/content/master/getting-started/install-crossplane-include.md
@@ -40,11 +40,11 @@ crossplane-stable/crossplane \
 --dry-run --debug \
 --namespace crossplane-system \
 --create-namespace
-install.go:200: [debug] Original chart version: ""
-install.go:217: [debug] CHART PATH: /home/vagrant/.cache/helm/repository/crossplane-1.13.0.tgz
+install.go:214: [debug] Original chart version: ""
+install.go:231: [debug] CHART PATH: /Users/plumbis/Library/Caches/helm/repository/crossplane-1.14.4.tgz
 
 NAME: crossplane
-LAST DEPLOYED: Fri Jul 28 13:57:41 2023
+LAST DEPLOYED: Fri Dec 15 11:12:42 2023
 NAMESPACE: crossplane-system
 STATUS: pending-install
 REVISION: 1
@@ -62,12 +62,13 @@ customLabels: {}
 deploymentStrategy: RollingUpdate
 extraEnvVarsCrossplane: {}
 extraEnvVarsRBACManager: {}
+extraObjects: []
 extraVolumeMountsCrossplane: {}
 extraVolumesCrossplane: {}
 hostNetwork: false
 image:
   pullPolicy: IfNotPresent
-  repository: crossplane/crossplane
+  repository: xpkg.upbound.io/crossplane/crossplane
   tag: ""
 imagePullSecrets: {}
 leaderElection: true
@@ -139,13 +140,13 @@ metadata:
   namespace: crossplane-system
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 ---
 # Source: crossplane/templates/serviceaccount.yaml
 apiVersion: v1
@@ -155,24 +156,44 @@ metadata:
   namespace: crossplane-system
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 ---
 # Source: crossplane/templates/secret.yaml
-# The reason this is created empty and filled by the init container is that it's
-# mounted by the actual container, so if it wasn't created by Helm, then the
-# deployment wouldn't be deployed at all with secret to mount not found error.
-# In addition, Helm would delete this secret after uninstallation so the new
-# installation of Crossplane would use its own certificate.
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-tls-secret
+  name: crossplane-root-ca
+  namespace: crossplane-system
+type: Opaque
+---
+# Source: crossplane/templates/secret.yaml
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-server
+  namespace: crossplane-system
+type: Opaque
+---
+# Source: crossplane/templates/secret.yaml
+# The reason this is created empty and filled by the init container is we want
+# to manage the lifecycle of the secret via Helm. This way whenever Crossplane
+# is deleted, the secret is deleted as well.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crossplane-tls-client
   namespace: crossplane-system
 type: Opaque
 ---
@@ -183,13 +204,13 @@ metadata:
   name: crossplane
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -202,13 +223,13 @@ metadata:
   name: crossplane:system:aggregate-to-crossplane
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
     crossplane.io/scope: "system"
     rbac.crossplane.io/aggregate-to-crossplane: "true"
 rules:
@@ -225,6 +246,7 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  - customresourcedefinitions/status
   verbs:
   - "*"
 - apiGroups:
@@ -302,13 +324,13 @@ metadata:
   name: crossplane:allowed-provider-permissions
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -321,13 +343,13 @@ metadata:
   name: crossplane-rbac-manager
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 - apiGroups:
   - ""
@@ -342,11 +364,18 @@ rules:
   - ""
   resources:
   - namespaces
-  - serviceaccounts
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - get
+    - list
+    - watch
 # The RBAC manager creates a series of RBAC roles for each namespace it sees.
 # These RBAC roles are controlled (in the owner reference sense) by the namespace.
 # The RBAC manager needs permission to set finalizers on Namespaces in order to
@@ -455,13 +484,13 @@ metadata:
   name: crossplane-admin
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -474,13 +503,13 @@ metadata:
   name: crossplane-edit
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -493,13 +522,13 @@ metadata:
   name: crossplane-view
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -512,13 +541,13 @@ metadata:
   name: crossplane-browse
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -532,13 +561,13 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-admin: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane administrators have access to view events.
 - apiGroups: [""]
@@ -567,7 +596,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
+  resources: ["*"]
   verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
@@ -582,13 +611,13 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-edit: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane editors have access to view events.
 - apiGroups: [""]
@@ -610,7 +639,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
+  resources: ["*"]
   verbs: ["*"]
 ---
 # Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -621,13 +650,13 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-view: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane viewers have access to view events.
 - apiGroups: [""]
@@ -644,7 +673,7 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
+  resources: ["*"]
   verbs: [get, list, watch]
 ---
 # Source: crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -655,13 +684,13 @@ metadata:
   labels:
     rbac.crossplane.io/aggregate-to-browse: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane browsers have access to view events.
 - apiGroups: [""]
@@ -686,13 +715,13 @@ metadata:
     rbac.crossplane.io/aggregate-to-ns-admin: "true"
     rbac.crossplane.io/base-of-ns-admin: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane namespace admins have access to view events.
 - apiGroups: [""]
@@ -723,13 +752,13 @@ metadata:
     rbac.crossplane.io/aggregate-to-ns-edit: "true"
     rbac.crossplane.io/base-of-ns-edit: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane namespace editors have access to view events.
 - apiGroups: [""]
@@ -750,13 +779,13 @@ metadata:
     rbac.crossplane.io/aggregate-to-ns-view: "true"
     rbac.crossplane.io/base-of-ns-view: "true"
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 rules:
 # Crossplane namespace viewers have access to view events.
 - apiGroups: [""]
@@ -770,13 +799,13 @@ metadata:
   name: crossplane
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -793,13 +822,13 @@ metadata:
   name: crossplane-rbac-manager
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -816,13 +845,13 @@ metadata:
   name: crossplane-admin
   labels:
     app: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -841,13 +870,13 @@ metadata:
   labels:
     app: crossplane
     release: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 spec:
   selector:
     app: crossplane
@@ -866,13 +895,13 @@ metadata:
   labels:
     app: crossplane
     release: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 spec:
   replicas: 1
   selector:
@@ -886,20 +915,18 @@ spec:
       labels:
         app: crossplane
         release: crossplane
-        helm.sh/chart: crossplane-1.13.0
+        helm.sh/chart: crossplane-1.14.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/part-of: crossplane
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/version: "1.13.0"
+        app.kubernetes.io/version: "1.14.4"
     spec:
-      securityContext:
-        {}
       serviceAccountName: crossplane
       hostNetwork: false
       initContainers:
-        - image: "crossplane/crossplane:v1.13.0"
+        - image: "xpkg.upbound.io/crossplane/crossplane:v1.14.4"
           args:
           - core
           - init
@@ -923,11 +950,13 @@ spec:
               resourceFieldRef:
                 containerName: crossplane-init
                 resource: limits.cpu
+                divisor: "1"
           - name: GOMEMLIMIT
             valueFrom:
               resourceFieldRef:
                 containerName: crossplane-init
                 resource: limits.memory
+                divisor: "1"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
@@ -936,8 +965,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: "WEBHOOK_TLS_SECRET_NAME"
-            value: webhook-tls-secret
           - name: "WEBHOOK_SERVICE_NAME"
             value: crossplane-webhooks
           - name: "WEBHOOK_SERVICE_NAMESPACE"
@@ -946,8 +973,14 @@ spec:
                 fieldPath: metadata.namespace
           - name: "WEBHOOK_SERVICE_PORT"
             value: "9443"
+          - name: "TLS_CA_SECRET_NAME"
+            value: crossplane-root-ca
+          - name: "TLS_SERVER_SECRET_NAME"
+            value: crossplane-tls-server
+          - name: "TLS_CLIENT_SECRET_NAME"
+            value: crossplane-tls-client
       containers:
-      - image: "crossplane/crossplane:v1.13.0"
+      - image: "xpkg.upbound.io/crossplane/crossplane:v1.14.4"
         args:
         - core
         - start
@@ -960,7 +993,14 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 2
+          tcpSocket:
+            port: readyz
         ports:
+        - name: readyz
+          containerPort: 8081
         - name: webhooks
           containerPort: 9443
         securityContext:
@@ -989,30 +1029,32 @@ spec:
                 fieldPath: spec.serviceAccountName
           - name: LEADER_ELECTION
             value: "true"
-          - name: "WEBHOOK_TLS_SECRET_NAME"
-            value: webhook-tls-secret
-          - name: "WEBHOOK_TLS_CERT_DIR"
-            value: /webhook/tls
+          - name: "TLS_SERVER_SECRET_NAME"
+            value: crossplane-tls-server
+          - name: "TLS_SERVER_CERTS_DIR"
+            value: /tls/server
+          - name: "TLS_CLIENT_SECRET_NAME"
+            value: crossplane-tls-client
+          - name: "TLS_CLIENT_CERTS_DIR"
+            value: /tls/client
         volumeMounts:
           - mountPath: /cache
             name: package-cache
-          - mountPath: /webhook/tls
-            name: webhook-tls-secret
+          - mountPath: /tls/server
+            name: tls-server-certs
+          - mountPath: /tls/client
+            name: tls-client-certs
       volumes:
       - name: package-cache
         emptyDir:
           medium:
           sizeLimit: 20Mi
-      - name: webhook-tls-secret
+      - name: tls-server-certs
         secret:
-          # NOTE(muvaf): The tls.crt is used both by the server (requires it to
-          # be a single cert) and the caBundle fields of webhook configs and CRDs
-          # which can accept a whole bundle of certificates. In order to meet
-          # the requirements of both, we require a single certificate instead of
-          # a bundle.
-          # It's assumed that initializer generates this anyway, so it should be
-          # fine.
-          secretName: webhook-tls-secret
+          secretName: crossplane-tls-server
+      - name: tls-client-certs
+        secret:
+          secretName: crossplane-tls-client
 ---
 # Source: crossplane/templates/rbac-manager-deployment.yaml
 apiVersion: apps/v1
@@ -1023,13 +1065,13 @@ metadata:
   labels:
     app: crossplane-rbac-manager
     release: crossplane
-    helm.sh/chart: crossplane-1.13.0
+    helm.sh/chart: crossplane-1.14.4
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/part-of: crossplane
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/version: "1.13.0"
+    app.kubernetes.io/version: "1.14.4"
 spec:
   replicas: 1
   selector:
@@ -1043,19 +1085,17 @@ spec:
       labels:
         app: crossplane-rbac-manager
         release: crossplane
-        helm.sh/chart: crossplane-1.13.0
+        helm.sh/chart: crossplane-1.14.4
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/part-of: crossplane
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/version: "1.13.0"
+        app.kubernetes.io/version: "1.14.4"
     spec:
-      securityContext:
-        {}
       serviceAccountName: rbac-manager
       initContainers:
-      - image: "crossplane/crossplane:v1.13.0"
+      - image: "xpkg.upbound.io/crossplane/crossplane:v1.14.4"
         args:
         - rbac
         - init
@@ -1085,7 +1125,7 @@ spec:
                 containerName: crossplane-init
                 resource: limits.memory
       containers:
-      - image: "crossplane/crossplane:v1.13.0"
+      - image: "xpkg.upbound.io/crossplane/crossplane:v1.14.4"
         args:
         - rbac
         - start
@@ -1124,10 +1164,10 @@ Release: crossplane
 
 Chart Name: crossplane
 Chart Description: Crossplane is an open source Kubernetes add-on that enables platform teams to assemble infrastructure from multiple vendors, and expose higher level self-service APIs for application teams to consume.
-Chart Version: 1.13.0
-Chart Application Version: 1.13.0
+Chart Version: 1.14.4
+Chart Application Version: 1.14.4
 
-Kube Version: v1.27.4
+Kube Version: v1.27.3
 ```
 {{< /expand >}}
 
@@ -1158,9 +1198,13 @@ compositeresourcedefinitions      xrd,xrds     apiextensions.crossplane.io/v1   
 compositionrevisions              comprev      apiextensions.crossplane.io/v1         false        CompositionRevision
 compositions                      comp         apiextensions.crossplane.io/v1         false        Composition
 environmentconfigs                envcfg       apiextensions.crossplane.io/v1alpha1   false        EnvironmentConfig
+usages                                         apiextensions.crossplane.io/v1alpha1   false        Usage
 configurationrevisions                         pkg.crossplane.io/v1                   false        ConfigurationRevision
 configurations                                 pkg.crossplane.io/v1                   false        Configuration
 controllerconfigs                              pkg.crossplane.io/v1alpha1             false        ControllerConfig
+deploymentruntimeconfigs                       pkg.crossplane.io/v1beta1              false        DeploymentRuntimeConfig
+functionrevisions                              pkg.crossplane.io/v1beta1              false        FunctionRevision
+functions                                      pkg.crossplane.io/v1beta1              false        Function
 locks                                          pkg.crossplane.io/v1beta1              false        Lock
 providerrevisions                              pkg.crossplane.io/v1                   false        ProviderRevision
 providers                                      pkg.crossplane.io/v1                   false        Provider

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0   13m
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0         14m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0     14m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0   3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0         13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0     13m
 ```
 
 ## Create a custom API
@@ -433,7 +433,7 @@ View the resource with `kubectl get nosql`.
 ```shell {copy-lines="1"}
 kubectl get nosql
 NAME                SYNCED   READY   COMPOSITION          AGE
-my-nosql-database   True     True    dynamo-with-bucket   3m35s
+my-nosql-database   True     True    dynamo-with-bucket   14s
 ```
 
 This object is a Crossplane _composite resource_ (also called an `XR`).  
@@ -446,10 +446,10 @@ View the individual resources with `kubectl get managed`
 ```shell {copy-lines="1"}
 kubectl get managed
 NAME                                                    READY   SYNCED   EXTERNAL-NAME             AGE
-table.dynamodb.aws.upbound.io/my-nosql-database-r94gq   True    True     my-nosql-database-r94gq   5m28s
+table.dynamodb.aws.upbound.io/my-nosql-database-t5wtx   True    True     my-nosql-database-t5wtx   33s
 
 NAME                                               READY   SYNCED   EXTERNAL-NAME             AGE
-bucket.s3.aws.upbound.io/my-nosql-database-2j65t   True    True     my-nosql-database-2j65t   5m28s
+bucket.s3.aws.upbound.io/my-nosql-database-xtzph   True    True     my-nosql-database-xtzph   33s
 ```
 
 Delete the resources with `kubectl delete nosql`.
@@ -506,7 +506,7 @@ View the Claim with `kubectl get claim -n crossplane-test`.
 ```shell {copy-lines="1"}
 kubectl get claim -n crossplane-test
 NAME                SYNCED   READY   CONNECTION-SECRET   AGE
-my-nosql-database   True     True                        42s
+my-nosql-database   True     True                        17s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
 EOF
 ```
 
@@ -80,6 +80,36 @@ spec:
 EOF
 ```
 {{</expand >}}
+
+## Install the DynamoDB Provider
+
+Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket 
+along with a DynamoDB Table.  
+Deploying a DynamoDB Table requires the DynamoDB Provider as well. 
+
+Add the new Provider to the cluster. 
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-dynamodb
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0
+EOF
+```
+
+View the new DynamoDB provider with `kubectl get providers`.
+
+
+```shell {copy-lines="1"}
+kubectl get providers
+NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0   13m
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0         14m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0     14m
+```
 
 ## Create a custom API
 
@@ -377,34 +407,7 @@ NAME                 XR-KIND   XR-APIVERSION                   AGE
 dynamo-with-bucket   NoSQL     database.example.com/v1alpha1   3s
 ```
 
-## Install the DynamoDB Provider
 
-Part 1 only installed the AWS S3 Provider. Deploying a DynamoDB Table requires
-the DynamoDB Provider as well. 
-
-Add the new Provider to the cluster. 
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-dynamodb
-spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0
-EOF
-```
-
-View the new DynamoDB provider with `kubectl get providers`.
-
-
-```shell {copy-lines="1"}
-kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0   13m
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0         14m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0     14m
-```
 
 ## Access the custom API
 

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0   3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0         13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0     13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0   3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0         13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0     13m
 ```
 
 ## Create a custom API

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0       97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0   88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0       97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0   88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.46.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.47.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0       2m53s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0   2m48s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0       97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0   88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.37.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.46.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -184,12 +184,11 @@ Any unique name is acceptable.
 {{< /hint >}}
 
 ```yaml {label="xr"}
-bucket=$(echo "crossplane-bucket-"$(head -n 4096 /dev/urandom | openssl sha1 | tail -c 10))
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl create -f -
 apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
-  name: $bucket
+  generateName: crossplane-bucket-
 spec:
   forProvider:
     region: us-east-2
@@ -222,8 +221,8 @@ This may take up to 5 minutes.
 
 ```shell {copy-lines="1"}
 kubectl get buckets
-NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
-crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s
+NAME                      READY   SYNCED   EXTERNAL-NAME             AGE
+crossplane-bucket-hhdzh   True    True     crossplane-bucket-hhdzh   5s
 ```
 
 ## Delete the managed resource
@@ -232,8 +231,8 @@ Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
 Use `kubectl delete bucket <bucketname>` to remove the bucket.
 
 ```shell {copy-lines="1"}
-kubectl delete bucket $bucket
-bucket.s3.aws.upbound.io "crossplane-bucket-45eed4ae0" deleted
+kubectl delete bucket crossplane-bucket-hhdzh
+bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 ```
 
 ## Next steps

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
 ```
 
 

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
 EOF
 ```
 
@@ -98,6 +98,36 @@ EOF
 {{< /editCode >}}
 
 {{</expand >}}
+
+## Install the PubSub Provider
+
+Part 1 only installed the GCP Storage Provider. This section deploys a 
+PubSub Topic along with a GCP storage bucket.  
+First install the GCP PubSub Provider.
+
+Add the new Provider to the cluster. 
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-gcp-pubsub
+spec:
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0
+EOF
+```
+
+View the new PubSub provider with `kubectl get providers`.
+
+```shell {copy-lines="1"}
+kubectl get providers
+NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    12m
+```
+
 
 ## Create a custom API
 
@@ -284,7 +314,7 @@ pubsubs.queue.example.com   True          True      7s
 View the new custom API endpoints with `kubectl api-resources | grep pubsub`
 
 ```shell {copy-lines="1",label="apiRes"}
-kubectl api-resources | grep pubsub
+kubectl api-resources | grep queue.example
 pubsubclaims                 queue.example.com/v1alpha1             true         PubSubClaim
 pubsubs                      queue.example.com/v1alpha1             false        PubSub
 ```
@@ -350,7 +380,7 @@ spec:
                 - "us-central1"
       patches:
         - fromFieldPath: "spec.location"
-          toFieldPath: "spec.forProvider.messageStoragePolicy[*].allowedPersistenceRegions[*]"
+          toFieldPath: "spec.forProvider.messageStoragePolicy[0].allowedPersistenceRegions[0]"
           transforms:
             - type: map
               map: 
@@ -381,34 +411,6 @@ View the Composition with `kubectl get composition`
 kubectl get composition
 NAME                XR-KIND   XR-APIVERSION       AGE
 topic-with-bucket   PubSub    queue.example.com   3s
-```
-
-## Install the PubSub Provider
-
-Part 1 only installed the GCP Storage Provider. Deploying a PubSub Topic 
-requires the PubSub Provider as well. 
-
-Add the new Provider to the cluster. 
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-gcp-pubsub
-spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.35.0
-EOF
-```
-
-View the new PubSub provider with `kubectl get providers`.
-
-```shell {copy-lines="1"}
-kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.35.0    7s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0   4h
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.35.0    4h
 ```
 
 ## Access the custom API
@@ -538,7 +540,7 @@ Deleting the Claim deletes all the Crossplane generated resources.
 `kubectl delete claim -n crossplane-test my-pubsub-queue`
 
 ```shell {copy-lines="1"}
-kubectl delete claim -n crossplane-test my-pubsub-queue
+kubectl delete pubsubclaim my-pubsub-queue -n crossplane-test
 pubsubclaim.queue.example.com "my-pubsub-queue" deleted
 ```
 

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0   14m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.35.0    14m
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.14/getting-started/provider-aws-part-2.md
+++ b/content/v1.14/getting-started/provider-aws-part-2.md
@@ -2,8 +2,6 @@
 title: AWS Quickstart Part 2
 weight: 120
 tocHidden: true
-aliases:
-  - /master/getting-started/provider-aws-part-3
 ---
 
 {{< hint "important" >}}
@@ -44,7 +42,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
 EOF
 ```
 
@@ -80,6 +78,36 @@ spec:
 EOF
 ```
 {{</expand >}}
+
+## Install the DynamoDB Provider
+
+Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket 
+along with a DynamoDB Table.  
+Deploying a DynamoDB Table requires the DynamoDB Provider as well. 
+
+Add the new Provider to the cluster. 
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-dynamodb
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0
+EOF
+```
+
+View the new DynamoDB provider with `kubectl get providers`.
+
+
+```shell {copy-lines="1"}
+kubectl get providers
+NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0   3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0         13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0     13m
+```
 
 ## Create a custom API
 
@@ -377,34 +405,7 @@ NAME                 XR-KIND   XR-APIVERSION                   AGE
 dynamo-with-bucket   NoSQL     database.example.com/v1alpha1   3s
 ```
 
-## Install the DynamoDB Provider
 
-Part 1 only installed the AWS S3 Provider. Deploying a DynamoDB Table requires
-the DynamoDB Provider as well. 
-
-Add the new Provider to the cluster. 
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws-dynamodb
-spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0
-EOF
-```
-
-View the new DynamoDB provider with `kubectl get providers`.
-
-
-```shell {copy-lines="1"}
-kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.37.0   13m
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0         14m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0     14m
-```
 
 ## Access the custom API
 
@@ -430,7 +431,7 @@ View the resource with `kubectl get nosql`.
 ```shell {copy-lines="1"}
 kubectl get nosql
 NAME                SYNCED   READY   COMPOSITION          AGE
-my-nosql-database   True     True    dynamo-with-bucket   3m35s
+my-nosql-database   True     True    dynamo-with-bucket   14s
 ```
 
 This object is a Crossplane _composite resource_ (also called an `XR`).  
@@ -443,10 +444,10 @@ View the individual resources with `kubectl get managed`
 ```shell {copy-lines="1"}
 kubectl get managed
 NAME                                                    READY   SYNCED   EXTERNAL-NAME             AGE
-table.dynamodb.aws.upbound.io/my-nosql-database-r94gq   True    True     my-nosql-database-r94gq   5m28s
+table.dynamodb.aws.upbound.io/my-nosql-database-t5wtx   True    True     my-nosql-database-t5wtx   33s
 
 NAME                                               READY   SYNCED   EXTERNAL-NAME             AGE
-bucket.s3.aws.upbound.io/my-nosql-database-2j65t   True    True     my-nosql-database-2j65t   5m28s
+bucket.s3.aws.upbound.io/my-nosql-database-xtzph   True    True     my-nosql-database-xtzph   33s
 ```
 
 Delete the resources with `kubectl delete nosql`.
@@ -503,7 +504,7 @@ View the Claim with `kubectl get claim -n crossplane-test`.
 ```shell {copy-lines="1"}
 kubectl get claim -n crossplane-test
 NAME                SYNCED   READY   CONNECTION-SECRET   AGE
-my-nosql-database   True     True                        42s
+my-nosql-database   True     True                        17s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed

--- a/content/v1.14/getting-started/provider-aws-part-2.md
+++ b/content/v1.14/getting-started/provider-aws-part-2.md
@@ -42,7 +42,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
 EOF
 ```
 
@@ -94,7 +94,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0
 EOF
 ```
 
@@ -104,9 +104,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.46.0   3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0         13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0     13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0   3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0         13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0     13m
 ```
 
 ## Create a custom API

--- a/content/v1.14/getting-started/provider-aws.md
+++ b/content/v1.14/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0       97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0   88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0       97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0   88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.46.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.47.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS

--- a/content/v1.14/getting-started/provider-aws.md
+++ b/content/v1.14/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.37.0       2m53s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.37.0   2m48s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.46.0       97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.46.0   88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.37.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.46.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -184,12 +184,11 @@ Any unique name is acceptable.
 {{< /hint >}}
 
 ```yaml {label="xr"}
-bucket=$(echo "crossplane-bucket-"$(head -n 4096 /dev/urandom | openssl sha1 | tail -c 10))
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl create -f -
 apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
-  name: $bucket
+  generateName: crossplane-bucket-
 spec:
   forProvider:
     region: us-east-2
@@ -222,8 +221,8 @@ This may take up to 5 minutes.
 
 ```shell {copy-lines="1"}
 kubectl get buckets
-NAME                          READY   SYNCED   EXTERNAL-NAME                 AGE
-crossplane-bucket-45eed4ae0   True    True     crossplane-bucket-45eed4ae0   61s
+NAME                      READY   SYNCED   EXTERNAL-NAME             AGE
+crossplane-bucket-hhdzh   True    True     crossplane-bucket-hhdzh   5s
 ```
 
 ## Delete the managed resource
@@ -232,8 +231,8 @@ Before shutting down your Kubernetes cluster, delete the S3 bucket just created.
 Use `kubectl delete bucket <bucketname>` to remove the bucket.
 
 ```shell {copy-lines="1"}
-kubectl delete bucket $bucket
-bucket.s3.aws.upbound.io "crossplane-bucket-45eed4ae0" deleted
+kubectl delete bucket crossplane-bucket-hhdzh
+bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 ```
 
 ## Next steps

--- a/content/v1.14/getting-started/provider-gcp-part-2.md
+++ b/content/v1.14/getting-started/provider-gcp-part-2.md
@@ -2,8 +2,6 @@
 title: GCP Quickstart Part 2
 weight: 120
 tocHidden: true
-aliases:
-  - /master/getting-started/provider-azure-part-3
 ---
 
 {{< hint "important" >}}
@@ -47,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
 EOF
 ```
 
@@ -98,6 +96,36 @@ EOF
 {{< /editCode >}}
 
 {{</expand >}}
+
+## Install the PubSub Provider
+
+Part 1 only installed the GCP Storage Provider. This section deploys a 
+PubSub Topic along with a GCP storage bucket.  
+First install the GCP PubSub Provider.
+
+Add the new Provider to the cluster. 
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-gcp-pubsub
+spec:
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0
+EOF
+```
+
+View the new PubSub provider with `kubectl get providers`.
+
+```shell {copy-lines="1"}
+kubectl get providers
+NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    12m
+```
+
 
 ## Create a custom API
 
@@ -284,7 +312,7 @@ pubsubs.queue.example.com   True          True      7s
 View the new custom API endpoints with `kubectl api-resources | grep pubsub`
 
 ```shell {copy-lines="1",label="apiRes"}
-kubectl api-resources | grep pubsub
+kubectl api-resources | grep queue.example
 pubsubclaims                 queue.example.com/v1alpha1             true         PubSubClaim
 pubsubs                      queue.example.com/v1alpha1             false        PubSub
 ```
@@ -350,7 +378,7 @@ spec:
                 - "us-central1"
       patches:
         - fromFieldPath: "spec.location"
-          toFieldPath: "spec.forProvider.messageStoragePolicy[*].allowedPersistenceRegions[*]"
+          toFieldPath: "spec.forProvider.messageStoragePolicy[0].allowedPersistenceRegions[0]"
           transforms:
             - type: map
               map: 
@@ -381,34 +409,6 @@ View the Composition with `kubectl get composition`
 kubectl get composition
 NAME                XR-KIND   XR-APIVERSION       AGE
 topic-with-bucket   PubSub    queue.example.com   3s
-```
-
-## Install the PubSub Provider
-
-Part 1 only installed the GCP Storage Provider. Deploying a PubSub Topic 
-requires the PubSub Provider as well. 
-
-Add the new Provider to the cluster. 
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-gcp-pubsub
-spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.35.0
-EOF
-```
-
-View the new PubSub provider with `kubectl get providers`.
-
-```shell {copy-lines="1"}
-kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.35.0    7s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0   4h
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.35.0    4h
 ```
 
 ## Access the custom API
@@ -538,7 +538,7 @@ Deleting the Claim deletes all the Crossplane generated resources.
 `kubectl delete claim -n crossplane-test my-pubsub-queue`
 
 ```shell {copy-lines="1"}
-kubectl delete claim -n crossplane-test my-pubsub-queue
+kubectl delete pubsubclaim my-pubsub-queue -n crossplane-test
 pubsubclaim.queue.example.com "my-pubsub-queue" deleted
 ```
 

--- a/content/v1.14/getting-started/provider-gcp-part-2.md
+++ b/content/v1.14/getting-started/provider-gcp-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
 EOF
 ```
 
@@ -112,7 +112,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
 EOF
 ```
 
@@ -121,9 +121,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.40.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
 ```
 
 

--- a/content/v1.14/getting-started/provider-gcp.md
+++ b/content/v1.14/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.14/getting-started/provider-gcp.md
+++ b/content/v1.14/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.35.0   14m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.35.0    14m
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.40.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.40.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -7,6 +7,8 @@ match: $sentence
 indicators:
   - ':'
 exceptions:
+  - API
+  - AWS
   - Azure
   - BigQuery
   - Claim

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -35,6 +35,7 @@ exceptions:
   - DynamoDB
   - Emmet
   - EnvironmentConfigs
+  - GCP
   - gRPC
   - Hashicorpterms
   - Helm


### PR DESCRIPTION
Updates the AWS quickstart to v0.46.0 and GCP to v0.40.0.