### PR TITLE
fix: composition function is beta

### DIFF
--- a/content/v1.14/software/install.md
+++ b/content/v1.14/software/install.md
@@ -247,7 +247,7 @@ at the table below.
 | --- | --- | --- |
 | Beta | `--enable-composition-revisions` | Enable support for CompositionRevisions. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
-| Alpha | `--enable-composition-functions` | Enable support for Composition Functions. |
+| Beta | `--enable-composition-functions` | Enable support for Composition Functions. |
 | Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |
 | Alpha | `--enable-usages` | Enable support for Usages. |


### PR DESCRIPTION
In the list of feature flags for crossplane v1.14, `--enable-composition-functions` was still listed as `Alpha`. This pull request changes this to `Beta` as composition functions matured to beta with v1.14