### PR TITLE
Fix mermaid diagrams in light/dark mode

### DIFF
--- a/themes/geekboot/assets/scss/_mermaid.scss
+++ b/themes/geekboot/assets/scss/_mermaid.scss
@@ -1,0 +1,14 @@
+.mermaid{
+    fill: var(--body-font-color) !important;
+
+    .messageText, .loopText>tspan, .marker, .marker.cross{
+        color: var(--body-font-color) !important;
+        fill: var(--body-font-color) !important;
+    }
+
+    .flowchart-link{
+        stroke: var(--body-font-color) !important;
+    }
+
+
+}

--- a/themes/geekboot/assets/scss/docs.scss
+++ b/themes/geekboot/assets/scss/docs.scss
@@ -50,3 +50,4 @@
 /* purgecss end ignore */
 @import "skippy";
 @import "fonts";
+@import "mermaid";


### PR DESCRIPTION
Mermaid diagrams were introduced in around the 1.14 docs release and have had display issues since day-1.

This fixes the (current) problems with mermaid diagrams displaying in both light and dark mode. Using the two examples we have today

Light:
![Screenshot 2024-02-16 at 4 20 55 PM](https://github.com/crossplane/docs/assets/10537576/5af5c71e-9e3c-4031-bf5d-d037fdeb5190)
![Screenshot 2024-02-16 at 4 20 43 PM](https://github.com/crossplane/docs/assets/10537576/2905b760-5b58-4594-a374-8c7745ba63dc)


Dark:
![Screenshot 2024-02-16 at 4 20 39 PM](https://github.com/crossplane/docs/assets/10537576/4ed2c79e-a00a-47dc-a0ff-3408f6550ae9)
![Screenshot 2024-02-16 at 4 20 34 PM](https://github.com/crossplane/docs/assets/10537576/294be71c-d84f-4899-848d-e5cbede6abb6)

Additional styles can be added if there are display problems in the future

Resolves #592

Signed-off-by: Pete Lumbis <pete@upbound.io>