### PR TITLE
shortcode to have checkmark emoji use the body font color

### DIFF
--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -365,15 +365,15 @@ The following is a list of common policy combinations:
 {{<table "table table-sm table-hover table-striped-columns" >}}
 | Create | Delete | LateInitialize | Observe | Update | Description |
 | :---:  | :---:  | :---:          | :---:   | :---:  | ---         |
-| ✔️      | ✔️      | ✔️              | ✔️       | ✔️      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
-| ✔️      | ✔️      | ✔️              | ✔️       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
-| ✔️      | ✔️      |                | ✔️       | ✔️      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
-| ✔️      | ✔️      |                | ✔️       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
-| ✔️      |        | ✔️              | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. |
-| ✔️      |        | ✔️              | ✔️       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
-| ✔️      |        |                | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
-| ✔️      |        |                | ✔️       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
-|        |        |                | ✔️       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       | {{<check>}}      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       | {{<check>}}      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
+| {{<check>}}      |        |                | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
+| {{<check>}}      |        |                | {{<check>}}       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
+|        |        |                | {{<check>}}       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
 |        |        |                |         |        | No policy set. An alternative method for [pausing](#paused) a resource.                                                                                              |
 {{< /table >}}
 

--- a/content/v1.13/concepts/managed-resources.md
+++ b/content/v1.13/concepts/managed-resources.md
@@ -380,15 +380,15 @@ The following is a list of common policy combinations:
 {{<table "table table-sm table-hover table-striped-columns" >}}
 | Create | Delete | LateInitialize | Observe | Update | Description |
 | :---:  | :---:  | :---:          | :---:   | :---:  | ---         |
-| ✔️      | ✔️      | ✔️              | ✔️       | ✔️      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
-| ✔️      | ✔️      | ✔️              | ✔️       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
-| ✔️      | ✔️      |                | ✔️       | ✔️      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
-| ✔️      | ✔️      |                | ✔️       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
-| ✔️      |        | ✔️              | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. |
-| ✔️      |        | ✔️              | ✔️       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
-| ✔️      |        |                | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
-| ✔️      |        |                | ✔️       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
-|        |        |                | ✔️       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       | {{<check>}}      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       | {{<check>}}      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
+| {{<check>}}      |        |                | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
+| {{<check>}}      |        |                | {{<check>}}       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
+|        |        |                | {{<check>}}       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
 |        |        |                |         |        | No policy set. An alternative method for [pausing](#paused) a resource.                                                                                              |
 {{< /table >}}
 

--- a/content/v1.14/concepts/managed-resources.md
+++ b/content/v1.14/concepts/managed-resources.md
@@ -365,15 +365,15 @@ The following is a list of common policy combinations:
 {{<table "table table-sm table-hover table-striped-columns" >}}
 | Create | Delete | LateInitialize | Observe | Update | Description |
 | :---:  | :---:  | :---:          | :---:   | :---:  | ---         |
-| ✔️      | ✔️      | ✔️              | ✔️       | ✔️      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
-| ✔️      | ✔️      | ✔️              | ✔️       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
-| ✔️      | ✔️      |                | ✔️       | ✔️      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
-| ✔️      | ✔️      |                | ✔️       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
-| ✔️      |        | ✔️              | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. |
-| ✔️      |        | ✔️              | ✔️       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
-| ✔️      |        |                | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
-| ✔️      |        |                | ✔️       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
-|        |        |                | ✔️       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       | {{<check>}}      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       | {{<check>}}      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
+| {{<check>}}      |        |                | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
+| {{<check>}}      |        |                | {{<check>}}       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
+|        |        |                | {{<check>}}       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
 |        |        |                |         |        | No policy set. An alternative method for [pausing](#paused) a resource.                                                                                              |
 {{< /table >}}
 

--- a/content/v1.15/concepts/managed-resources.md
+++ b/content/v1.15/concepts/managed-resources.md
@@ -365,15 +365,15 @@ The following is a list of common policy combinations:
 {{<table "table table-sm table-hover table-striped-columns" >}}
 | Create | Delete | LateInitialize | Observe | Update | Description |
 | :---:  | :---:  | :---:          | :---:   | :---:  | ---         |
-| ✔️      | ✔️      | ✔️              | ✔️       | ✔️      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
-| ✔️      | ✔️      | ✔️              | ✔️       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
-| ✔️      | ✔️      |                | ✔️       | ✔️      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
-| ✔️      | ✔️      |                | ✔️       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
-| ✔️      |        | ✔️              | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. |
-| ✔️      |        | ✔️              | ✔️       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
-| ✔️      |        |                | ✔️       | ✔️      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
-| ✔️      |        |                | ✔️       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
-|        |        |                | ✔️       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       | {{<check>}}      | _Default policy_. Crossplane has full control over the resource.                                                                                                     |
+| {{<check>}}      | {{<check>}}      | {{<check>}}              | {{<check>}}       |        | After creation any changes made to the managed resource aren't passed to the external resource. Useful for immutable external resources. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       | {{<check>}}      | Prevent Crossplane from managing any settings not defined in the managed resource. Useful for immutable fields in an external resource. |
+| {{<check>}}      | {{<check>}}      |                | {{<check>}}       |        | Crossplane doesn't import any settings from the external resource and doesn't push changes to the managed resource. Crossplane recreates the external resource if it's deleted. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. |
+| {{<check>}}      |        | {{<check>}}              | {{<check>}}       |        | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't apply changes to the external resource after creation. |
+| {{<check>}}      |        |                | {{<check>}}       | {{<check>}}      | Crossplane doesn't delete the external resource when deleting the managed resource. Crossplane doesn't import any settings from the external resource. |
+| {{<check>}}      |        |                | {{<check>}}       |        | Crossplane creates the external resource but doesn't apply any changes to the external resource or managed resource. Crossplane can't delete the resource. |
+|        |        |                | {{<check>}}       |        | Crossplane only observes a resource. Used for [observe only resources]({{<ref "/knowledge-base/guides/import-existing-resources#import-resources-automatically">}}). |
 |        |        |                |         |        | No policy set. An alternative method for [pausing](#paused) a resource.                                                                                              |
 {{< /table >}}
 

--- a/themes/geekboot/layouts/shortcodes/check.html
+++ b/themes/geekboot/layouts/shortcodes/check.html
@@ -1,0 +1,1 @@
+<div style="color: transparent;text-shadow: 0 0 0 var(--body-font-color);">✔️</span>


### PR DESCRIPTION
Creates a shortcode that inserts a ✔️ with a CSS style to set the color of the emoji to the same as the body font color. This makes ✔️ black in light mode and white in dark mode.

The only place we use the ✔️ is in the table for MR management policies:
https://deploy-preview-714--crossplane.netlify.app/v1.15/concepts/managed-resources/#managementpolicies

Resolves #523 

Signed-off-by: Pete Lumbis <pete@upbound.io>