### PR TITLE
add links to provider auth docs and upgrade AWS to 1.1.0

### DIFF
--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:1.1.0
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:1.1.0
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0   3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0         13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0     13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:1.1.0     3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0           13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0       13m
 ```
 
 ## Create a custom API

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.1.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0
 EOF
 ```
 

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -5,7 +5,7 @@ weight: 100
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
 with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws/v0.37.0).
+[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.1.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0       97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0   88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.47.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -106,9 +106,9 @@ az ad sp create-for-rbac \
 Save your Azure JSON output as `azure-credentials.json`.
 
 {{< hint type="note" >}}
-The Azure Provider 
-[Authentication documentation](https://github.com/upbound/provider-azure/blob/main/AUTHENTICATION.md)
-describes other authentication methods.
+The
+[Authentication](https://docs.upbound.io/providers/provider-azure/authentication/) 
+section of the Azure Provider documentation describes other authentication methods.
 {{< /hint >}}
 
 ### Create a Kubernetes secret with the Azure credentials

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -129,6 +129,12 @@ Data
 creds:  2330 bytes
 ```
 
+{{< hint type="note" >}}
+The
+[Authentication](https://docs.upbound.io/providers/provider-gcp/authentication/) 
+section of the GCP Provider documentation describes other authentication methods.
+{{< /hint >}}
+
 ## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the GCP Provider.  
 

--- a/content/v1.14/getting-started/provider-azure.md
+++ b/content/v1.14/getting-started/provider-azure.md
@@ -106,9 +106,9 @@ az ad sp create-for-rbac \
 Save your Azure JSON output as `azure-credentials.json`.
 
 {{< hint type="note" >}}
-The Azure Provider 
-[Authentication documentation](https://github.com/upbound/provider-azure/blob/main/AUTHENTICATION.md)
-describes other authentication methods.
+The
+[Authentication](https://docs.upbound.io/providers/provider-azure/authentication/) 
+section of the Azure Provider documentation describes other authentication methods.
 {{< /hint >}}
 
 ### Create a Kubernetes secret with the Azure credentials

--- a/content/v1.14/getting-started/provider-gcp.md
+++ b/content/v1.14/getting-started/provider-gcp.md
@@ -129,6 +129,12 @@ Data
 creds:  2330 bytes
 ```
 
+{{< hint type="note" >}}
+The
+[Authentication](https://docs.upbound.io/providers/provider-gcp/authentication/) 
+section of the GCP Provider documentation describes other authentication methods.
+{{< /hint >}}
+
 ## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the GCP Provider.  
 

--- a/content/v1.15/getting-started/provider-aws-part-2.md
+++ b/content/v1.15/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:1.1.0
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:1.1.0
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v0.47.0   3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0         13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0     13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:1.1.0     3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0           13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0       13m
 ```
 
 ## Create a custom API

--- a/content/v1.15/getting-started/provider-aws.md
+++ b/content/v1.15/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.1.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0
 EOF
 ```
 

--- a/content/v1.15/getting-started/provider-aws.md
+++ b/content/v1.15/getting-started/provider-aws.md
@@ -5,7 +5,7 @@ weight: 100
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
 with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws/v0.37.0).
+[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v0.1.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v0.47.0       97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v0.47.0   88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.47.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS

--- a/content/v1.15/getting-started/provider-azure.md
+++ b/content/v1.15/getting-started/provider-azure.md
@@ -106,9 +106,9 @@ az ad sp create-for-rbac \
 Save your Azure JSON output as `azure-credentials.json`.
 
 {{< hint type="note" >}}
-The Azure Provider 
-[Authentication documentation](https://github.com/upbound/provider-azure/blob/main/AUTHENTICATION.md)
-describes other authentication methods.
+The
+[Authentication](https://docs.upbound.io/providers/provider-azure/authentication/) 
+section of the Azure Provider documentation describes other authentication methods.
 {{< /hint >}}
 
 ### Create a Kubernetes secret with the Azure credentials

--- a/content/v1.15/getting-started/provider-gcp.md
+++ b/content/v1.15/getting-started/provider-gcp.md
@@ -129,6 +129,12 @@ Data
 creds:  2330 bytes
 ```
 
+{{< hint type="note" >}}
+The
+[Authentication](https://docs.upbound.io/providers/provider-gcp/authentication/) 
+section of the GCP Provider documentation describes other authentication methods.
+{{< /hint >}}
+
 ## Create a ProviderConfig
 A `ProviderConfig` customizes the settings of the GCP Provider.  
 


### PR DESCRIPTION
Adds links to the docs.upbound.io authentication docs for each provider.

For v1.15 and master this also upgrades provider AWS to v1..1.0

Resolves #533

Signed-off-by: Pete Lumbis <pete@upbound.io>