### PR TITLE
Claim Communication Examples

### DIFF
--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -298,6 +298,18 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// to add desired managed resources.
 	xr, err := request.GetObservedCompositeResource(req)
 	if err != nil {
+		// You can set a custom status condition on the claim. This
+		// allows you to communicate with the user.
+		response.ConditionFalse(rsp, "FunctionSuccess", "InternalError").
+			WithMessage("Something went wrong.").
+			TargetCompositeAndClaim()
+
+		// You can emit an event regarding the claim. This allows you to
+		// communicate with the user. Note that events should be used 
+		// sparingly and are subject to throttling
+		response.Warning(rsp, errors.New("something went wrong")).
+			TargetCompositeAndClaim()
+
 		// If the function can't read the XR, the request is malformed. This
 		// should never happen. The function returns a fatal result. This tells
 		// Crossplane to stop running functions and return an error.
@@ -387,6 +399,11 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// logs. A function can use response.Normal and response.Warning to emit
 	// Kubernetes events associated with the XR it's operating on.
 	log.Info("Added desired buckets", "region", region, "count", len(names))
+
+	// You can set a custom status condition on the claim. This allows you
+	// to communicate with the user.
+	response.ConditionTrue(rsp, "FunctionSuccess", "Success").
+		TargetCompositeAndClaim()
 
 	return rsp, nil
 }

--- a/content/v1.17/guides/write-a-composition-function-in-go.md
+++ b/content/v1.17/guides/write-a-composition-function-in-go.md
@@ -298,6 +298,18 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// to add desired managed resources.
 	xr, err := request.GetObservedCompositeResource(req)
 	if err != nil {
+		// You can set a custom status condition on the claim. This
+		// allows you to communicate with the user.
+		response.ConditionFalse(rsp, "FunctionSuccess", "InternalError").
+			WithMessage("Something went wrong.").
+			TargetCompositeAndClaim()
+
+		// You can emit an event regarding the claim. This allows you to
+		// communicate with the user. Note that events should be used 
+		// sparingly and are subject to throttling
+		response.Warning(rsp, errors.New("something went wrong")).
+			TargetCompositeAndClaim()
+
 		// If the function can't read the XR, the request is malformed. This
 		// should never happen. The function returns a fatal result. This tells
 		// Crossplane to stop running functions and return an error.
@@ -387,6 +399,11 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// logs. A function can use response.Normal and response.Warning to emit
 	// Kubernetes events associated with the XR it's operating on.
 	log.Info("Added desired buckets", "region", region, "count", len(names))
+
+	// You can set a custom status condition on the claim. This allows you
+	// to communicate with the user.
+	response.ConditionTrue(rsp, "FunctionSuccess", "Success").
+		TargetCompositeAndClaim()
 
 	return rsp, nil
 }


### PR DESCRIPTION
Adds examples of communicating to the user by setting status conditions and emitting events.

Related to https://github.com/crossplane/docs/issues/795.