### PR TITLE
Remove mention of the RBAC manager management policy

### DIFF
--- a/content/master/concepts/pods.md
+++ b/content/master/concepts/pods.md
@@ -243,11 +243,9 @@ The RBAC manager container preforms the following tasks:
   them to control their managed resources
 * allowing the `crossplane` ServiceAccount to create managed resources
 * creating ClusterRoles to access Crossplane resources in all namespaces
-* creating Roles to access Crossplane resources in specific namespaces
 
 Use the [ClusterRoles]({{<ref "#crossplane-clusterroles">}}) to grant access to all Crossplane resources in the
 cluster.  
-Use the [Roles]({{<ref "#crossplane-roles" >}}) to only grant access to Crossplane Claims. 
 
 #### Crossplane ClusterRoles
 
@@ -313,27 +311,6 @@ View the full RBAC policy with
 ```shell
 kubectl describe clusterrole crossplane-browse
 ```
-
-#### Crossplane Roles
-By default the RBAC manager creates three Roles in every namespace. These Roles 
-grant access to Claims in a specific namespace. The RBAC manager dynamically 
-updates the Roles to access the specific API endpoints in a Claim. 
-
-{{< hint "note" >}}
-The specific details of the namespace Roles are beyond this guide. For more
-information read the [Composite Resource ClusterRole Mechanics](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md#composite-resource-clusterrole-mechanics)
-section of the RBAC Manager design document.
-{{< /hint >}}
-
-You can disable these namespace specific roles by configuring the RBAC manager
-with `--manage=Basic`.
-
-
-{{< hint "note" >}}
-
-Instructions for changing Crossplane pod settings during installation are in the
-[Crossplane Install]({{<ref "../software/install">}}) section. 
-{{< /hint >}}
 
 ## Leader election
 

--- a/content/master/getting-started/install-crossplane-include.md
+++ b/content/master/getting-started/install-crossplane-include.md
@@ -90,7 +90,6 @@ rbacManager:
   args: []
   deploy: true
   leaderElection: true
-  managementPolicy: Basic
   nodeSelector: {}
   replicas: 1
   skipAggregatedClusterRoles: false

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -147,7 +147,6 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `rbacManager.args` | Add custom arguments to the RBAC Manager pod. | `[]` |
 | `rbacManager.deploy` | Deploy the RBAC Manager pod and its required roles. | `true` |
 | `rbacManager.leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the RBAC Manager pod. | `true` |
-| `rbacManager.managementPolicy` | Defines the Roles and ClusterRoles the RBAC Manager creates and manages. - A policy of `Basic` creates and binds Roles only for the Crossplane ServiceAccount, Provider ServiceAccounts and creates Crossplane ClusterRoles. - A policy of `All` includes all the `Basic` settings and also creates Crossplane Roles in all namespaces. - Read the Crossplane docs for more information on the [RBAC Roles and ClusterRoles](https://docs.crossplane.io/latest/concepts/pods/#crossplane-clusterroles) | `"Basic"` |
 | `rbacManager.nodeSelector` | Add `nodeSelectors` to the RBAC Manager pod deployment. | `{}` |
 | `rbacManager.replicas` | The number of RBAC Manager pod `replicas` to deploy. | `1` |
 | `rbacManager.skipAggregatedClusterRoles` | Don't install aggregated Crossplane ClusterRoles. | `false` |


### PR DESCRIPTION
It's going away per https://github.com/crossplane/crossplane/issues/5227. See also https://github.com/crossplane/crossplane/issues/5227.