### PR TITLE
add RNs for recent docs changes

### DIFF
--- a/content/master/release-notes/docs.md
+++ b/content/master/release-notes/docs.md
@@ -12,6 +12,30 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## February 22, 2024
+
+### Updated content 🏗️
+
+* New [Crossplane upgrade]({{<ref "../software/upgrade">}}) documentation.
+* Added notes to the [managed resources]({{<ref "../concepts/managed-resources" >}}) 
+  page that Crossplane can't delete paused resources.
+* Upgrade the AWS quickstart to use the new "no fork" Upjet provider version 1.1.0
+* Add links to the quickstart guides to the different authentication methods for
+  the provider.
+* Expanded `crossplane beta validate` [command reference]({{<ref "../cli/command-reference#beta-validate">}}). 
+* Documentation for the new [server side apply]({{<ref "../concepts/server-side-apply" >}}) alpha feature. 
+
+
+### 🔨 Docs fixes
+<!-- vale Google.WordList = NO -->
+<!-- allow "check" --> 
+* Fixed [an issue](https://github.com/crossplane/docs/pull/718) where mermaid 
+  diagrams didn't display the right colors across light and dark modes. 
+* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716") 
+  feature for doc page table of contents.
+* Fixed the color of check marks (✔️) in dark mode. 
+<!-- vale Google.WordList = YES -->
+
 ## February 15, 2024
 
 <!-- ### New features 🎉 -->

--- a/content/v1.15/release-notes/docs.md
+++ b/content/v1.15/release-notes/docs.md
@@ -12,6 +12,30 @@ removed: 🗑️
 moved: 🗺️
 -->
 
+## February 22, 2024
+
+### Updated content 🏗️
+
+* New [Crossplane upgrade]({{<ref "../software/upgrade">}}) documentation.
+* Added notes to the [managed resources]({{<ref "../concepts/managed-resources" >}}) 
+  page that Crossplane can't delete paused resources.
+* Upgrade the AWS quickstart to use the new "no fork" Upjet provider version 1.1.0
+* Add links to the quickstart guides to the different authentication methods for
+  the provider.
+* Expanded `crossplane beta validate` [command reference]({{<ref "../cli/command-reference#beta-validate">}}). 
+* Documentation for the new [server side apply]({{<ref "../concepts/server-side-apply" >}}) alpha feature. 
+
+
+### 🔨 Docs fixes
+<!-- vale Google.WordList = NO -->
+<!-- allow "check" --> 
+* Fixed [an issue](https://github.com/crossplane/docs/pull/718) where mermaid 
+  diagrams didn't display the right colors across light and dark modes. 
+* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716") 
+  feature for doc page table of contents.
+* Fixed the color of check marks (✔️) in dark mode. 
+<!-- vale Google.WordList = YES -->
+
 ## February 15, 2024
 
 <!-- ### New features 🎉 -->


### PR DESCRIPTION
Adds doc release notes for the new content and docs features/fixes since the 1.15 release. 