### PR TITLE
Remove quickstart-subnet location patch

### DIFF
--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -401,15 +401,6 @@ spec:
                   matchControllerRef: true
                 resourceGroupNameSelector:
                   matchControllerRef: true
-          patches:
-            - type: FromCompositeFieldPath
-              fromFieldPath: "spec.location"
-              toFieldPath: "spec.forProvider.location"
-              transforms:
-                - type: map
-                  map: 
-                    EU: "Sweden Central"
-                    US: "Central US"
         - name: quickstart-network
           base:
             apiVersion: network.azure.upbound.io/v1beta1

--- a/content/v1.17/getting-started/provider-azure-part-2.md
+++ b/content/v1.17/getting-started/provider-azure-part-2.md
@@ -401,15 +401,6 @@ spec:
                   matchControllerRef: true
                 resourceGroupNameSelector:
                   matchControllerRef: true
-          patches:
-            - type: FromCompositeFieldPath
-              fromFieldPath: "spec.location"
-              toFieldPath: "spec.forProvider.location"
-              transforms:
-                - type: map
-                  map: 
-                    EU: "Sweden Central"
-                    US: "Central US"
         - name: quickstart-network
           base:
             apiVersion: network.azure.upbound.io/v1beta1


### PR DESCRIPTION
This is an unnecessary patch that breaks the composition.

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->