### PR TITLE
bump go function guide to latest function-sdk-go:v0.3.0 experience

### DIFF
--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -425,10 +425,9 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3
-provider](https://github.com/crossplane-contrib/provider-upjet-aws). One
-advantage of writing a function in Go is that you can compose resources using
-the same strongly typed structs Crossplane uses in its providers.
+The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+One advantage of writing a function in Go is that you can compose resources
+using the same strongly typed structs Crossplane uses in its providers.
 
 You must get the AWS Provider Go module to use this type:
 

--- a/content/v1.17/guides/write-a-composition-function-in-go.md
+++ b/content/v1.17/guides/write-a-composition-function-in-go.md
@@ -425,10 +425,9 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3
-provider](https://github.com/crossplane-contrib/provider-upjet-aws). One
-advantage of writing a function in Go is that you can compose resources using
-the same strongly typed structs Crossplane uses in its providers.
+The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+One advantage of writing a function in Go is that you can compose resources
+using the same strongly typed structs Crossplane uses in its providers.
 
 You must get the AWS Provider Go module to use this type:
 


### PR DESCRIPTION
This docs PR updates the go function guide to use the latest experience (minor updates) from `function-sdk-go:v0.3.0`.

This is a companion PR to https://github.com/crossplane/function-template-go/pull/81 which updates the function-template-go repo to use the latest SDK release also.

I've tested this by walking through the entire guide locally using these updated steps and everything is working OK ✅ 