### PR TITLE
Simplify provider versions in examples

### DIFF
--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -325,10 +325,10 @@ inside Crossplane.
 
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
-For example, to install version 0.42.0 of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.42.0):
+For example, to install the latest version of the 
+[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
 
-`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0`
+`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -507,10 +507,10 @@ already installed in Crossplane.
 The package file must be an organization, image and tag on the `xpkg.upbound.io`
 registry on [Upbound Marketplace](https://marketplace.upbound.io/).
 
-For example, to update to version 0.42.0 of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v0.42.0):
+For example, to update to the latest version of the 
+[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
 
-`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0`
+`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
 
 
 ## beta
@@ -957,7 +957,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.17.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -339,7 +339,7 @@ For example, this installation of the Upbound AWS reference platform is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0   12s
+provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -352,7 +352,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0
+  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
   Revision:                       1
 Status:
   Conditions:
@@ -390,10 +390,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0          Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.17.0      Active                                 10d
+upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -653,7 +653,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1.9.0
+  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.17.0
+  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.17.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.17.0       13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.0.0     3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       13m
 ```
 
 ## Create a custom API

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.17.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.0.0         97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.0.0     88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1.8.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v1.8.0
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.8.0   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.8.0   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.8.0    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.0.0    25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0    3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0     3h
 ```
 
 ## Access the custom API

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1.8.0
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.8.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.8.0    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    26s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.0.0     39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0    13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0     12m
 ```
 
 

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/master/software/uninstall.md
+++ b/content/master/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v0.27.0   8h
+upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.


### PR DESCRIPTION
Provider versions change constantly, and updating the examples in the docs with every release is not feasible.
Users of the docs sometimes end up installing very old versions of the providers, which results in a sub-optimal experience and the need for help.

This PR introduces two main changes:
1. The provider version to be installed is set to the major version only, e.g., v1 instead of v1.2.3. This has the effect of installing the latest provider version of the v1 major release. Note this capability is limited to the Upbound Marketplace for the providers used in the Quickstart guide.
2. Updates the example output where provider versions are listed all to v1.0.0 for consistency.