### PR TITLE
Rename referenced master branches to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -8,7 +8,7 @@ labels: release
 - [ ] Update the `$LATEST_VER` parameter in [netlify_build.sh](https://github.com/crossplane/docs/blob/master/netlify_build.sh#L3)
 - [ ] Update `params.latest` in [config.yaml](https://github.com/crossplane/docs/blob/master/config.yaml#L93)
 - [ ] Update `version` in the `_index.md` file of `/content/<new latest>` from `master` to the correct version.
-- [ ] Copy Crossplane [cluster/crds](https://github.com/crossplane/crossplane/tree/master/cluster/crds) contents to `/content/<new latest>/api/crds`.
+- [ ] Copy Crossplane [cluster/crds](https://github.com/crossplane/crossplane/tree/main/cluster/crds) contents to `/content/<new latest>/api/crds`.
 - [ ] Create a [new release/tag](https://github.com/crossplane/docs/releases/new) named "v<EOL version>-archive" to snapshot EOL'd docs.
 - [ ] Remove EOL'd docs version from "/content" directory and run `hugo` locally to check for broken links.
 - [ ] Trigger [Algolia Crawler](https://crawler.algolia.com/) after publishing to reindex results.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -5,10 +5,10 @@ organization](https://github.com/crossplane/) will list their repository maintai
 `OWNERS.md` file.
 
 Please see the Crossplane
-[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md) for governance
 guidelines and responsibilities for the steering committee and maintainers.
 
-The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://github.com/crossplane/crossplane/blob/master/OWNERS.md) with the following changes:
+The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://github.com/crossplane/crossplane/blob/main/OWNERS.md) with the following changes:
 
 
 * Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis)) as a maintainer

--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -12,7 +12,7 @@ the Crossplane documentation.
 
 Information on contributing to the Crossplane software project is in the
 Crossplane 
-[`CONTRIBUTING.md`](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+[`CONTRIBUTING.md`](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 file.
 
 ## Code of conduct

--- a/content/contribute/features.md
+++ b/content/contribute/features.md
@@ -316,7 +316,7 @@ Hugo to fail.
 ## API documentation
 
 The API documentation is auto generated from the Crossplane YAML files from the 
-[cluster/crds](https://github.com/crossplane/crossplane/tree/master/cluster/crds) 
+[cluster/crds](https://github.com/crossplane/crossplane/tree/main/cluster/crds) 
 directory. 
 
 Place any updated files in the `/content/<version>/api/yaml` folder to update or 

--- a/content/master/cli/_index.md
+++ b/content/master/cli/_index.md
@@ -27,10 +27,10 @@ To download the latest version for your CPU architecture with the Crossplane
 install script.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | sh
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh)
+[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
 detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
@@ -61,4 +61,4 @@ By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
 download script curl command:  
 
-`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | XP_VERSION=v1.14.0 sh`
+`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`

--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -176,7 +176,7 @@ The Crossplane CLI combines a directory of YAML files and packages them as
 an [OCI container image](https://opencontainers.org/).  
 
 The CLI applies the required annotations and values to meet the 
-[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md).
+[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building 
 [configuration]({{< ref "../concepts/packages" >}}),

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -361,7 +361,7 @@ It's strongly recommended to use the Crossplane command-line tool to
 provide error checking and formatting to Crossplane package builds. 
 
 Read the 
-[Crossplane package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md) 
+[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md) 
 for package requirements when building packages with third-party tools.
 {{</hint >}}
 

--- a/content/master/concepts/pods.md
+++ b/content/master/concepts/pods.md
@@ -207,7 +207,7 @@ Disabling the RBAC manager requires manual Kubernetes permissions definitions
 for proper Crossplane operations. 
 
 The 
-[RBAC manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[RBAC manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 provides more comprehensive details on the Crossplane RBAC requirements.
 {{< /hint >}}
 

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -81,11 +81,11 @@ group is for creating Provider packages.
 Instructions on building Providers are outside of the scope of this
 document.  
 Read the Crossplane contributing 
-[Provider Development Guide](https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md)
+[Provider Development Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md)
 for more information.
 
 For information on the specification of Provider packages read the 
-[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md#provider-package-requirements).
+[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md#provider-package-requirements).
 
 ```yaml {label="meta-pkg"}
 apiVersion: meta.pkg.crossplane.io/v1
@@ -440,7 +440,7 @@ This can create significant strain on undersized API Servers, impacting Provider
 install times.
 
 The Crossplane community has more
-[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/master/design/one-pager-crd-scaling.md).
+[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/main/design/one-pager-crd-scaling.md).
 {{< /hint >}}
 
 ### Provider conditions

--- a/content/master/guides/vault-as-secret-store.md
+++ b/content/master/guides/vault-as-secret-store.md
@@ -630,7 +630,7 @@ kubectl delete claim my-ess
 <!-- named links -->
 
 [Vault]: https://www.vaultproject.io/
-[External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
+[External Secret Store]: https://github.com/crossplane/crossplane/blob/main/design/design-doc-external-secret-stores.md
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal

--- a/content/master/learn/_index.md
+++ b/content/master/learn/_index.md
@@ -7,8 +7,8 @@ weight: 500
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 
 ***Learn more about using Crossplane***
- - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/master/design)
- - [Roadmap](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md)
+ - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/main/design)
+ - [Roadmap](https://github.com/crossplane/crossplane/blob/main/ROADMAP.md)
  - [Crossplane Architecture](https://docs.google.com/document/d/1whncqdUeU2cATGEJhHvzXWC9xdK29Er45NJeoemxebo/edit?usp=sharing)
  - [GitLab deploys into multiple clouds from kubectl using Crossplane](https://about.gitlab.com/2019/05/20/gitlab-first-deployed-kubernetes-api-to-multiple-clouds/)
  - [CNCF Talks & Community Presentations](https://www.youtube.com/playlist?list=PL510POnNVaaZJj9OG6PbgsZvgYbhwJRyE)
@@ -18,7 +18,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
  - [Keep the Space Shuttle Flying: Writing Robust Operators](https://www.youtube.com/watch?v=uf97lOApOv8)
  - [Best practices for building Kubernetes Operators](https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps)
  - [Programming Kubernetes Book](https://www.oreilly.com/library/view/programming-kubernetes/9781492047094/)
- - [Contributor Guide](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+ - [Contributor Guide](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 
 ***Join the growing Crossplane community and get involved!***
 - Join our [Community Slack](https://slack.crossplane.io/)!

--- a/content/master/learn/release-cycle.md
+++ b/content/master/learn/release-cycle.md
@@ -96,5 +96,5 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Active Development]: #active-development
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -101,7 +101,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options
@@ -112,7 +112,7 @@ chart.
 
 Apply customizations with the command line or with a Helm _values_ file. 
 
-<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/README.md -->
+<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/main/cluster/charts/crossplane/README.md -->
 <!-- vale gitlab.Substitutions = NO -->
 <!-- allow lowercase yaml -->
 {{<expand "All Crossplane customization options" >}}

--- a/content/v1.15/cli/_index.md
+++ b/content/v1.15/cli/_index.md
@@ -27,10 +27,10 @@ To download the latest version for your CPU architecture with the Crossplane
 install script.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | sh
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh)
+[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
 detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
@@ -61,4 +61,4 @@ By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
 download script curl command:  
 
-`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | XP_VERSION=v1.14.0 sh`
+`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`

--- a/content/v1.15/cli/command-reference.md
+++ b/content/v1.15/cli/command-reference.md
@@ -37,7 +37,7 @@ The Crossplane CLI combines a directory of YAML files and packages them as
 an [OCI container image](https://opencontainers.org/).  
 
 The CLI applies the required annotations and values to meet the 
-[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md).
+[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building 
 [configuration]({{< ref "../concepts/packages" >}}),

--- a/content/v1.15/concepts/packages.md
+++ b/content/v1.15/concepts/packages.md
@@ -361,7 +361,7 @@ It's strongly recommended to use the Crossplane command-line tool to
 provide error checking and formatting to Crossplane package builds. 
 
 Read the 
-[Crossplane package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md) 
+[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md) 
 for package requirements when building packages with third-party tools.
 {{</hint >}}
 

--- a/content/v1.15/concepts/pods.md
+++ b/content/v1.15/concepts/pods.md
@@ -207,7 +207,7 @@ Disabling the RBAC manager requires manual Kubernetes permissions definitions
 for proper Crossplane operations. 
 
 The 
-[RBAC manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[RBAC manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 provides more comprehensive details on the Crossplane RBAC requirements.
 {{< /hint >}}
 

--- a/content/v1.15/concepts/providers.md
+++ b/content/v1.15/concepts/providers.md
@@ -81,11 +81,11 @@ group is for creating Provider packages.
 Instructions on building Providers are outside of the scope of this
 document.  
 Read the Crossplane contributing 
-[Provider Development Guide](https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md)
+[Provider Development Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md)
 for more information.
 
 For information on the specification of Provider packages read the 
-[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md#provider-package-requirements).
+[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md#provider-package-requirements).
 
 ```yaml {label="meta-pkg"}
 apiVersion: meta.pkg.crossplane.io/v1
@@ -440,7 +440,7 @@ This can create significant strain on undersized API Servers, impacting Provider
 install times.
 
 The Crossplane community has more
-[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/master/design/one-pager-crd-scaling.md).
+[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/main/design/one-pager-crd-scaling.md).
 {{< /hint >}}
 
 ### Provider conditions

--- a/content/v1.15/guides/vault-as-secret-store.md
+++ b/content/v1.15/guides/vault-as-secret-store.md
@@ -618,7 +618,7 @@ kubectl delete claim my-ess
 <!-- named links -->
 
 [Vault]: https://www.vaultproject.io/
-[External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
+[External Secret Store]: https://github.com/crossplane/crossplane/blob/main/design/design-doc-external-secret-stores.md
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal

--- a/content/v1.15/learn/_index.md
+++ b/content/v1.15/learn/_index.md
@@ -7,8 +7,8 @@ weight: 500
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 
 ***Learn more about using Crossplane***
- - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/master/design)
- - [Roadmap](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md)
+ - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/main/design)
+ - [Roadmap](https://github.com/crossplane/crossplane/blob/main/ROADMAP.md)
  - [Crossplane Architecture](https://docs.google.com/document/d/1whncqdUeU2cATGEJhHvzXWC9xdK29Er45NJeoemxebo/edit?usp=sharing)
  - [GitLab deploys into multiple clouds from kubectl using Crossplane](https://about.gitlab.com/2019/05/20/gitlab-first-deployed-kubernetes-api-to-multiple-clouds/)
  - [CNCF Talks & Community Presentations](https://www.youtube.com/playlist?list=PL510POnNVaaZJj9OG6PbgsZvgYbhwJRyE)
@@ -18,7 +18,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
  - [Keep the Space Shuttle Flying: Writing Robust Operators](https://www.youtube.com/watch?v=uf97lOApOv8)
  - [Best practices for building Kubernetes Operators](https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps)
  - [Programming Kubernetes Book](https://www.oreilly.com/library/view/programming-kubernetes/9781492047094/)
- - [Contributor Guide](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+ - [Contributor Guide](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 
 ***Join the growing Crossplane community and get involved!***
 - Join our [Community Slack](https://slack.crossplane.io/)!

--- a/content/v1.15/learn/release-cycle.md
+++ b/content/v1.15/learn/release-cycle.md
@@ -96,5 +96,5 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Active Development]: #active-development
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com

--- a/content/v1.15/software/install.md
+++ b/content/v1.15/software/install.md
@@ -101,7 +101,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options
@@ -112,7 +112,7 @@ chart.
 
 Apply customizations with the command line or with a Helm _values_ file. 
 
-<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/README.md -->
+<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/main/cluster/charts/crossplane/README.md -->
 <!-- vale gitlab.Substitutions = NO -->
 <!-- allow lowercase yaml -->
 {{<expand "All Crossplane customization options" >}}

--- a/content/v1.16/cli/_index.md
+++ b/content/v1.16/cli/_index.md
@@ -27,10 +27,10 @@ To download the latest version for your CPU architecture with the Crossplane
 install script.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | sh
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh)
+[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
 detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
@@ -61,4 +61,4 @@ By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
 download script curl command:  
 
-`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | XP_VERSION=v1.14.0 sh`
+`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`

--- a/content/v1.16/cli/command-reference.md
+++ b/content/v1.16/cli/command-reference.md
@@ -47,7 +47,7 @@ The Crossplane CLI combines a directory of YAML files and packages them as
 an [OCI container image](https://opencontainers.org/).  
 
 The CLI applies the required annotations and values to meet the 
-[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md).
+[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building 
 [configuration]({{< ref "../concepts/packages" >}}),

--- a/content/v1.16/concepts/packages.md
+++ b/content/v1.16/concepts/packages.md
@@ -361,7 +361,7 @@ It's strongly recommended to use the Crossplane command-line tool to
 provide error checking and formatting to Crossplane package builds. 
 
 Read the 
-[Crossplane package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md) 
+[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md) 
 for package requirements when building packages with third-party tools.
 {{</hint >}}
 

--- a/content/v1.16/concepts/pods.md
+++ b/content/v1.16/concepts/pods.md
@@ -207,7 +207,7 @@ Disabling the RBAC manager requires manual Kubernetes permissions definitions
 for proper Crossplane operations. 
 
 The 
-[RBAC manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[RBAC manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 provides more comprehensive details on the Crossplane RBAC requirements.
 {{< /hint >}}
 

--- a/content/v1.16/concepts/providers.md
+++ b/content/v1.16/concepts/providers.md
@@ -81,11 +81,11 @@ group is for creating Provider packages.
 Instructions on building Providers are outside of the scope of this
 document.  
 Read the Crossplane contributing 
-[Provider Development Guide](https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md)
+[Provider Development Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md)
 for more information.
 
 For information on the specification of Provider packages read the 
-[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md#provider-package-requirements).
+[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md#provider-package-requirements).
 
 ```yaml {label="meta-pkg"}
 apiVersion: meta.pkg.crossplane.io/v1
@@ -440,7 +440,7 @@ This can create significant strain on undersized API Servers, impacting Provider
 install times.
 
 The Crossplane community has more
-[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/master/design/one-pager-crd-scaling.md).
+[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/main/design/one-pager-crd-scaling.md).
 {{< /hint >}}
 
 ### Provider conditions

--- a/content/v1.16/guides/vault-as-secret-store.md
+++ b/content/v1.16/guides/vault-as-secret-store.md
@@ -618,7 +618,7 @@ kubectl delete claim my-ess
 <!-- named links -->
 
 [Vault]: https://www.vaultproject.io/
-[External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
+[External Secret Store]: https://github.com/crossplane/crossplane/blob/main/design/design-doc-external-secret-stores.md
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal

--- a/content/v1.16/learn/_index.md
+++ b/content/v1.16/learn/_index.md
@@ -7,8 +7,8 @@ weight: 500
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 
 ***Learn more about using Crossplane***
- - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/master/design)
- - [Roadmap](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md)
+ - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/main/design)
+ - [Roadmap](https://github.com/crossplane/crossplane/blob/main/ROADMAP.md)
  - [Crossplane Architecture](https://docs.google.com/document/d/1whncqdUeU2cATGEJhHvzXWC9xdK29Er45NJeoemxebo/edit?usp=sharing)
  - [GitLab deploys into multiple clouds from kubectl using Crossplane](https://about.gitlab.com/2019/05/20/gitlab-first-deployed-kubernetes-api-to-multiple-clouds/)
  - [CNCF Talks & Community Presentations](https://www.youtube.com/playlist?list=PL510POnNVaaZJj9OG6PbgsZvgYbhwJRyE)
@@ -18,7 +18,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
  - [Keep the Space Shuttle Flying: Writing Robust Operators](https://www.youtube.com/watch?v=uf97lOApOv8)
  - [Best practices for building Kubernetes Operators](https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps)
  - [Programming Kubernetes Book](https://www.oreilly.com/library/view/programming-kubernetes/9781492047094/)
- - [Contributor Guide](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+ - [Contributor Guide](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 
 ***Join the growing Crossplane community and get involved!***
 - Join our [Community Slack](https://slack.crossplane.io/)!

--- a/content/v1.16/learn/release-cycle.md
+++ b/content/v1.16/learn/release-cycle.md
@@ -96,5 +96,5 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Active Development]: #active-development
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com

--- a/content/v1.16/software/install.md
+++ b/content/v1.16/software/install.md
@@ -101,7 +101,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options
@@ -112,7 +112,7 @@ chart.
 
 Apply customizations with the command line or with a Helm _values_ file. 
 
-<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/README.md -->
+<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/main/cluster/charts/crossplane/README.md -->
 <!-- vale gitlab.Substitutions = NO -->
 <!-- allow lowercase yaml -->
 {{<expand "All Crossplane customization options" >}}

--- a/content/v1.17/cli/_index.md
+++ b/content/v1.17/cli/_index.md
@@ -27,10 +27,10 @@ To download the latest version for your CPU architecture with the Crossplane
 install script.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | sh
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
 ```
 
-[The script](https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh)
+[The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
 detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
@@ -61,4 +61,4 @@ By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
 download script curl command:  
 
-`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh" | XP_VERSION=v1.14.0 sh`
+`curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`

--- a/content/v1.17/cli/command-reference.md
+++ b/content/v1.17/cli/command-reference.md
@@ -176,7 +176,7 @@ The Crossplane CLI combines a directory of YAML files and packages them as
 an [OCI container image](https://opencontainers.org/).  
 
 The CLI applies the required annotations and values to meet the 
-[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md).
+[Crossplane XPKG specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md).
 
 The `crossplane` CLI supports building 
 [configuration]({{< ref "../concepts/packages" >}}),

--- a/content/v1.17/concepts/packages.md
+++ b/content/v1.17/concepts/packages.md
@@ -361,7 +361,7 @@ It's strongly recommended to use the Crossplane command-line tool to
 provide error checking and formatting to Crossplane package builds. 
 
 Read the 
-[Crossplane package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md) 
+[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md) 
 for package requirements when building packages with third-party tools.
 {{</hint >}}
 

--- a/content/v1.17/concepts/pods.md
+++ b/content/v1.17/concepts/pods.md
@@ -207,7 +207,7 @@ Disabling the RBAC manager requires manual Kubernetes permissions definitions
 for proper Crossplane operations. 
 
 The 
-[RBAC manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[RBAC manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 provides more comprehensive details on the Crossplane RBAC requirements.
 {{< /hint >}}
 

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -81,11 +81,11 @@ group is for creating Provider packages.
 Instructions on building Providers are outside of the scope of this
 document.  
 Read the Crossplane contributing 
-[Provider Development Guide](https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md)
+[Provider Development Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md)
 for more information.
 
 For information on the specification of Provider packages read the 
-[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md#provider-package-requirements).
+[Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md#provider-package-requirements).
 
 ```yaml {label="meta-pkg"}
 apiVersion: meta.pkg.crossplane.io/v1
@@ -440,7 +440,7 @@ This can create significant strain on undersized API Servers, impacting Provider
 install times.
 
 The Crossplane community has more
-[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/master/design/one-pager-crd-scaling.md).
+[details on scaling CRDs](https://github.com/crossplane/crossplane/blob/main/design/one-pager-crd-scaling.md).
 {{< /hint >}}
 
 ### Provider conditions

--- a/content/v1.17/guides/vault-as-secret-store.md
+++ b/content/v1.17/guides/vault-as-secret-store.md
@@ -630,7 +630,7 @@ kubectl delete claim my-ess
 <!-- named links -->
 
 [Vault]: https://www.vaultproject.io/
-[External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
+[External Secret Store]: https://github.com/crossplane/crossplane/blob/main/design/design-doc-external-secret-stores.md
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal

--- a/content/v1.17/learn/_index.md
+++ b/content/v1.17/learn/_index.md
@@ -7,8 +7,8 @@ weight: 500
 If you have any questions, please drop us a note on [Crossplane Slack][join-crossplane-slack] or [contact us][contact-us]!
 
 ***Learn more about using Crossplane***
- - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/master/design)
- - [Roadmap](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md)
+ - [Latest Design Docs](https://github.com/crossplane/crossplane/tree/main/design)
+ - [Roadmap](https://github.com/crossplane/crossplane/blob/main/ROADMAP.md)
  - [Crossplane Architecture](https://docs.google.com/document/d/1whncqdUeU2cATGEJhHvzXWC9xdK29Er45NJeoemxebo/edit?usp=sharing)
  - [GitLab deploys into multiple clouds from kubectl using Crossplane](https://about.gitlab.com/2019/05/20/gitlab-first-deployed-kubernetes-api-to-multiple-clouds/)
  - [CNCF Talks & Community Presentations](https://www.youtube.com/playlist?list=PL510POnNVaaZJj9OG6PbgsZvgYbhwJRyE)
@@ -18,7 +18,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
  - [Keep the Space Shuttle Flying: Writing Robust Operators](https://www.youtube.com/watch?v=uf97lOApOv8)
  - [Best practices for building Kubernetes Operators](https://cloud.google.com/blog/products/containers-kubernetes/best-practices-for-building-kubernetes-operators-and-stateful-apps)
  - [Programming Kubernetes Book](https://www.oreilly.com/library/view/programming-kubernetes/9781492047094/)
- - [Contributor Guide](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+ - [Contributor Guide](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 
 ***Join the growing Crossplane community and get involved!***
 - Join our [Community Slack](https://slack.crossplane.io/)!

--- a/content/v1.17/learn/release-cycle.md
+++ b/content/v1.17/learn/release-cycle.md
@@ -96,5 +96,5 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Active Development]: #active-development
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
-[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
 [community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com

--- a/content/v1.17/software/install.md
+++ b/content/v1.17/software/install.md
@@ -101,7 +101,7 @@ The `crossplane-rbac-manager` creates and manages Kubernetes _ClusterRoles_ for
 installed Crossplane _Provider_ and their _Custom Resource Definitions_.
 
 The 
-[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md) 
+[Crossplane RBAC Manager design document](https://github.com/crossplane/crossplane/blob/main/design/design-doc-rbac-manager.md) 
 has more information on the installed _ClusterRoles_.
 
 ## Installation options
@@ -112,7 +112,7 @@ chart.
 
 Apply customizations with the command line or with a Helm _values_ file. 
 
-<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/master/cluster/charts/crossplane/README.md -->
+<!-- Generated from Helm README at https://github.com/crossplane/crossplane/blob/main/cluster/charts/crossplane/README.md -->
 <!-- vale gitlab.Substitutions = NO -->
 <!-- allow lowercase yaml -->
 {{<expand "All Crossplane customization options" >}}


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

Rename the referenced `master` branches of Crossplane projects to `main`, as a follow-up to https://github.com/crossplane/crossplane/issues/2045.