### PR TITLE
corrects xpkg build output flag. 

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -475,14 +475,14 @@ metadata:
 # Removed for brevity
 ```
 
-Specify the output file with `--output=<filename>.xpkg` option.
+Specify the output file with `--package-file=<filename>.xpkg` option.
 
 For example, to build a package from a directory named `test-directory` and
 generate a package named `test-package.xpkg` in the current working directory,
 use the command:
 
 ```shell
-crossplane xpkg build --package-root=test-directory --output=test-package.xpkg
+crossplane xpkg build --package-root=test-directory --package-file=test-package.xpkg
 ```
 
 ```shell

--- a/content/v1.14/concepts/packages.md
+++ b/content/v1.14/concepts/packages.md
@@ -466,14 +466,14 @@ metadata:
 # Removed for brevity
 ```
 
-Specify the output file with `--output=<filename>.xpkg` option.
+Specify the output file with `--package-file=<filename>.xpkg` option.
 
 For example, to build a package from a directory named `test-directory` and
 generate a package named `test-package.xpkg` in the current working directory,
 use the command:
 
 ```shell
-crossplane xpkg build --package-root=test-directory --output=test-package.xpkg
+crossplane xpkg build --package-root=test-directory --package-file=test-package.xpkg
 ```
 
 ```shell

--- a/content/v1.15/concepts/packages.md
+++ b/content/v1.15/concepts/packages.md
@@ -475,14 +475,14 @@ metadata:
 # Removed for brevity
 ```
 
-Specify the output file with `--output=<filename>.xpkg` option.
+Specify the output file with `--package-file=<filename>.xpkg` option.
 
 For example, to build a package from a directory named `test-directory` and
 generate a package named `test-package.xpkg` in the current working directory,
 use the command:
 
 ```shell
-crossplane xpkg build --package-root=test-directory --output=test-package.xpkg
+crossplane xpkg build --package-root=test-directory --package-file=test-package.xpkg
 ```
 
 ```shell


### PR DESCRIPTION
The flag in `xpkg build` was changed from `--output` to `--package-file` and was missed in the Packages concept doc. 

These are the only three places that `--output` was missed.

Resolves #689