### PR TITLE
fix: Objects with .status: {} should return Healthy

### DIFF
--- a/content/knowledge-base/integrations/argo-cd-crossplane.md
+++ b/content/knowledge-base/integrations/argo-cd-crossplane.md
@@ -70,13 +70,13 @@ data:
           "ProviderConfigUsage"
         }
 
-        if obj.status == nil and contains(has_no_status, obj.kind) then
+        if obj.status == nil or next(obj.status) == nil and contains(has_no_status, obj.kind) then
           health_status.status = "Healthy"
           health_status.message = "Resource is up-to-date."
           return health_status
         end
 
-        if obj.status == nil or obj.status.conditions == nil then
+        if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
           if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
@@ -137,18 +137,18 @@ data:
           "ProviderConfig",
           "ProviderConfigUsage"
         }
-        if obj.status == nil and contains(has_no_status, obj.kind) then
+        if obj.status == nil or next(obj.status) == nil and contains(has_no_status, obj.kind) then
             health_status.status = "Healthy"
             health_status.message = "Resource is up-to-date."
           return health_status
         end
 
-        if obj.status == nil or obj.status.conditions == nil then
-            if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
-              health_status.status = "Healthy"
-              health_status.message = "Resource is in use."
-              return health_status
-            end
+        if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
+          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
+            health_status.status = "Healthy"
+            health_status.message = "Resource is in use."
+            return health_status
+          end
           return health_status
         end
 


### PR DESCRIPTION
This fixes the health status for `ProviderConfig` objects, that kept being reported as _Progressing_ in ArgoCD.

The reason is that the script was only checking for `nil` values in the status and conditions fields. In Lua, an empty table is not the same as `nil`. In the `ProviderConfig` object, the `status` field is an empty object `status: {}`.

```yaml
apiVersion: azure.upbound.io/v1beta1
  kind: ProviderConfig
  metadata:
    annotations:
      argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
      argocd.argoproj.io/tracking-id: [REDACTED]:azure.upbound.io/ProviderConfig:crossplane-system/azure-workload-identity
    creationTimestamp: "2024-04-09T13:33:11Z"
    finalizers:
    - in-use.crossplane.io
    generation: 1
    name: azure-workload-identity
    resourceVersion: "19576"
    uid: f2414d9f-df3a-4378-b760-0a4301da82ff
  spec:
    clientID: [REDACTED]
    credentials:
      source: OIDCTokenFile
    oidcTokenFilePath: /var/run/secrets/azure/tokens/azure-identity-token
    subscriptionID: [REDACTED]
    tenantID: [REDACTED]
  status: {}
```

This fix extends the conditions to also catch when the field _field exists but is empty_, by using the `next` function to return `nil` if the table is empty. The ProviderConfig is now showing healthy! 

![image](https://github.com/crossplane/docs/assets/6105170/a7e0747b-e879-4310-bff4-84ccd6c7780e)

