### PR TITLE
External link fixes

### DIFF
--- a/content/master/release-notes/docs.md
+++ b/content/master/release-notes/docs.md
@@ -42,7 +42,7 @@ registry.
 <!-- allow "check" --> 
 * Fixed [an issue](https://github.com/crossplane/docs/pull/718) where mermaid 
   diagrams didn't display the right colors across light and dark modes. 
-* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716") 
+* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716)" 
   feature for doc page table of contents.
 * Fixed the color of check marks (✔️) in dark mode. 
 <!-- vale Google.WordList = YES -->

--- a/content/v1.15/release-notes/docs.md
+++ b/content/v1.15/release-notes/docs.md
@@ -42,7 +42,7 @@ registry.
 <!-- allow "check" --> 
 * Fixed [an issue](https://github.com/crossplane/docs/pull/718) where mermaid 
   diagrams didn't display the right colors across light and dark modes. 
-* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716") 
+* Added support for a "[you are here](https://github.com/crossplane/docs/pull/716)" 
   feature for doc page table of contents.
 * Fixed the color of check marks (✔️) in dark mode. 
 <!-- vale Google.WordList = YES -->

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -57,7 +57,7 @@
               </div>
               <div>
                 <svg class="bi" width="1em" height="1em"><use xlink:href="#github"/></svg>
-                <span class="ps-1"><a href="{{printf "https://github.com/crossplane/docs/tree/master/content/%s" .Page.File}}">View page source</a></span>
+                <span class="ps-1"><a href="{{printf "https://github.com/crossplane/docs/tree/master/content/%s" .Page.File.Path}}">View page source</a></span>
               </div>
             </div>
           </nav>

--- a/utils/htmltest/.htmltest.yml
+++ b/utils/htmltest/.htmltest.yml
@@ -3,9 +3,11 @@ DirectoryPath: "public"
 # This doesn't cause errors
 IgnoreInternalEmptyHash: true
 CheckExternal: false
+StripQueryString: false
 IgnoreURLs:
   - "github.com/crossplane/docs/tree/master/content/(.*).md" # Ignore the links to "view this source"
   - "www.googletagmanager.com/*" # Ignore google tag manager
   - "twitter.com/*" # Ignore twitter links since they send to login page
   - "https://releases.crossplane.io/stable/current/bin" # S3 bucket listing always returns 404 status even with directory listing
   - "docs.crossplane.io/latest/*" # Allow links to the latest release (e.g. from knowledge-base)
+  - "github.com/crossplane/docs/issues/new*" # Ignore the "open an issue" link


### PR DESCRIPTION
Fixes broken external links and changes the link checking tool's default of stripping query strings to it properly validates youtube links.

Signed-off-by: Pete Lumbis <pete@upbound.io>