### PR TITLE
Fix: update quickstart azure provider version

### DIFF
--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
 EOF
 ```
 
@@ -468,7 +468,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
 EOF
 ```
 
@@ -478,9 +478,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.34.0   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.34.0   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.34.0    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
 ```
 
 ## Access the custom API

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.34.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.34.0    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.34.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
 {{< /hint >}}
 
 

--- a/content/v1.15/getting-started/provider-azure-part-2.md
+++ b/content/v1.15/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
 EOF
 ```
 
@@ -468,7 +468,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
 EOF
 ```
 
@@ -478,9 +478,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.34.0   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.34.0   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.34.0    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
 ```
 
 ## Access the custom API

--- a/content/v1.15/getting-started/provider-azure.md
+++ b/content/v1.15/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.34.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.34.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.34.0    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.34.0).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
 {{< /hint >}}
 
 


### PR DESCRIPTION
I was following the Azure quickstart docs but had trouble getting it to work.
The error I got was the following:
```
Error: unable to build authorizer for Resource Manager API: could not configure AzureCli Authorizer: could not parse Azure CLI version: launching Azure CLI: exec: "az": executable file not found in $PATH
```
Which seemed like an issue with Terraform after some superficial searching but not too sure what was going on.

I was using [client certificates for authorization](https://docs.upbound.io/providers/provider-azure/authentication/#create-a-service-principal-with-client-certificate-credentials-using-the-azure-cli-tool) and after looking at the provider versioning realized that this was only introduced in [v0.40.0](https://docs.upbound.io/providers/provider-azure/#v0400) and the version in the docs was way behind.

After using the latest version everything worked fine.