### PR TITLE
fix(vault-injection): remove backslashes in controllerconfigs

### DIFF
--- a/content/v1.13/guides/vault-injection.md
+++ b/content/v1.13/guides/vault-injection.md
@@ -17,13 +17,13 @@ A provider may optionally support additional credentials sources, but the common
 sources cover a wide variety of use cases. One specific use case that is popular
 among organizations that use [Vault] for secrets management is using a sidecar
 to inject credentials into the filesystem. This guide will demonstrate how to
-use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp] 
+use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp]
 and [provider-aws].
 
-> Note: in this guide we will copy GCP credentials and AWS access keys 
-> into Vault's KV secrets engine. This is a simple generic approach to 
-> managing secrets with Vault, but is not as robust as using Vault's 
-> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP]. 
+> Note: in this guide we will copy GCP credentials and AWS access keys
+> into Vault's KV secrets engine. This is a simple generic approach to
+> managing secrets with Vault, but is not as robust as using Vault's
+> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP].
 
 ## Setup
 
@@ -186,7 +186,7 @@ In order to provision infrastructure on AWS, you will need to use an existing or
 user with appropriate permissions. The following steps will create an AWS IAM user and give it the necessary
 permissions.
 
-> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will 
+> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will
 > still need to provide the values for the `ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
 ```console
@@ -298,11 +298,11 @@ metadata:
 spec:
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
+      vault.hashicorp.com/agent-inject: "true"
       vault.hashicorp.com/role: "crossplane-providers"
       vault.hashicorp.com/agent-inject-secret-creds.txt: "secret/provider-creds/gcp-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/gcp-default\" -}}
+        {{- with secret "secret/provider-creds/gcp-default" -}}
          {{ .Data.data | toJSON }}
         {{- end -}}
 ---
@@ -341,7 +341,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the GCP credentials are being injected into the container run the 
+To verify that the GCP credentials are being injected into the container run the
 following command:
 
 ```console
@@ -406,11 +406,11 @@ spec:
     - --debug
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
-      vault.hashicorp.com/role: \"crossplane-providers\"
-      vault.hashicorp.com/agent-inject-secret-creds.txt: \"secret/provider-creds/aws-default\"
+      vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/role: "crossplane-providers"
+      vault.hashicorp.com/agent-inject-secret-creds.txt: "secret/provider-creds/aws-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/aws-default\" -}}
+        {{- with secret "secret/provider-creds/aws-default" -}}
           [default]
           aws_access_key_id="{{ .Data.data.access_key }}"
           aws_secret_access_key="{{ .Data.data.secret_key }}"
@@ -447,7 +447,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the AWS credentials are being injected into the container run the 
+To verify that the AWS credentials are being injected into the container run the
 following command:
 
 ```console
@@ -499,7 +499,7 @@ kubectl get bucket -w
 [provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
-[GCP]: https://www.vaultproject.io/docs/secrets/gcp 
+[GCP]: https://www.vaultproject.io/docs/secrets/gcp
 [unsealed]: https://www.vaultproject.io/docs/concepts/seal
 [Kubernetes authentication backend]: https://www.vaultproject.io/docs/auth/kubernetes
 [kv secrets engine]: https://www.vaultproject.io/docs/secrets/kv/kv-v2

--- a/content/v1.14/guides/vault-injection.md
+++ b/content/v1.14/guides/vault-injection.md
@@ -17,13 +17,13 @@ A provider may optionally support additional credentials sources, but the common
 sources cover a wide variety of use cases. One specific use case that is popular
 among organizations that use [Vault] for secrets management is using a sidecar
 to inject credentials into the filesystem. This guide will demonstrate how to
-use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp] 
+use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp]
 and [provider-aws].
 
-> Note: in this guide we will copy GCP credentials and AWS access keys 
-> into Vault's KV secrets engine. This is a simple generic approach to 
-> managing secrets with Vault, but is not as robust as using Vault's 
-> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP]. 
+> Note: in this guide we will copy GCP credentials and AWS access keys
+> into Vault's KV secrets engine. This is a simple generic approach to
+> managing secrets with Vault, but is not as robust as using Vault's
+> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP].
 
 ## Setup
 
