### PR TITLE
Document the crossplane.io/external-create-... annotations

### DIFF
--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -678,8 +678,8 @@ the resource doesn't exist. When the provider thinks a resource doesn't exist
 it creates the resource.
 
 Some external systems don't let a provider specify a resource's name when the
-provider creates it. Instead the external system generates an unpredictable name
-and returns it to the provider.
+provider creates it. Instead the external system generates an nondeterministic
+name and returns it to the provider.
 
 When the external system generates the resource's name, it's critical that the
 provider saves it to the managed resource's `crossplane.io/external-name`

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -712,14 +712,6 @@ Events:
   Warning  CannotInitializeManagedResource  29m (x19 over 19h)  managed/queue.sqs.aws.crossplane.io  cannot determine creation result - remove the crossplane.io/external-create-pending annotation if it is safe to proceed
 ```
 
-{{<hint "important">}}
-The safest thing for a provider to do when it detects that it might have leaked
-a resource is to stop and wait for human intervention.
-
-This ensures the provider doesn't create duplicates of the leaked resource.
-Duplicate resources can be costly and dangerous.
-{{</hint>}}
-
 Providers use the creation annotations to detect that they might have leaked a
 resource.
 
@@ -738,6 +730,14 @@ The provider knows it might have leaked a resource because it updates all the
 resource's annotations at the same time. If the provider couldn't update the
 creation annotations after it created the resource, it also couldn't update the
 `crossplane.io/external-name` annotation.
+
+{{<hint "important">}}
+The safest thing for a provider to do when it detects that it might have leaked
+a resource is to stop and wait for human intervention.
+
+This ensures the provider doesn't create duplicates of the leaked resource.
+Duplicate resources can be costly and dangerous.
+{{</hint>}}
 
 {{<hint "tip">}}
 If a resource has a `cannot determine creation result` error, inspect the

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -740,8 +740,8 @@ creation annotations after it created the resource, it also couldn't update the
 `crossplane.io/external-name` annotation.
 
 {{<hint "tip">}}
-Inspect the external system when resources have a `cannot determine creation
-result` error.
+If a resource has a `cannot determine creation result` error, inspect the
+external system.
 
 Use the timestamp from the `crossplane.io/external-create-pending` annotation to
 determine when the provider might have leaked a resource. Look for resources

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -752,7 +752,7 @@ external system.
 
 Remove the `crossplane.io/external-create-pending` annotation from the managed
 resource after you're sure no leaked resource exists. This tells the provider to
-resume reconciliation of the managed resource.
+resume reconciliation of and recreate the managed resource.
 {{</hint>}}
 
 Providers also use the creation annotations to avoid leaking resources.

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -672,9 +672,9 @@ A provider uses the
 {{<hover label="creation" line="7">}}crossplane.io/external-name{{</hover>}}
 annotation to lookup a managed resource in an external system.
 
-If the provider can't find a managed resource in an external system, it thinks
-the resource doesn't exist. When the provider thinks a resource doesn't exist
-it creates the resource.
+The provider looks up the resource in the external system to determine if it
+exists, and if it matches the managed resource's desired state. If the provider
+can't find the resource, it creates it.
 
 Some external systems don't let a provider specify a resource's name when the
 provider creates it. Instead the external system generates an nondeterministic
@@ -688,14 +688,20 @@ A provider can't guarantee that it can save the annotation. The provider could
 restart or lose network connectivity between creating the resource and saving
 the annotation.
 
-{{<hint "important">}}
-Anytime an external system generates a resource's name there is a risk the
-provider could leak the resource.
-{{</hint>}}
-
 A provider can detect that it might have leaked a resource. If the provider
 thinks it might have leaked a resource, it stops reconciling it until you tell
 the provider it's safe to proceed.
+
+{{<hint "important">}}
+Anytime an external system generates a resource's name there is a risk the
+provider could leak the resource.
+
+The safest thing for a provider to do when it detects that it might have leaked
+a resource is to stop and wait for human intervention.
+
+This ensures the provider doesn't create duplicates of the leaked resource.
+Duplicate resources can be costly and dangerous.
+{{</hint>}}
 
 When a provider thinks it might have leaked a resource it creates a `cannot
 determine creation result` event associated with the managed resource. Use
@@ -730,14 +736,6 @@ The provider knows it might have leaked a resource because it updates all the
 resource's annotations at the same time. If the provider couldn't update the
 creation annotations after it created the resource, it also couldn't update the
 `crossplane.io/external-name` annotation.
-
-{{<hint "important">}}
-The safest thing for a provider to do when it detects that it might have leaked
-a resource is to stop and wait for human intervention.
-
-This ensures the provider doesn't create duplicates of the leaked resource.
-Duplicate resources can be costly and dangerous.
-{{</hint>}}
 
 {{<hint "tip">}}
 If a resource has a `cannot determine creation result` error, inspect the

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -653,7 +653,6 @@ Providers set three creation annotations to avoid and detect leaked resources:
 * `crossplane.io/external-create-failed` - The last time the provider failed to
   create the resource.
 
-
 Use `kubectl get` to view the annotations on a managed resource. For example, an
 AWS VPC resource:
 
@@ -681,9 +680,9 @@ Some external systems don't let a provider specify a resource's name when the
 provider creates it. Instead the external system generates an nondeterministic
 name and returns it to the provider.
 
-When the external system generates the resource's name, it's critical that the
-provider saves it to the managed resource's `crossplane.io/external-name`
-annotation. If it doesn't, it leaks the resource.
+When the external system generates the resource's name, the provider attempts to
+save it to the managed resource's `crossplane.io/external-name` annotation. If
+it doesn't, it _leaks_ the resource.
 
 A provider can't guarantee that it can save the annotation. The provider could
 restart or lose network connectivity between creating the resource and saving

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -658,7 +658,7 @@ Use `kubectl get` to view the annotations on a managed resource. For example, an
 AWS VPC resource:
 
 ```yaml {label="creation" copy-lines="2-9"}
-$ kubectl get vpc my-vpc
+$ kubectl get -o yaml vpc my-vpc
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPC
 metadata:

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -635,7 +635,8 @@ my-rds-instance      True    True     my-custom-name       11m
 
 ### Creation annotations
 
-In some rare situations a provider can forget that it created a resource. When
+When an external system like AWS generates nondeterministic resource names it's
+possible for a provider to create a resource but not record that it did. When
 this happens the provider can't manage the resource.
 
 {{<hint "tip">}}

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -671,7 +671,7 @@ metadata:
 
 A provider uses the
 {{<hover label="creation" line="7">}}crossplane.io/external-name{{</hover>}}
-annotation to find a resource in an external system, for example AWS.
+annotation to lookup a managed resource in an external system.
 
 If the provider can't find a managed resource in an external system, it thinks
 the resource doesn't exist. When the provider thinks a resource doesn't exist


### PR DESCRIPTION
These annotations were introduced in https://github.com/crossplane/crossplane-runtime/pull/283.

Per https://github.com/crossplane/crossplane/issues/3037 folks find these annotations hard to reason about. That's understandable, because they're doing a lot of subtle things.

This section ended up super long, but I think this is an area where folks really need to understand what's happening in order to make good decisions when Crossplane refuses to proceed.