### PR TITLE
Add a callout that paused resources can't be deleted

### DIFF
--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -802,6 +802,15 @@ spec:
 
 Remove the annotation to resume reconciliation.
 
+{{<hint "important">}}
+Kubernetes and Crossplane can't delete resources with a `paused` annotation,
+even with `kubectl delete`. 
+
+Read 
+[Crossplane discussion #4839](https://github.com/crossplane/crossplane/issues/4839) 
+for more details.
+{{< /hint >}}
+
 ## Finalizers
 Crossplane applies a 
 [Finalizer](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)

--- a/content/v1.14/concepts/managed-resources.md
+++ b/content/v1.14/concepts/managed-resources.md
@@ -681,6 +681,15 @@ spec:
 
 Remove the annotation to resume reconciliation.
 
+{{<hint "important">}}
+Kubernetes and Crossplane can't delete resources with a `paused` annotation,
+even with `kubectl delete`. 
+
+Read 
+[Crossplane discussion #4839](https://github.com/crossplane/crossplane/issues/4839) 
+for more details.
+{{< /hint >}}
+
 ## Finalizers
 Crossplane applies a 
 [Finalizer](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)

--- a/content/v1.15/concepts/managed-resources.md
+++ b/content/v1.15/concepts/managed-resources.md
@@ -802,6 +802,15 @@ spec:
 
 Remove the annotation to resume reconciliation.
 
+{{<hint "important">}}
+Kubernetes and Crossplane can't delete resources with a `paused` annotation,
+even with `kubectl delete`. 
+
+Read 
+[Crossplane discussion #4839](https://github.com/crossplane/crossplane/issues/4839) 
+for more details.
+{{< /hint >}}
+
 ## Finalizers
 Crossplane applies a 
 [Finalizer](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)


### PR DESCRIPTION
Adds a note that managed resources with a pause annotation can't be deleted.

Resolves #573