### PR TITLE
Link to crossplane website's new public package registries page

### DIFF
--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -22,7 +22,7 @@ Examples of providers include:
 * [Provider Kubernetes](https://github.com/crossplane-contrib/provider-kubernetes)
 
 {{< hint "tip" >}}
-Find more providers in the [Upbound Marketplace](https://marketplace.upbound.io).
+Find more providers in Crossplane's [public package registries](https://www.crossplane.io/registries).
 {{< /hint >}}
 
 <!-- vale write-good.Passive = NO -->

--- a/content/master/getting-started/introduction.md
+++ b/content/master/getting-started/introduction.md
@@ -110,8 +110,8 @@ In the `bucket` CRD is a
 [`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
 value that defines which AWS region to deploy the bucket in.
 
-The Upbound Marketplace contains a large 
-[collection of Crossplane Providers](https://marketplace.upbound.io/providers).
+Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 
+collection of Crossplane Providers.
 
 More providers are available in the [Crossplane Contrib repository](https://github.com/crossplane-contrib/).
 

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -22,7 +22,7 @@ Examples of providers include:
 * [Provider Kubernetes](https://github.com/crossplane-contrib/provider-kubernetes)
 
 {{< hint "tip" >}}
-Find more providers in the [Upbound Marketplace](https://marketplace.upbound.io).
+Find more providers in Crossplane's [public package registries](https://www.crossplane.io/registries).
 {{< /hint >}}
 
 <!-- vale write-good.Passive = NO -->

--- a/content/v1.17/getting-started/introduction.md
+++ b/content/v1.17/getting-started/introduction.md
@@ -110,8 +110,8 @@ In the `bucket` CRD is a
 [`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
 value that defines which AWS region to deploy the bucket in.
 
-The Upbound Marketplace contains a large 
-[collection of Crossplane Providers](https://marketplace.upbound.io/providers).
+Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 
+collection of Crossplane Providers.
 
 More providers are available in the [Crossplane Contrib repository](https://github.com/crossplane-contrib/).
 


### PR DESCRIPTION
Following the addition of the new [public package registries page](https://www.crossplane.io/registries) on crossplane.io with https://github.com/crossplane/website/pull/63, this PR updates a couple of links in the docs to now point to this new registry index/listing page instead.