### PR TITLE
fix: Invalid inequality operator in ArgoCD custom health for ProviderConfig

### DIFF
--- a/content/knowledge-base/integrations/argo-cd-crossplane.md
+++ b/content/knowledge-base/integrations/argo-cd-crossplane.md
@@ -77,7 +77,7 @@ data:
         end
 
         if obj.status == nil or obj.status.conditions == nil then
-          if obj.kind == "ProviderConfig" and obj.status.users != nil then
+          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
             return health_status


### PR DESCRIPTION
Fixes mistake by #673. In Lua, the inequality operator is `~=` not `!=`. This caused an ArgoCD ComparisonError and sync failure.
```
error setting app health: failed to get resource health for "ProviderConfig" with name "azure" in namespace "": <string> line:27(column:56) near '!': Invalid token
```