@@ -186,7 +186,7 @@ In order to provision infrastructure on AWS, you will need to use an existing or
 user with appropriate permissions. The following steps will create an AWS IAM user and give it the necessary
 permissions.
 
-> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will 
+> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will
 > still need to provide the values for the `ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
 ```console
@@ -298,11 +298,11 @@ metadata:
 spec:
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
+      vault.hashicorp.com/agent-inject: "true"
       vault.hashicorp.com/role: "crossplane-providers"
       vault.hashicorp.com/agent-inject-secret-creds.txt: "secret/provider-creds/gcp-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/gcp-default\" -}}
+        {{- with secret "secret/provider-creds/gcp-default" -}}
          {{ .Data.data | toJSON }}
         {{- end -}}
 ---
@@ -341,7 +341,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the GCP credentials are being injected into the container run the 
+To verify that the GCP credentials are being injected into the container run the
 following command:
 
 ```console
@@ -406,11 +406,11 @@ spec:
     - --debug
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
-      vault.hashicorp.com/role: \"crossplane-providers\"
-      vault.hashicorp.com/agent-inject-secret-creds.txt: \"secret/provider-creds/aws-default\"
+      vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/role: "crossplane-providers"
+      vault.hashicorp.com/agent-inject-secret-creds.txt:\"secret/provider-creds/aws-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/aws-default\" -}}
+        {{- with secret "secret/provider-creds/aws-default" -}}
           [default]
           aws_access_key_id="{{ .Data.data.access_key }}"
           aws_secret_access_key="{{ .Data.data.secret_key }}"
@@ -447,7 +447,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the AWS credentials are being injected into the container run the 
+To verify that the AWS credentials are being injected into the container run the
 following command:
 
 ```console
@@ -499,7 +499,7 @@ kubectl get bucket -w
 [provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
-[GCP]: https://www.vaultproject.io/docs/secrets/gcp 
+[GCP]: https://www.vaultproject.io/docs/secrets/gcp
 [unsealed]: https://www.vaultproject.io/docs/concepts/seal
 [Kubernetes authentication backend]: https://www.vaultproject.io/docs/auth/kubernetes
 [kv secrets engine]: https://www.vaultproject.io/docs/secrets/kv/kv-v2

--- a/content/v1.15/guides/vault-injection.md
+++ b/content/v1.15/guides/vault-injection.md
@@ -17,13 +17,13 @@ A provider may optionally support additional credentials sources, but the common
 sources cover a wide variety of use cases. One specific use case that is popular
 among organizations that use [Vault] for secrets management is using a sidecar
 to inject credentials into the filesystem. This guide will demonstrate how to
-use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp] 
+use the [Vault Kubernetes Sidecar] to provide credentials for [provider-gcp]
 and [provider-aws].
 
-> Note: in this guide we will copy GCP credentials and AWS access keys 
-> into Vault's KV secrets engine. This is a simple generic approach to 
-> managing secrets with Vault, but is not as robust as using Vault's 
-> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP]. 
+> Note: in this guide we will copy GCP credentials and AWS access keys
+> into Vault's KV secrets engine. This is a simple generic approach to
+> managing secrets with Vault, but is not as robust as using Vault's
+> dedicated cloud provider secrets engines for [AWS], [Azure], and [GCP].
 
 ## Setup
 
@@ -186,7 +186,7 @@ In order to provision infrastructure on AWS, you will need to use an existing or
 user with appropriate permissions. The following steps will create an AWS IAM user and give it the necessary
 permissions.
 
-> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will 
+> Note: if you have an existing IAM user with appropriate permissions, you can skip this step but you will
 > still need to provide the values for the `ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
 ```console
@@ -298,11 +298,11 @@ metadata:
 spec:
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
+      vault.hashicorp.com/agent-inject: "true"
       vault.hashicorp.com/role: "crossplane-providers"
       vault.hashicorp.com/agent-inject-secret-creds.txt: "secret/provider-creds/gcp-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/gcp-default\" -}}
+        {{- with secret "secret/provider-creds/gcp-default" -}}
          {{ .Data.data | toJSON }}
         {{- end -}}
 ---
