### PR TITLE
Add PR Template linking to docs contrib guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+Thanks for contributing to the docs! 
+
+For information about local previews with Hugo read the contributing getting started guide:
+https://docs.crossplane.io/contribute/contribute/
+
+For information about Hugo's features like tabs and hint boxes read the styling features guide:
+https://docs.crossplane.io/contribute/features/
+
+For information on using Vale and testing locally read our Using Vale guide:
+https://docs.crossplane.io/contribute/vale/
+
+Need more help? Join the Crossplane Slack and ask in the #documentation channel.
+https://slack.crossplane.io/
+-->


### PR DESCRIPTION
Adds a PR template with links to the Docs contrib guide with info on using vale, running Hugo locally and using Hugo features.