### PR TITLE
Fixes wrong link for compositions 

### DIFF
--- a/content/master/concepts/_index.md
+++ b/content/master/concepts/_index.md
@@ -34,7 +34,7 @@ building and managing external resources through Kubernetes.
   Deleting a managed resource requires a Provider to delete the associated
   external resource.
 
-* [**Compositions**]({{<ref "./composite-resources">}}) are a template of managed
+* [**Compositions**]({{<ref "./compositions">}}) are a template of managed
   resources. Compositions describe more complex deployments, combining multiple
   managed resources and any resource customizations, like the size of a database
   or the cloud provider region.

--- a/content/v1.13/concepts/_index.md
+++ b/content/v1.13/concepts/_index.md
@@ -34,7 +34,7 @@ building and managing external resources through Kubernetes.
   Deleting a managed resource requires a Provider to delete the associated
   external resource.
 
-* [**Compositions**]({{<ref "./composite-resources">}}) are a template of managed
+* [**Compositions**]({{<ref "./compositions">}}) are a template of managed
   resources. Compositions describe more complex deployments, combining multiple
   managed resources and any resource customizations, like the size of a database
   or the cloud provider region.

--- a/content/v1.14/concepts/_index.md
+++ b/content/v1.14/concepts/_index.md
@@ -34,7 +34,7 @@ building and managing external resources through Kubernetes.
   Deleting a managed resource requires a Provider to delete the associated
   external resource.
 
-* [**Compositions**]({{<ref "./composite-resources">}}) are a template of managed
+* [**Compositions**]({{<ref "./compositions">}}) are a template of managed
   resources. Compositions describe more complex deployments, combining multiple
   managed resources and any resource customizations, like the size of a database
   or the cloud provider region.

--- a/content/v1.15/concepts/_index.md
+++ b/content/v1.15/concepts/_index.md
@@ -34,7 +34,7 @@ building and managing external resources through Kubernetes.
   Deleting a managed resource requires a Provider to delete the associated
   external resource.
 
-* [**Compositions**]({{<ref "./composite-resources">}}) are a template of managed
+* [**Compositions**]({{<ref "./compositions">}}) are a template of managed
   resources. Compositions describe more complex deployments, combining multiple
   managed resources and any resource customizations, like the size of a database
   or the cloud provider region.


### PR DESCRIPTION
Fixes wrong link for compositions from `composite-resources` to `compositions`