### PR TITLE
Fix composite functions "annotations" key

### DIFF
--- a/content/master/concepts/composition-functions.md
+++ b/content/master/concepts/composition-functions.md
@@ -332,7 +332,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-patch-and-transform
-  annotation:
+  annotations:
     render.crossplane.io/runtime: Development
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4

--- a/content/v1.14/concepts/composition-functions.md
+++ b/content/v1.14/concepts/composition-functions.md
@@ -332,7 +332,7 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-patch-and-transform
-  annotation:
+  annotations:
     render.crossplane.io/runtime: Development
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4


### PR DESCRIPTION
The annotations are expected to be under the "annotations" key. Currently, the docs instruct user to use "annotation".

Copy pasting the example won't work. This can be quite confusing as the user will continue to see function containers spin-up and the local function instance ignored.