### PR TITLE
add `init` --ref-name flag

### DIFF
--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -622,7 +622,8 @@ personalize the template.
 | Short flag   | Long flag               | Description                                                                                      |
 | ------------ | ----------------------- | ------------------------------                                                                   |
 | `-d`         | `--directory`           | The directory to create and load the template files into. Uses the current directory by default. |
-| `-r`         | `--run-init-script`     | Run the init.sh script without prompting, if it exists.                                                        |
+| `-r`         | `--run-init-script`     | Run the init.sh script without prompting, if it exists.                                          |
+| `-b`         | `--ref-name`            | The branch or tag to clone from the template repository.                                         |
 <!-- vale Crossplane.Spelling = YES -->
 {{< /table >}}
 


### PR DESCRIPTION
Adds the `init --ref-name` [flag](https://github.com/crossplane/crossplane/pull/5391) to docs.