@@ -341,7 +341,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the GCP credentials are being injected into the container run the 
+To verify that the GCP credentials are being injected into the container run the
 following command:
 
 ```console
@@ -406,11 +406,11 @@ spec:
     - --debug
   metadata:
     annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
-      vault.hashicorp.com/role: \"crossplane-providers\"
-      vault.hashicorp.com/agent-inject-secret-creds.txt: \"secret/provider-creds/aws-default\"
+      vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/role: "crossplane-providers"
+      vault.hashicorp.com/agent-inject-secret-creds.txt: "secret/provider-creds/aws-default"
       vault.hashicorp.com/agent-inject-template-creds.txt: |
-        {{- with secret \"secret/provider-creds/aws-default\" -}}
+        {{- with secret "secret/provider-creds/aws-default" -}}
           [default]
           aws_access_key_id="{{ .Data.data.access_key }}"
           aws_secret_access_key="{{ .Data.data.secret_key }}"
@@ -447,7 +447,7 @@ spec:
       path: /vault/secrets/creds.txt" | kubectl apply -f -
 ```
 
-To verify that the AWS credentials are being injected into the container run the 
+To verify that the AWS credentials are being injected into the container run the
 following command:
 
 ```console
@@ -499,7 +499,7 @@ kubectl get bucket -w
 [provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
-[GCP]: https://www.vaultproject.io/docs/secrets/gcp 
+[GCP]: https://www.vaultproject.io/docs/secrets/gcp
 [unsealed]: https://www.vaultproject.io/docs/concepts/seal
 [Kubernetes authentication backend]: https://www.vaultproject.io/docs/auth/kubernetes
 [kv secrets engine]: https://www.vaultproject.io/docs/secrets/kv/kv-v2


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

based on the original implementation docs https://github.com/crossplane/crossplane/issues/2785 and a slack convo we need to remove the backslashes

```
3m        Warning  FailedCreate       replicaset/provider-aws-6408aa706aed-66b74b77df  Error creating: admission webhook "[vault.hashicorp.com](http://vault.hashicorp.com/)" denied the request: error checking if should inject agent: cannot parse '' as bool:
 strconv.ParseBool: parsing "\\\"true\\\"": invalid syntax
43m        Normal   ScalingReplicaSet  deployment/provider-aws-e0b33d016bb8             Scaled up replica set provider-aws-e0b33d016bb8-7d6b8789c6 to 1
40m        Warning  FailedCreate       replicaset/provider-aws-e0b33d016bb8-7d6b8789c6  Error creating: admission webhook "[vault.hashicorp.com](http://vault.hashicorp.com/)" denied the request: error checking if should inject agent: cannot parse '' as bool:
 strconv.ParseBool: parsing "\\\"true\\\"": invalid syntax
37m        Normal   ScalingReplicaSet  deployment/provider-aws-6408aa706aed             Scaled up replica set provider-aws-6408aa706aed-66b74b77df to 1
26m        Warning  FailedCreate       replicaset/provider-aws-6408aa706aed-66b74b77df  Error creating: admission webhook "[vault.hashicorp.com](http://vault.hashicorp.com/)" denied the request: error checking if should inject agent: cannot parse '' as bool:
 strconv.ParseBool: parsing "\\\"true\\\"": invalid syntax
24m        Normal   ScalingReplicaSet  deployment/provider-aws-6408aa706aed             Scaled up replica set provider-aws-6408aa706aed-66b74b77df to 1
18m        Warning  FailedCreate       replicaset/provider-aws-6408aa706aed-66b74b77df  Error creating: admission webhook "[vault.hashicorp.com](http://vault.hashicorp.com/)" denied the request: error checking if should inject agent: cannot parse '' as bool:
 strconv.ParseBool: parsing "\\\"true\\\"": invalid syntax
15m        Normal   ScalingReplicaSet  deployment/provider-aws-fe5dd61cd4bf             Scaled up replica set provider-aws-fe5dd61cd4bf-d5f7bb87b to 1
4m50s      Warning  FailedCreate       replicaset/provider-aws-fe5dd61cd4bf-d5f7bb87b   Error creating: admission webhook "[vault.hashicorp.com](http://vault.hashicorp.com/)" denied the request: error checking if should inject agent: cannot parse '' as bool:
 strconv.ParseBool: parsing "\\\"true\\\"": invalid syntax
```