### PR TITLE
Fix table colors in dark mode

### DIFF
--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -120,6 +120,9 @@ h3, h4, h5, h6 {
 
 .table-responsive {
   margin-bottom: 1rem;
+  border: 1px solid #{$fog-200};
+  background-color: var(--body-background) !important;
+  color: var(--body-font-color);
 }
 
 // Hide bottom borders and wider padding for header items
@@ -137,6 +140,7 @@ h3, h4, h5, h6 {
   padding-right: 24px;
   padding-top: 12px;
   padding-bottom: 12px;
+  border-top: 1px solid #{$fog-300};
 }
 // Decrease padding for small tables
 .table.table-sm th {
@@ -152,17 +156,14 @@ h3, h4, h5, h6 {
   padding-bottom: 8px;
 }
 
+.table a{
+  color: var(--content-link-color);
+}
 
 // Color theme toggle
 .form-check-input:checked {
   background-color: #{$aqua-700};
   border-color: #{$aqua-700};
-}
-
-.table {
-  color: var(--font-body-color);
-  // Override bootstrap defaults to support dark mode
-  --bs-table-hover-color: var(--font-body-color);
 }
 
 .ga-tag{

--- a/themes/geekboot/assets/scss/_content.scss
+++ b/themes/geekboot/assets/scss/_content.scss
@@ -115,7 +115,13 @@ h3, h4, h5, h6 {
   border-radius: 6px;
   border-collapse: separate;
   border-spacing: 0px;
+  margin-bottom: 0px !important;
 }
+
+.table-responsive {
+  margin-bottom: 1rem;
+}
+
 // Hide bottom borders and wider padding for header items
 .table th {
   border-bottom: none;

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -107,33 +107,18 @@
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
     }
 
-    // This is the selector bootstrap uses for table styling
-    .table :not(caption) > * > * {
-        background-color: var(--body-background) !important;
+    .table {
+        --bs-table-bg: var(--body-background);
+        --bs-table-color-state: var(--body-font-color);
+        --bs-table-striped-color: #{$fog-800};
+        --bs-table-striped-bg: #{$fog-800};
+    }
+
+    .table-hover > tbody > tr:hover > * {
+        background-color: #{$fog-700};
         color: var(--body-font-color);
     }
 
-    .table td {
-        border-top: 1px solid #{$fog-200};
-    }
-
-    .table-responsive {
-        border: 1px solid #{$fog-200};
-    }
-
-    .table td {
-        border-top: 1px solid #{$fog-300};
-    }
-
-    // Dark stripe
-    .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
-        background-color: #{$fog-500} !important;
-    }
-
-    // Light stripe
-    .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
-        background-color: #{$fog-800} !important;
-    }
 
     // Add border to top nav and footer
     .docs-navbar {

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -115,10 +115,13 @@
         border: 1px solid #{$fog-700};
         --bs-table-hover-bg: #{$fog-100};
     }
+
+    // grey stripe
     .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
         --bs-table-accent-bg: #{$fog-950};
-        color: #{$fog-0};
     }
+
+    // white stripe
     .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
         --bs-table-hover-bg: #{$fog-1000} !important;
     }
@@ -152,11 +155,6 @@
                 color: #{$fog-0};
             }
         }
-    }
-
-    //Striped table font color
-    .table-striped-columns > :not(caption) > tr > :nth-child(even){
-        color: inherit !important;
     }
 }
 

--- a/themes/geekboot/assets/scss/dark-mode.scss
+++ b/themes/geekboot/assets/scss/dark-mode.scss
@@ -107,23 +107,32 @@
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e") !important;
     }
 
-    // Tables
+    // This is the selector bootstrap uses for table styling
+    .table :not(caption) > * > * {
+        background-color: var(--body-background) !important;
+        color: var(--body-font-color);
+    }
+
     .table td {
-        border-top: 1px solid #{$fog-700};
-    }
-    .table {
-        border: 1px solid #{$fog-700};
-        --bs-table-hover-bg: #{$fog-100};
+        border-top: 1px solid #{$fog-200};
     }
 
-    // grey stripe
+    .table-responsive {
+        border: 1px solid #{$fog-200};
+    }
+
+    .table td {
+        border-top: 1px solid #{$fog-300};
+    }
+
+    // Dark stripe
     .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
-        --bs-table-accent-bg: #{$fog-950};
+        background-color: #{$fog-500} !important;
     }
 
-    // white stripe
+    // Light stripe
     .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
-        --bs-table-hover-bg: #{$fog-1000} !important;
+        background-color: #{$fog-800} !important;
     }
 
     // Add border to top nav and footer

--- a/themes/geekboot/assets/scss/light-mode.scss
+++ b/themes/geekboot/assets/scss/light-mode.scss
@@ -118,16 +118,19 @@
     .table td {
         border-top: 1px solid #{$fog-200};
     }
-    .table {
+
+    .table-responsive {
         border: 1px solid #{$fog-200};
-        --bs-table-hover-bg: #{$fog-0};
     }
+
+    // Dark Stripe
     .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
-        --bs-table-accent-bg: #{$fog-50};
-        color: #{$fog-1000};
+        background-color: #{$fog-50} !important;
     }
+
+    // Light Stripe
     .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
-        --bs-table-hover-bg: #{$fog-0} !important;
+
     }
 
     // Tab Colors

--- a/themes/geekboot/assets/scss/light-mode.scss
+++ b/themes/geekboot/assets/scss/light-mode.scss
@@ -115,22 +115,16 @@
     }
 
     // Tables
-    .table td {
-        border-top: 1px solid #{$fog-200};
+    .table {
+        --bs-table-bg: var(--body-background);
+        --bs-table-color-state: var(--body-font-color);
+        --bs-table-striped-color: #{$fog-50};
+        --bs-table-striped-bg: #{$fog-50};
     }
 
-    .table-responsive {
-        border: 1px solid #{$fog-200};
-    }
-
-    // Dark Stripe
-    .table-striped > tbody > tr:nth-of-type(odd) > *, .table-striped-columns > :not(caption) > tr > :nth-child(even) {
-        background-color: #{$fog-50} !important;
-    }
-
-    // Light Stripe
-    .table-striped > tbody > tr:nth-of-type(even) > *, .table-striped-columns > :not(caption) > tr > :nth-child(odd) {
-
+    .table-hover > tbody > tr:hover > * {
+        background-color: #{$fog-50};
+        color: var(--body-font-color);
     }
 
     // Tab Colors

--- a/themes/geekboot/layouts/shortcodes/table.html
+++ b/themes/geekboot/layouts/shortcodes/table.html
@@ -1,8 +1,8 @@
 {{ $htmlTable := .Inner | markdownify }}
 {{ $old := "<table>" }}
 {{ $class := .Get 0 | default "table"}}
-{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $new := printf "<table class=\"%s \">" $class }}
 {{ $htmlTable := replace $htmlTable $old $new }}
-<div class="table-responsive">
+<div class="table-responsive border rounded">
 {{ $htmlTable | safeHTML }}
 </div>


### PR DESCRIPTION
Fixes the coloring for tables in dark mode. 

Examples of rendered tables:
* https://deploy-preview-700--crossplane.netlify.app/contribute/features/#tables
* https://deploy-preview-700--crossplane.netlify.app/v1.14/software/install/#customize-the-crossplane-helm-chart (expand the "All Crossplane customization options" folded section)
* https://deploy-preview-700--crossplane.netlify.app/v1.14/concepts/patch-and-transform/#types-of-patches

This addresses tables for light and dark mode as well as striped, hover and standard tables. 

Resolves #690.
