### PR TITLE
Improve documentation of defaultCompositeDeletePolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ Zone.Identifier
 ######################
 .vscode/*
 
+# PyCharm #
+######################
+.idea/
+
 # Common Python Venv #
 ######################
 venv/*

--- a/content/master/concepts/composite-resource-definitions.md
+++ b/content/master/concepts/composite-resource-definitions.md
@@ -630,7 +630,7 @@ The `defaultCompositeDeletePolicy` defines the default value for the claim's
 `compositeDeletePolicy` property if the user doesn't specify a value when creating
 the claim. The claim controller uses the `compositeDeletePolicy` property to specify
 the propagation policy when deleting the associated composite.
-The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+The `compositeDeletePolicy` doesn't apply to standalone composites that don't have
 associated claims.
 
 Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
@@ -644,10 +644,8 @@ Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
 deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
-to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource. Kubernetes deletes all the dependent objects before deleting the
-composite resource. The deletion of the claim suspends until the composite
-and all associated child resources are deleted.
+to use foreground cascading deletion which deletes all child resources before deleting the
+parent resource. The claim controller waits for the composite deletion to finish before returning.
 
 When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
 the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.

--- a/content/master/concepts/composite-resource-definitions.md
+++ b/content/master/concepts/composite-resource-definitions.md
@@ -638,7 +638,7 @@ the default value `Background` for the `compositeDeletePolicy` property.
 When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
 and returns, relying on Kubernetes to delete the remaining child objects,
-like managed resources, nested composites, secrets, etc.
+like managed resources, nested composites and secrets.
 
 Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the

--- a/content/master/concepts/composite-resource-definitions.md
+++ b/content/master/concepts/composite-resource-definitions.md
@@ -626,17 +626,32 @@ XRDs can set default parameters for composite resources and Claims.
 <!-- vale off -->
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
-The `defaultCompositeDeletePolicy` defines the deletion policy for composite
-resources and claims. 
+The `defaultCompositeDeletePolicy` defines the default value for the claim's 
+`compositeDeletePolicy` property if the user does not specify a value when the
+claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
+the propagation policy when the controller deletes the associated composite.
+The `compositeDeletePolicy` does not apply to standalone composites that are created
+without claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy deletes 
-the composite resource or Claim and relies on Kubernetes to delete the remaining
-dependent objects, like managed resources or secrets. 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
+created with the default value `Background` for the `compositeDeletePolicy` property.
+When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+the claim controller deletes the composite resource using the propagation policy `background`
+and returns immediately, relying on Kubernetes to delete the remaining child objects,
+like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes Kubernetes to attach a
-`foregroundDeletion` finalizer to the composite resource or Claim. Kubernetes
-deletes all the dependent objects before deleting the composite resource or
-Claim. 
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
+the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+`compositeDeletePolicy` property set to `Foreground` the controller
+deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+to use foreground cascading deletion which ensures that all child resources are deleted before the
+parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
+composite resource.  The deletion of the claim suspends until the composite
+and all associated child resources have been deleted.
+
+The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
+the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
+
 
 The default value is `defaultCompositeDeletePolicy: Background`. 
 

--- a/content/master/concepts/composite-resource-definitions.md
+++ b/content/master/concepts/composite-resource-definitions.md
@@ -627,31 +627,30 @@ XRDs can set default parameters for composite resources and Claims.
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
 The `defaultCompositeDeletePolicy` defines the default value for the claim's 
-`compositeDeletePolicy` property if the user does not specify a value when the
-claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
-the propagation policy when the controller deletes the associated composite.
-The `compositeDeletePolicy` does not apply to standalone composites that are created
-without claims.
+`compositeDeletePolicy` property if the user doesn't specify a value when creating
+the claim. The claim controller uses the `compositeDeletePolicy` property to specify
+the propagation policy when deleting the associated composite.
+The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+associated claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
-created with the default value `Background` for the `compositeDeletePolicy` property.
-When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
+the default value `Background` for the `compositeDeletePolicy` property.
+When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
-and returns immediately, relying on Kubernetes to delete the remaining child objects,
+and returns, relying on Kubernetes to delete the remaining child objects,
 like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
-the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
+the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
-deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
 to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
-composite resource.  The deletion of the claim suspends until the composite
-and all associated child resources have been deleted.
+parent resource. Kubernetes deletes all the dependent objects before deleting the
+composite resource. The deletion of the claim suspends until the composite
+and all associated child resources are deleted.
 
-The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
-the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
-
+When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
+the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.
 
 The default value is `defaultCompositeDeletePolicy: Background`. 
 

--- a/content/v1.13/concepts/composite-resource-definitions.md
+++ b/content/v1.13/concepts/composite-resource-definitions.md
@@ -631,17 +631,31 @@ XRDs can set default parameters for composite resources and Claims.
 <!-- vale off -->
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
-The `defaultCompositeDeletePolicy` defines the deletion policy for composite
-resources and claims. 
+The `defaultCompositeDeletePolicy` defines the default value for the claim's 
+`compositeDeletePolicy` property if the user does not specify a value when the
+claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
+the propagation policy when the controller deletes the associated composite.
+The `compositeDeletePolicy` does not apply to standalone composites that are created
+without claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy deletes 
-the composite resource or Claim and relies on Kubernetes to delete the remaining
-dependent objects, like managed resources or secrets. 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
+created with the default value `Background` for the `compositeDeletePolicy` property.
+When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+the claim controller deletes the composite resource using the propagation policy `background`
+and returns immediately, relying on Kubernetes to delete the remaining child objects,
+like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes Kubernetes to attach a
-`foregroundDeletion` finalizer to the composite resource or Claim. Kubernetes
-deletes all the dependent objects before deleting the composite resource or
-Claim. 
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
+the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+`compositeDeletePolicy` property set to `Foreground` the controller
+deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+to use foreground cascading deletion which ensures that all child resources are deleted before the
+parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
+composite resource.  The deletion of the claim suspends until the composite
+and all associated child resources have been deleted.
+
+The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
+the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
 
 The default value is `defaultCompositeDeletePolicy: Background`. 
 

--- a/content/v1.13/concepts/composite-resource-definitions.md
+++ b/content/v1.13/concepts/composite-resource-definitions.md
@@ -643,7 +643,7 @@ the default value `Background` for the `compositeDeletePolicy` property.
 When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
 and returns, relying on Kubernetes to delete the remaining child objects,
-like managed resources, nested composites, secrets, etc.
+like managed resources, nested composites and secrets.
 
 Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the

--- a/content/v1.13/concepts/composite-resource-definitions.md
+++ b/content/v1.13/concepts/composite-resource-definitions.md
@@ -635,7 +635,7 @@ The `defaultCompositeDeletePolicy` defines the default value for the claim's
 `compositeDeletePolicy` property if the user doesn't specify a value when creating
 the claim. The claim controller uses the `compositeDeletePolicy` property to specify
 the propagation policy when deleting the associated composite.
-The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+The `compositeDeletePolicy` doesn't apply to standalone composites that don't have
 associated claims.
 
 Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
@@ -649,10 +649,8 @@ Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
 deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
-to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource. Kubernetes deletes all the dependent objects before deleting the
-composite resource. The deletion of the claim suspends until the composite
-and all associated child resources are deleted.
+to use foreground cascading deletion which deletes all child resources before deleting the
+parent resource. The claim controller waits for the composite deletion to finish before returning.
 
 When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
 the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.

--- a/content/v1.13/concepts/composite-resource-definitions.md
+++ b/content/v1.13/concepts/composite-resource-definitions.md
@@ -632,30 +632,30 @@ XRDs can set default parameters for composite resources and Claims.
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
 The `defaultCompositeDeletePolicy` defines the default value for the claim's 
-`compositeDeletePolicy` property if the user does not specify a value when the
-claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
-the propagation policy when the controller deletes the associated composite.
-The `compositeDeletePolicy` does not apply to standalone composites that are created
-without claims.
+`compositeDeletePolicy` property if the user doesn't specify a value when creating
+the claim. The claim controller uses the `compositeDeletePolicy` property to specify
+the propagation policy when deleting the associated composite.
+The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+associated claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
-created with the default value `Background` for the `compositeDeletePolicy` property.
-When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
+the default value `Background` for the `compositeDeletePolicy` property.
+When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
-and returns immediately, relying on Kubernetes to delete the remaining child objects,
+and returns, relying on Kubernetes to delete the remaining child objects,
 like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
-the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
+the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
-deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
 to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
-composite resource.  The deletion of the claim suspends until the composite
-and all associated child resources have been deleted.
+parent resource. Kubernetes deletes all the dependent objects before deleting the
+composite resource. The deletion of the claim suspends until the composite
+and all associated child resources are deleted.
 
-The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
-the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
+When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
+the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.
 
 The default value is `defaultCompositeDeletePolicy: Background`. 
 

--- a/content/v1.14/concepts/composite-resource-definitions.md
+++ b/content/v1.14/concepts/composite-resource-definitions.md
@@ -627,30 +627,30 @@ XRDs can set default parameters for composite resources and Claims.
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
 The `defaultCompositeDeletePolicy` defines the default value for the claim's 
-`compositeDeletePolicy` property if the user does not specify a value when the
-claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
-the propagation policy when the controller deletes the associated composite.
-The `compositeDeletePolicy` does not apply to standalone composites that are created
-without claims.
+`compositeDeletePolicy` property if the user doesn't specify a value when creating
+the claim. The claim controller uses the `compositeDeletePolicy` property to specify
+the propagation policy when deleting the associated composite.
+The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+associated claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
-created with the default value `Background` for the `compositeDeletePolicy` property.
-When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
+the default value `Background` for the `compositeDeletePolicy` property.
+When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
-and returns immediately, relying on Kubernetes to delete the remaining child objects,
+and returns, relying on Kubernetes to delete the remaining child objects,
 like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
-the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
+the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
-deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
 to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
-composite resource.  The deletion of the claim suspends until the composite
-and all associated child resources have been deleted.
+parent resource. Kubernetes deletes all the dependent objects before deleting the
+composite resource. The deletion of the claim suspends until the composite
+and all associated child resources are deleted.
 
-The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
-the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
+When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
+the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.
 
 
 The default value is `defaultCompositeDeletePolicy: Background`. 

--- a/content/v1.14/concepts/composite-resource-definitions.md
+++ b/content/v1.14/concepts/composite-resource-definitions.md
@@ -630,7 +630,7 @@ The `defaultCompositeDeletePolicy` defines the default value for the claim's
 `compositeDeletePolicy` property if the user doesn't specify a value when creating
 the claim. The claim controller uses the `compositeDeletePolicy` property to specify
 the propagation policy when deleting the associated composite.
-The `compositeDeletePolicy` doesn't apply to standalone composites that do not have
+The `compositeDeletePolicy` doesn't apply to standalone composites that don't have
 associated claims.
 
 Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to have
@@ -644,10 +644,8 @@ Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the
 `compositeDeletePolicy` property set to `Foreground` the controller
 deletes the associated composite using the propagation policy `foreground`. This causes Kubernetes
-to use foreground cascading deletion which ensures that all child resources are deleted before the
-parent resource. Kubernetes deletes all the dependent objects before deleting the
-composite resource. The deletion of the claim suspends until the composite
-and all associated child resources are deleted.
+to use foreground cascading deletion which deletes all child resources before deleting the
+parent resource. The claim controller waits for the composite deletion to finish before returning.
 
 When creating a claim the user can override the `defaultCompositeDeletePolicy` by including
 the `spec.compositeDeletePolicy` property with either the `Background` or `Foreground` value.

--- a/content/v1.14/concepts/composite-resource-definitions.md
+++ b/content/v1.14/concepts/composite-resource-definitions.md
@@ -638,7 +638,7 @@ the default value `Background` for the `compositeDeletePolicy` property.
 When a deleted claim has the `compositeDeletePolicy` property set to `Background` 
 the claim controller deletes the composite resource using the propagation policy `background`
 and returns, relying on Kubernetes to delete the remaining child objects,
-like managed resources, nested composites, secrets, etc.
+like managed resources, nested composites and secrets.
 
 Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to have
 the `compositeDeletePolicy` default value `Foreground`. When a deleted claim has the

--- a/content/v1.14/concepts/composite-resource-definitions.md
+++ b/content/v1.14/concepts/composite-resource-definitions.md
@@ -626,17 +626,32 @@ XRDs can set default parameters for composite resources and Claims.
 <!-- vale off -->
 #### defaultCompositeDeletePolicy
 <!-- vale on -->
-The `defaultCompositeDeletePolicy` defines the deletion policy for composite
-resources and claims. 
+The `defaultCompositeDeletePolicy` defines the default value for the claim's 
+`compositeDeletePolicy` property if the user does not specify a value when the
+claim is created. The `compositeDeletePolicy` is used by the claim controller to specify
+the propagation policy when the controller deletes the associated composite.
+The `compositeDeletePolicy` does not apply to standalone composites that are created
+without claims.
 
-Using a `defaultCompositeDeletePolicy: Background` policy deletes 
-the composite resource or Claim and relies on Kubernetes to delete the remaining
-dependent objects, like managed resources or secrets. 
+Using a `defaultCompositeDeletePolicy: Background` policy causes the CRD for the claim to be
+created with the default value `Background` for the `compositeDeletePolicy` property.
+When a claim is deleted and has the `compositeDeletePolicy` property set to `Background` 
+the claim controller deletes the composite resource using the propagation policy `background`
+and returns immediately, relying on Kubernetes to delete the remaining child objects,
+like managed resources, nested composites, secrets, etc.
 
-Using `defaultCompositeDeletePolicy: Foreground` causes Kubernetes to attach a
-`foregroundDeletion` finalizer to the composite resource or Claim. Kubernetes
-deletes all the dependent objects before deleting the composite resource or
-Claim. 
+Using `defaultCompositeDeletePolicy: Foreground` causes the CRD for the claim to be created with
+the `compositeDeletePolicy` default value `Foreground`.  When a claim is deleted and has the
+`compositeDeletePolicy` property set to `Foreground` the controller
+deletes the associated composite using the propagation policy `foreground`.  This causes Kubernetes
+to use foreground cascading deletion which ensures that all child resources are deleted before the
+parent resource is deleted. Kubernetes deletes all the dependent objects before deleting the
+composite resource.  The deletion of the claim suspends until the composite
+and all associated child resources have been deleted.
+
+The user can override the `defaultCompositeDeletePolicy` when creating a claim by including
+the `spec.compositeDeletePolicy` attribute with either the `Background` or `Foreground` values.
+
 
 The default value is `defaultCompositeDeletePolicy: Background`. 
 


### PR DESCRIPTION
Updated the description of the `defaultCompositeDeletePolicy` property as a result of https://github.com/crossplane/crossplane/issues/5301

Also updated .gitignore to include the .idea directory created by PyCharm
