### PR TITLE
add upgrade guides

### DIFF
--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -11,13 +11,13 @@ The recommended upgrade method for an existing Crossplane install is to use
  
 
 ## Add the Crossplane Helm repository
-Verify Helm has the Crossplane repositry.
+Verify Helm has the Crossplane repository.
 
 ```shell
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 ```
 
-## Update the Helm repositry
+## Update the Helm repository
 
 Update the local Crossplane Helm chart with `helm repo update`.
 
@@ -32,8 +32,8 @@ available in the locally cached Helm chart.
 
 ## Upgrade Crossplane
 
-Upgrade Crossplane with `helm upgrade`, providing the namespace where Crossplane
-is installed. By default, Crossplane installs into the `crossplane-system`
+Upgrade Crossplane with `helm upgrade`, providing the Crossplane namespace. 
+By default, Crossplane installs into the `crossplane-system`
 namespace. 
 
 ```shell
@@ -43,7 +43,7 @@ helm upgrade crossplane --namespace crossplane-system crossplane-stable/crosspla
 Helm preserves any arguments or flags originally used when installing
 Crossplane. 
 
-Any new default Crossplane behaviors are changed unless changed in the `helm
+Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 

--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -1,7 +1,60 @@
 ---
 title: Upgrade Crossplane
 weight: 200
-draft: true
 ---
 
-Install, Uninstall, Upgrade
+The recommended upgrade method for an existing Crossplane install is to use
+[Helm](http://helm.io).
+
+## Prerequisites
+* [Helm](https://helm.sh/docs/intro/install/) version `v3.2.0` or later
+ 
+
+## Add the Crossplane Helm repository
+Verify Helm has the Crossplane repositry.
+
+```shell
+helm repo add crossplane-stable https://charts.crossplane.io/stable
+```
+
+## Update the Helm repositry
+
+Update the local Crossplane Helm chart with `helm repo update`.
+
+```shell
+helm repo update
+```
+
+{{<hint "important" >}}
+Upgrading Crossplane without updating the Helm chart installs the last version 
+available in the locally cached Helm chart.
+{{< /hint >}}
+
+## Upgrade Crossplane
+
+Upgrade Crossplane with `helm upgrade`, providing the namespace where Crossplane
+is installed. By default, Crossplane installs into the `crossplane-system`
+namespace. 
+
+```shell
+helm upgrade crossplane --namespace crossplane-system crossplane-stable/crossplane
+```
+
+Helm preserves any arguments or flags originally used when installing
+Crossplane. 
+
+Any new default Crossplane behaviors are changed unless changed in the `helm
+upgrade` command.
+
+For example, in v1.15.0 Crossplane changed the default image registry from 
+`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+before v1.15.0 updates the default package registry. 
+
+Override new defaults by 
+[customizing the Helm chart](https://docs.crossplane.io/v1.15/software/install/#customize-the-crossplane-helm-chart) 
+with the upgrade command.
+
+For example, to maintain the original image registry use 
+```shell 
+helm upgrade crossplane --namespace crossplane-system crossplane-stable/crossplane `--set 'args={"--registry=index.docker.io"}'
+```

--- a/content/v1.15/software/upgrade.md
+++ b/content/v1.15/software/upgrade.md
@@ -11,13 +11,13 @@ The recommended upgrade method for an existing Crossplane install is to use
  
 
 ## Add the Crossplane Helm repository
-Verify Helm has the Crossplane repositry.
+Verify Helm has the Crossplane repository.
 
 ```shell
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 ```
 
-## Update the Helm repositry
+## Update the Helm repository
 
 Update the local Crossplane Helm chart with `helm repo update`.
 
@@ -32,8 +32,8 @@ available in the locally cached Helm chart.
 
 ## Upgrade Crossplane
 
-Upgrade Crossplane with `helm upgrade`, providing the namespace where Crossplane
-is installed. By default, Crossplane installs into the `crossplane-system`
+Upgrade Crossplane with `helm upgrade`, providing the Crossplane namespace. 
+By default, Crossplane installs into the `crossplane-system`
 namespace. 
 
 ```shell
@@ -43,7 +43,7 @@ helm upgrade crossplane --namespace crossplane-system crossplane-stable/crosspla
 Helm preserves any arguments or flags originally used when installing
 Crossplane. 
 
-Any new default Crossplane behaviors are changed unless changed in the `helm
+Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 

--- a/content/v1.15/software/upgrade.md
+++ b/content/v1.15/software/upgrade.md
@@ -1,7 +1,60 @@
 ---
 title: Upgrade Crossplane
 weight: 200
-draft: true
 ---
 
-Install, Uninstall, Upgrade
+The recommended upgrade method for an existing Crossplane install is to use
+[Helm](http://helm.io).
+
+## Prerequisites
+* [Helm](https://helm.sh/docs/intro/install/) version `v3.2.0` or later
+ 
+
+## Add the Crossplane Helm repository
+Verify Helm has the Crossplane repositry.
+
+```shell
+helm repo add crossplane-stable https://charts.crossplane.io/stable
+```
+
+## Update the Helm repositry
+
+Update the local Crossplane Helm chart with `helm repo update`.
+
+```shell
+helm repo update
+```
+
+{{<hint "important" >}}
+Upgrading Crossplane without updating the Helm chart installs the last version 
+available in the locally cached Helm chart.
+{{< /hint >}}
+
+## Upgrade Crossplane
+
+Upgrade Crossplane with `helm upgrade`, providing the namespace where Crossplane
+is installed. By default, Crossplane installs into the `crossplane-system`
+namespace. 
+
+```shell
+helm upgrade crossplane --namespace crossplane-system crossplane-stable/crossplane
+```
+
+Helm preserves any arguments or flags originally used when installing
+Crossplane. 
+
+Any new default Crossplane behaviors are changed unless changed in the `helm
+upgrade` command.
+
+For example, in v1.15.0 Crossplane changed the default image registry from 
+`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+before v1.15.0 updates the default package registry. 
+
+Override new defaults by 
+[customizing the Helm chart](https://docs.crossplane.io/v1.15/software/install/#customize-the-crossplane-helm-chart) 
+with the upgrade command.
+
+For example, to maintain the original image registry use 
+```shell 
+helm upgrade crossplane --namespace crossplane-system crossplane-stable/crossplane `--set 'args={"--registry=index.docker.io"}'
+```


### PR DESCRIPTION
Adds instructions on how to Upgrade Crossplane with Helm along with guidelines for updating new default settings. 

Resolves #545 