### PR TITLE
remove incorrect restriction about envkeys in patches

### DIFF
--- a/content/v1.13/concepts/patch-and-transform.md
+++ b/content/v1.13/concepts/patch-and-transform.md
@@ -964,10 +964,6 @@ strings.
 The {{<hover label="combineToEnv" line="20">}}toFieldPath{{</hover>}} is the
 key in the environment to write the new string to. 
 
-{{< hint "important" >}}
-The environment's key must already exist. Patches can't create new environment
-keys. 
-{{< /hint >}}
 
 ```yaml {label="combineToEnv",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1

--- a/content/v1.14/concepts/patch-and-transform.md
+++ b/content/v1.14/concepts/patch-and-transform.md
@@ -964,10 +964,6 @@ strings.
 The {{<hover label="combineToEnv" line="20">}}toFieldPath{{</hover>}} is the
 key in the environment to write the new string to. 
 
-{{< hint "important" >}}
-The environment's key must already exist. Patches can't create new environment
-keys. 
-{{< /hint >}}
 
 ```yaml {label="combineToEnv",copy-lines="none"}
 apiVersion: apiextensions.crossplane.io/v1


### PR DESCRIPTION
In #549 we removed references that envkeys had to exist before a patch, but missed some references. This should clean up the remaining references.