### PR TITLE
Remove false restriction about using '.status.atProvider' into ToEnvironmentFieldPath

### DIFF
--- a/content/master/concepts/patch-and-transform.md
+++ b/content/master/concepts/patch-and-transform.md
@@ -827,15 +827,6 @@ kind: Composition
 Because the environment is in-memory, there is no command to confirm the patch
 wrote the value to the environment.
 
-{{<hint "important">}}
-The 
-{{<hover label="toEnvField" line="12">}}ToEnvironmentFieldPath{{</hover>}}
-patch happens **before** creating a resource.  
-The 
-{{<hover label="toEnvField" line="13">}}fromFieldPath{{</hover>}} can't
-read from the `atProvider` or `Status` fields.
-{{< /hint >}}
-
 
 <!-- vale Google.Headings = NO -->
 ### CombineFromEnvironment

--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -827,15 +827,6 @@ kind: Composition
 Because the environment is in-memory, there is no command to confirm the patch
 wrote the value to the environment.
 
-{{<hint "important">}}
-The 
-{{<hover label="toEnvField" line="12">}}ToEnvironmentFieldPath{{</hover>}}
-patch happens **before** creating a resource.  
-The 
-{{<hover label="toEnvField" line="13">}}fromFieldPath{{</hover>}} can't
-read from the `atProvider` or `Status` fields.
-{{< /hint >}}
-
 
 <!-- vale Google.Headings = NO -->
 ### CombineFromEnvironment

--- a/content/v1.14/concepts/patch-and-transform.md
+++ b/content/v1.14/concepts/patch-and-transform.md
@@ -827,15 +827,6 @@ kind: Composition
 Because the environment is in-memory, there is no command to confirm the patch
 wrote the value to the environment.
 
-{{<hint "important">}}
-The 
-{{<hover label="toEnvField" line="12">}}ToEnvironmentFieldPath{{</hover>}}
-patch happens **before** creating a resource.  
-The 
-{{<hover label="toEnvField" line="13">}}fromFieldPath{{</hover>}} can't
-read from the `atProvider` or `Status` fields.
-{{< /hint >}}
-
 
 <!-- vale Google.Headings = NO -->
 ### CombineFromEnvironment


### PR DESCRIPTION
As confirmed @phisco in [Slack](https://crossplane.slack.com/archives/CEG3T90A1/p1706970216073849?thread_ts=1706970216.073849&cid=CEG3T90A1), the 'patch and transform' documentation is wrong about the impossibility to use data from `.status.atProvider` in the `fromFielPath` of the `ToEnvironmentFieldPath` patch.

This restriction is incompatible with the example in the `EnvironmentConfig` page that shows it is :
 ```
patches:
- type: ToEnvironmentFieldPath
   fromFieldPath: status.atProvider.id
   toFieldPath: vpcId
```
https://docs.crossplane.io/latest/concepts/environment-configs/#patch-an-individual-resource