### PR TITLE
Don't say composition revisions are beta

### DIFF
--- a/content/knowledge-base/guides/composition-revisions-example.md
+++ b/content/knowledge-base/guides/composition-revisions-example.md
@@ -1,8 +1,5 @@
 ---
 title: Composition Revision Example
-state: beta
-alphaVersion: "1.4"
-betaVersion: "1.11"
 ---
 This tutorial discusses how CompositionRevisions work and how they manage Composite Resource
 (XR) updates. This starts with a `Composition` and `CompositeResourceDefinition` (XRD) that defines a `MyVPC`

--- a/content/knowledge-base/guides/composition-revisions.md
+++ b/content/knowledge-base/guides/composition-revisions.md
@@ -1,8 +1,5 @@
 ---
 title: Composition Revisions
-state: beta
-alphaVersion: "1.4"
-betaVersion: "1.11"
 ---
 
 This guide discusses the use of "Composition Revisions" to safely make and roll

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -244,7 +244,6 @@ at the table below.
 {{< table caption="Feature flags" >}}
 | Status | Flag | Description |
 | --- | --- | --- |
-| Beta | `--enable-composition-revisions` | Enable support for CompositionRevisions. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
 | Alpha | `--enable-composition-functions` | Enable support for Composition Functions. |
 | Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |


### PR DESCRIPTION
Relates to https://github.com/crossplane/docs/issues/709. I don't think it's a complete 'fix'.

Revisions became GA in v1.12 per https://github.com/crossplane/crossplane/issues/3715. I think there's more to do to integrate them into the main docs flow as a GA feature, but at minimum let's stop actively saying they're beta.

When the feature became GA, we:

* Made it impossible to disable the feature using the flag.
* Hid the feature flag from the help output.
* Log a warning that the flag will be removed if it is passed.