### PR TITLE
Add documentation for ImageConfig

### DIFF
--- a/content/master/api/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_compositeresourcedefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: compositeresourcedefinitions.apiextensions.crossplane.io
 spec:
   group: apiextensions.crossplane.io
@@ -35,7 +35,6 @@ spec:
         description: |-
           A CompositeResourceDefinition defines the schema for a new custom Kubernetes
           API.
-
 
           Read the Crossplane documentation for
           [more information about CustomResourceDefinitions](https://docs.crossplane.io/latest/concepts/composite-resource-definitions).
@@ -155,7 +154,6 @@ spec:
                               service is a reference to the service for this webhook. Either
                               service or url must be specified.
 
-
                               If the webhook is running within the cluster, then you should use `service`.
                             properties:
                               name:
@@ -189,13 +187,11 @@ spec:
                               (`scheme://host:port/path`). Exactly one of `url` or `service`
                               must be specified.
 
-
                               The `host` should not refer to a service running in the cluster; use
                               the `service` field instead. The host might be resolved via external
                               DNS in some apiservers (e.g., `kube-apiserver` cannot resolve
                               in-cluster DNS as that would be a layering violation). `host` may
                               also be an IP address.
-
 
                               Please note that using `localhost` or `127.0.0.1` as a `host` is
                               risky unless you take great care to run this webhook on all hosts
@@ -203,14 +199,11 @@ spec:
                               webhook. Such installs are likely to be non-portable, i.e., not easy
                               to turn up in a new cluster.
 
-
                               The scheme must be "https"; the URL must begin with "https://".
-
 
                               A path is optional, and if present may be any string permissible in
                               a URL. You may use the path to pass an arbitrary string to the
                               webhook, for example, a cluster identifier.
-
 
                               Attempting to use a user or basic auth e.g. "user:password@" is not
                               allowed. Fragments ("#...") and query parameters ("?...") are not

--- a/content/master/api/crds/apiextensions.crossplane.io_compositionrevisions.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_compositionrevisions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: compositionrevisions.apiextensions.crossplane.io
 spec:
   group: apiextensions.crossplane.io
@@ -37,7 +37,6 @@ spec:
         description: |-
           A CompositionRevision represents a revision of a Composition. Crossplane
           creates new revisions when there are changes to the Composition.
-
 
           Crossplane creates and manages CompositionRevisions. Don't directly edit
           CompositionRevisions.
@@ -82,521 +81,18 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              environment:
-                description: |-
-                  Environment configures the environment in which resources are rendered.
-
-
-                  THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
-                  unless the relevant Crossplane feature flag is enabled, and may be
-                  changed or removed without notice.
-                properties:
-                  defaultData:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
-                    description: |-
-                      DefaultData statically defines the initial state of the environment.
-                      It has the same schema-less structure as the data field in
-                      environment configs.
-                      It is overwritten by the selected environment configs.
-                    type: object
-                  environmentConfigs:
-                    description: |-
-                      EnvironmentConfigs selects a list of `EnvironmentConfig`s. The resolved
-                      resources are stored in the composite resource at
-                      `spec.environmentConfigRefs` and is only updated if it is null.
-
-
-                      The list of references is used to compute an in-memory environment at
-                      compose time. The data of all object is merged in the order they are
-                      listed, meaning the values of EnvironmentConfigs with a larger index take
-                      priority over ones with smaller indices.
-
-
-                      The computed environment can be accessed in a composition using
-                      `FromEnvironmentFieldPath` and `CombineFromEnvironment` patches.
-                    items:
-                      description: EnvironmentSource selects a EnvironmentConfig resource.
-                      properties:
-                        ref:
-                          description: |-
-                            Ref is a named reference to a single EnvironmentConfig.
-                            Either Ref or Selector is required.
-                          properties:
-                            name:
-                              description: The name of the object.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        selector:
-                          description: Selector selects EnvironmentConfig(s) via labels.
-                          properties:
-                            matchLabels:
-                              description: MatchLabels ensures an object with matching
-                                labels is selected.
-                              items:
-                                description: |-
-                                  An EnvironmentSourceSelectorLabelMatcher acts like a k8s label selector but
-                                  can draw the label value from a different path.
-                                properties:
-                                  fromFieldPathPolicy:
-                                    default: Required
-                                    description: |-
-                                      FromFieldPathPolicy specifies the policy for the valueFromFieldPath.
-                                      The default is Required, meaning that an error will be returned if the
-                                      field is not found in the composite resource.
-                                      Optional means that if the field is not found in the composite resource,
-                                      that label pair will just be skipped. N.B. other specified label
-                                      matchers will still be used to retrieve the desired
-                                      environment config, if any.
-                                    enum:
-                                    - Optional
-                                    - Required
-                                    type: string
-                                  key:
-                                    description: Key of the label to match.
-                                    type: string
-                                  type:
-                                    default: FromCompositeFieldPath
-                                    description: Type specifies where the value for
-                                      a label comes from.
-                                    enum:
-                                    - FromCompositeFieldPath
-                                    - Value
-                                    type: string
-                                  value:
-                                    description: Value specifies a literal label value.
-                                    type: string
-                                  valueFromFieldPath:
-                                    description: ValueFromFieldPath specifies the
-                                      field path to look for the label value.
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                              type: array
-                            maxMatch:
-                              description: MaxMatch specifies the number of extracted
-                                EnvironmentConfigs in Multiple mode, extracts all
-                                if nil.
-                              format: int64
-                              type: integer
-                            minMatch:
-                              description: MinMatch specifies the required minimum
-                                of extracted EnvironmentConfigs in Multiple mode.
-                              format: int64
-                              type: integer
-                            mode:
-                              default: Single
-                              description: 'Mode specifies retrieval strategy: "Single"
-                                or "Multiple".'
-                              enum:
-                              - Single
-                              - Multiple
-                              type: string
-                            sortByFieldPath:
-                              default: metadata.name
-                              description: SortByFieldPath is the path to the field
-                                based on which list of EnvironmentConfigs is alphabetically
-                                sorted.
-                              type: string
-                          type: object
-                        type:
-                          default: Reference
-                          description: |-
-                            Type specifies the way the EnvironmentConfig is selected.
-                            Default is `Reference`
-                          enum:
-                          - Reference
-                          - Selector
-                          type: string
-                      type: object
-                    type: array
-                  patches:
-                    description: |-
-                      Patches is a list of environment patches that are executed before a
-                      composition's resources are composed.
-                    items:
-                      description: EnvironmentPatch is a patch for a Composition environment.
-                      properties:
-                        combine:
-                          description: |-
-                            Combine is the patch configuration for a CombineFromComposite or
-                            CombineToComposite patch.
-                          properties:
-                            strategy:
-                              description: |-
-                                Strategy defines the strategy to use to combine the input variable values.
-                                Currently only string is supported.
-                              enum:
-                              - string
-                              type: string
-                            string:
-                              description: |-
-                                String declares that input variables should be combined into a single
-                                string, using the relevant settings for formatting purposes.
-                              properties:
-                                fmt:
-                                  description: |-
-                                    Format the input using a Go format string. See
-                                    https://golang.org/pkg/fmt/ for details.
-                                  type: string
-                              required:
-                              - fmt
-                              type: object
-                            variables:
-                              description: |-
-                                Variables are the list of variables whose values will be retrieved and
-                                combined.
-                              items:
-                                description: |-
-                                  A CombineVariable defines the source of a value that is combined with
-                                  others to form and patch an output value. Currently, this only supports
-                                  retrieving values from a field path.
-                                properties:
-                                  fromFieldPath:
-                                    description: |-
-                                      FromFieldPath is the path of the field on the source whose value is
-                                      to be used as input.
-                                    type: string
-                                required:
-                                - fromFieldPath
-                                type: object
-                              minItems: 1
-                              type: array
-                          required:
-                          - strategy
-                          - variables
-                          type: object
-                        fromFieldPath:
-                          description: |-
-                            FromFieldPath is the path of the field on the resource whose value is
-                            to be used as input. Required when type is FromCompositeFieldPath or
-                            ToCompositeFieldPath.
-                          type: string
-                        policy:
-                          description: Policy configures the specifics of patching
-                            behaviour.
-                          properties:
-                            fromFieldPath:
-                              description: |-
-                                FromFieldPath specifies how to patch from a field path. The default is
-                                'Optional', which means the patch will be a no-op if the specified
-                                fromFieldPath does not exist. Use 'Required' if the patch should fail if
-                                the specified path does not exist.
-                              enum:
-                              - Optional
-                              - Required
-                              type: string
-                            mergeOptions:
-                              description: MergeOptions Specifies merge options on
-                                a field path.
-                              properties:
-                                appendSlice:
-                                  description: Specifies that already existing elements
-                                    in a merged slice should be preserved
-                                  type: boolean
-                                keepMapValues:
-                                  description: Specifies that already existing values
-                                    in a merged map should be preserved
-                                  type: boolean
-                              type: object
-                          type: object
-                        toFieldPath:
-                          description: |-
-                            ToFieldPath is the path of the field on the resource whose value will
-                            be changed with the result of transforms. Leave empty if you'd like to
-                            propagate to the same path as fromFieldPath.
-                          type: string
-                        transforms:
-                          description: |-
-                            Transforms are the list of functions that are used as a FIFO pipe for the
-                            input to be transformed.
-                          items:
-                            description: |-
-                              Transform is a unit of process whose input is transformed into an output with
-                              the supplied configuration.
-                            properties:
-                              convert:
-                                description: Convert is used to cast the input into
-                                  the given output type.
-                                properties:
-                                  format:
-                                    description: |-
-                                      The expected input format.
-
-
-                                      * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
-                                      Only used during `string -> float64` conversions.
-                                      * `json` - parses the input as a JSON string.
-                                      Only used during `string -> object` or `string -> list` conversions.
-
-
-                                      If this property is null, the default conversion is applied.
-                                    enum:
-                                    - none
-                                    - quantity
-                                    - json
-                                    type: string
-                                  toType:
-                                    description: ToType is the type of the output
-                                      of this transform.
-                                    enum:
-                                    - string
-                                    - int
-                                    - int64
-                                    - bool
-                                    - float64
-                                    - object
-                                    - array
-                                    type: string
-                                required:
-                                - toType
-                                type: object
-                              map:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                description: Map uses the input as a key in the given
-                                  map and returns the value.
-                                type: object
-                              match:
-                                description: Match is a more complex version of Map
-                                  that matches a list of patterns.
-                                properties:
-                                  fallbackTo:
-                                    default: Value
-                                    description: Determines to what value the transform
-                                      should fallback if no pattern matches.
-                                    enum:
-                                    - Value
-                                    - Input
-                                    type: string
-                                  fallbackValue:
-                                    description: |-
-                                      The fallback value that should be returned by the transform if now pattern
-                                      matches.
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  patterns:
-                                    description: |-
-                                      The patterns that should be tested against the input string.
-                                      Patterns are tested in order. The value of the first match is used as
-                                      result of this transform.
-                                    items:
-                                      description: |-
-                                        MatchTransformPattern is a transform that returns the value that matches a
-                                        pattern.
-                                      properties:
-                                        literal:
-                                          description: |-
-                                            Literal exactly matches the input string (case sensitive).
-                                            Is required if `type` is `literal`.
-                                          type: string
-                                        regexp:
-                                          description: |-
-                                            Regexp to match against the input string.
-                                            Is required if `type` is `regexp`.
-                                          type: string
-                                        result:
-                                          description: The value that is used as result
-                                            of the transform if the pattern matches.
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type:
-                                          default: literal
-                                          description: |-
-                                            Type specifies how the pattern matches the input.
-
-
-                                            * `literal` - the pattern value has to exactly match (case sensitive) the
-                                            input string. This is the default.
-
-
-                                            * `regexp` - the pattern treated as a regular expression against
-                                            which the input string is tested. Crossplane will throw an error if the
-                                            key is not a valid regexp.
-                                          enum:
-                                          - literal
-                                          - regexp
-                                          type: string
-                                      required:
-                                      - result
-                                      - type
-                                      type: object
-                                    type: array
-                                type: object
-                              math:
-                                description: |-
-                                  Math is used to transform the input via mathematical operations such as
-                                  multiplication.
-                                properties:
-                                  clampMax:
-                                    description: ClampMax makes sure that the value
-                                      is not bigger than the given value.
-                                    format: int64
-                                    type: integer
-                                  clampMin:
-                                    description: ClampMin makes sure that the value
-                                      is not smaller than the given value.
-                                    format: int64
-                                    type: integer
-                                  multiply:
-                                    description: Multiply the value.
-                                    format: int64
-                                    type: integer
-                                  type:
-                                    default: Multiply
-                                    description: Type of the math transform to be
-                                      run.
-                                    enum:
-                                    - Multiply
-                                    - ClampMin
-                                    - ClampMax
-                                    type: string
-                                type: object
-                              string:
-                                description: |-
-                                  String is used to transform the input into a string or a different kind
-                                  of string. Note that the input does not necessarily need to be a string.
-                                properties:
-                                  convert:
-                                    description: |-
-                                      Optional conversion method to be specified.
-                                      `ToUpper` and `ToLower` change the letter case of the input string.
-                                      `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
-                                      `ToJson` converts any input value into its raw JSON representation.
-                                      `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
-                                      converted to JSON.
-                                      `ToAdler32` generate a addler32 hash based on the input string.
-                                    enum:
-                                    - ToUpper
-                                    - ToLower
-                                    - ToBase64
-                                    - FromBase64
-                                    - ToJson
-                                    - ToSha1
-                                    - ToSha256
-                                    - ToSha512
-                                    - ToAdler32
-                                    type: string
-                                  fmt:
-                                    description: |-
-                                      Format the input using a Go format string. See
-                                      https://golang.org/pkg/fmt/ for details.
-                                    type: string
-                                  join:
-                                    description: Join defines parameters to join a
-                                      slice of values to a string.
-                                    properties:
-                                      separator:
-                                        description: |-
-                                          Separator defines the character that should separate the values from each
-                                          other in the joined string.
-                                        type: string
-                                    required:
-                                    - separator
-                                    type: object
-                                  regexp:
-                                    description: Extract a match from the input using
-                                      a regular expression.
-                                    properties:
-                                      group:
-                                        description: Group number to match. 0 (the
-                                          default) matches the entire expression.
-                                        type: integer
-                                      match:
-                                        description: |-
-                                          Match string. May optionally include submatches, aka capture groups.
-                                          See https://pkg.go.dev/regexp/ for details.
-                                        type: string
-                                    required:
-                                    - match
-                                    type: object
-                                  trim:
-                                    description: Trim the prefix or suffix from the
-                                      input
-                                    type: string
-                                  type:
-                                    default: Format
-                                    description: Type of the string transform to be
-                                      run.
-                                    enum:
-                                    - Format
-                                    - Convert
-                                    - TrimPrefix
-                                    - TrimSuffix
-                                    - Regexp
-                                    - Join
-                                    type: string
-                                type: object
-                              type:
-                                description: Type of the transform to be run.
-                                enum:
-                                - map
-                                - match
-                                - math
-                                - string
-                                - convert
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          type: array
-                        type:
-                          default: FromCompositeFieldPath
-                          description: |-
-                            Type sets the patching behaviour to be used. Each patch type may require
-                            its own fields to be set on the Patch object.
-                          enum:
-                          - FromCompositeFieldPath
-                          - ToCompositeFieldPath
-                          - CombineFromComposite
-                          - CombineToComposite
-                          type: string
-                      type: object
-                    type: array
-                  policy:
-                    description: |-
-                      Policy represents the Resolve and Resolution policies which apply to
-                      all EnvironmentSourceReferences in EnvironmentConfigs list.
-                    properties:
-                      resolution:
-                        default: Required
-                        description: |-
-                          Resolution specifies whether resolution of this reference is required.
-                          The default is 'Required', which means the reconcile will fail if the
-                          reference cannot be resolved. 'Optional' means this reference will be
-                          a no-op if it cannot be resolved.
-                        enum:
-                        - Required
-                        - Optional
-                        type: string
-                      resolve:
-                        description: |-
-                          Resolve specifies when this reference should be resolved. The default
-                          is 'IfNotPresent', which will attempt to resolve the reference only when
-                          the corresponding field is not present. Use 'Always' to resolve the
-                          reference on every reconcile.
-                        enum:
-                        - Always
-                        - IfNotPresent
-                        type: string
-                    type: object
-                type: object
               mode:
                 default: Resources
                 description: |-
                   Mode controls what type or "mode" of Composition will be used.
 
-
                   "Pipeline" indicates that a Composition specifies a pipeline of
                   Composition Functions, each of which is responsible for producing
                   composed resources that Crossplane should create or update.
 
-
                   "Resources" indicates that a Composition uses what is commonly referred
                   to as "Patch & Transform" or P&T composition. This mode of Composition
                   uses an array of resources, each a template for a composed resource.
-
 
                   All Compositions should use Pipeline mode. Resources mode is deprecated.
                   Resources mode won't be removed in Crossplane 1.x, and will remain the
@@ -612,10 +108,8 @@ spec:
                   resource in this Composition. PatchSets cannot themselves refer to other
                   PatchSets.
 
-
                   PatchSets are only used by the "Resources" mode of Composition. They
                   are ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -638,8 +132,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -688,8 +182,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -746,12 +240,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -827,10 +319,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -969,14 +459,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array
@@ -990,7 +476,6 @@ spec:
                   Pipeline is a list of composition function steps that will be used when a
                   composite resource referring to this composition is created. One of
                   resources and pipeline must be specified - you cannot specify both.
-
 
                   The Pipeline is only used by the "Pipeline" mode of Composition. It is
                   ignored by other modes.
@@ -1075,7 +560,6 @@ spec:
                   with which the connection details of composite resources dynamically
                   provisioned using this composition will be published.
 
-
                   THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
                   unless the relevant Crossplane feature flag is enabled, and may be
                   changed or removed without notice.
@@ -1091,10 +575,8 @@ spec:
                   Resources is a list of resource templates that will be used when a
                   composite resource referring to this composition is created.
 
-
                   Resources are only used by the "Resources" mode of Composition. They are
                   ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -1178,8 +660,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -1228,8 +710,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -1286,12 +768,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -1367,10 +847,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -1509,14 +987,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array
@@ -1587,12 +1061,15 @@ spec:
                   type: object
                 type: array
               revision:
-                description: Revision number. Newer revisions have larger numbers.
+                description: |-
+                  Revision number. Newer revisions have larger numbers.
+
+                  This number can change. When a Composition transitions from state A
+                  -> B -> A there will be only two CompositionRevisions. Crossplane will
+                  edit the original CompositionRevision to change its revision number from
+                  0 to 2.
                 format: int64
                 type: integer
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               writeConnectionSecretsToNamespace:
                 description: |-
                   WriteConnectionSecretsToNamespace specifies the namespace in which the
@@ -1685,7 +1162,6 @@ spec:
           A CompositionRevision represents a revision of a Composition. Crossplane
           creates new revisions when there are changes to the Composition.
 
-
           Crossplane creates and manages CompositionRevisions. Don't directly edit
           CompositionRevisions.
         properties:
@@ -1729,521 +1205,18 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              environment:
-                description: |-
-                  Environment configures the environment in which resources are rendered.
-
-
-                  THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
-                  unless the relevant Crossplane feature flag is enabled, and may be
-                  changed or removed without notice.
-                properties:
-                  defaultData:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
-                    description: |-
-                      DefaultData statically defines the initial state of the environment.
-                      It has the same schema-less structure as the data field in
-                      environment configs.
-                      It is overwritten by the selected environment configs.
-                    type: object
-                  environmentConfigs:
-                    description: |-
-                      EnvironmentConfigs selects a list of `EnvironmentConfig`s. The resolved
-                      resources are stored in the composite resource at
-                      `spec.environmentConfigRefs` and is only updated if it is null.
-
-
-                      The list of references is used to compute an in-memory environment at
-                      compose time. The data of all object is merged in the order they are
-                      listed, meaning the values of EnvironmentConfigs with a larger index take
-                      priority over ones with smaller indices.
-
-
-                      The computed environment can be accessed in a composition using
-                      `FromEnvironmentFieldPath` and `CombineFromEnvironment` patches.
-                    items:
-                      description: EnvironmentSource selects a EnvironmentConfig resource.
-                      properties:
-                        ref:
-                          description: |-
-                            Ref is a named reference to a single EnvironmentConfig.
-                            Either Ref or Selector is required.
-                          properties:
-                            name:
-                              description: The name of the object.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        selector:
-                          description: Selector selects EnvironmentConfig(s) via labels.
-                          properties:
-                            matchLabels:
-                              description: MatchLabels ensures an object with matching
-                                labels is selected.
-                              items:
-                                description: |-
-                                  An EnvironmentSourceSelectorLabelMatcher acts like a k8s label selector but
-                                  can draw the label value from a different path.
-                                properties:
-                                  fromFieldPathPolicy:
-                                    default: Required
-                                    description: |-
-                                      FromFieldPathPolicy specifies the policy for the valueFromFieldPath.
-                                      The default is Required, meaning that an error will be returned if the
-                                      field is not found in the composite resource.
-                                      Optional means that if the field is not found in the composite resource,
-                                      that label pair will just be skipped. N.B. other specified label
-                                      matchers will still be used to retrieve the desired
-                                      environment config, if any.
-                                    enum:
-                                    - Optional
-                                    - Required
-                                    type: string
-                                  key:
-                                    description: Key of the label to match.
-                                    type: string
-                                  type:
-                                    default: FromCompositeFieldPath
-                                    description: Type specifies where the value for
-                                      a label comes from.
-                                    enum:
-                                    - FromCompositeFieldPath
-                                    - Value
-                                    type: string
-                                  value:
-                                    description: Value specifies a literal label value.
-                                    type: string
-                                  valueFromFieldPath:
-                                    description: ValueFromFieldPath specifies the
-                                      field path to look for the label value.
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                              type: array
-                            maxMatch:
-                              description: MaxMatch specifies the number of extracted
-                                EnvironmentConfigs in Multiple mode, extracts all
-                                if nil.
-                              format: int64
-                              type: integer
-                            minMatch:
-                              description: MinMatch specifies the required minimum
-                                of extracted EnvironmentConfigs in Multiple mode.
-                              format: int64
-                              type: integer
-                            mode:
-                              default: Single
-                              description: 'Mode specifies retrieval strategy: "Single"
-                                or "Multiple".'
-                              enum:
-                              - Single
-                              - Multiple
-                              type: string
-                            sortByFieldPath:
-                              default: metadata.name
-                              description: SortByFieldPath is the path to the field
-                                based on which list of EnvironmentConfigs is alphabetically
-                                sorted.
-                              type: string
-                          type: object
-                        type:
-                          default: Reference
-                          description: |-
-                            Type specifies the way the EnvironmentConfig is selected.
-                            Default is `Reference`
-                          enum:
-                          - Reference
-                          - Selector
-                          type: string
-                      type: object
-                    type: array
-                  patches:
-                    description: |-
-                      Patches is a list of environment patches that are executed before a
-                      composition's resources are composed.
-                    items:
-                      description: EnvironmentPatch is a patch for a Composition environment.
-                      properties:
-                        combine:
-                          description: |-
-                            Combine is the patch configuration for a CombineFromComposite or
-                            CombineToComposite patch.
-                          properties:
-                            strategy:
-                              description: |-
-                                Strategy defines the strategy to use to combine the input variable values.
-                                Currently only string is supported.
-                              enum:
-                              - string
-                              type: string
-                            string:
-                              description: |-
-                                String declares that input variables should be combined into a single
-                                string, using the relevant settings for formatting purposes.
-                              properties:
-                                fmt:
-                                  description: |-
-                                    Format the input using a Go format string. See
-                                    https://golang.org/pkg/fmt/ for details.
-                                  type: string
-                              required:
-                              - fmt
-                              type: object
-                            variables:
-                              description: |-
-                                Variables are the list of variables whose values will be retrieved and
-                                combined.
-                              items:
-                                description: |-
-                                  A CombineVariable defines the source of a value that is combined with
-                                  others to form and patch an output value. Currently, this only supports
-                                  retrieving values from a field path.
-                                properties:
-                                  fromFieldPath:
-                                    description: |-
-                                      FromFieldPath is the path of the field on the source whose value is
-                                      to be used as input.
-                                    type: string
-                                required:
-                                - fromFieldPath
-                                type: object
-                              minItems: 1
-                              type: array
-                          required:
-                          - strategy
-                          - variables
-                          type: object
-                        fromFieldPath:
-                          description: |-
-                            FromFieldPath is the path of the field on the resource whose value is
-                            to be used as input. Required when type is FromCompositeFieldPath or
-                            ToCompositeFieldPath.
-                          type: string
-                        policy:
-                          description: Policy configures the specifics of patching
-                            behaviour.
-                          properties:
-                            fromFieldPath:
-                              description: |-
-                                FromFieldPath specifies how to patch from a field path. The default is
-                                'Optional', which means the patch will be a no-op if the specified
-                                fromFieldPath does not exist. Use 'Required' if the patch should fail if
-                                the specified path does not exist.
-                              enum:
-                              - Optional
-                              - Required
-                              type: string
-                            mergeOptions:
-                              description: MergeOptions Specifies merge options on
-                                a field path.
-                              properties:
-                                appendSlice:
-                                  description: Specifies that already existing elements
-                                    in a merged slice should be preserved
-                                  type: boolean
-                                keepMapValues:
-                                  description: Specifies that already existing values
-                                    in a merged map should be preserved
-                                  type: boolean
-                              type: object
-                          type: object
-                        toFieldPath:
-                          description: |-
-                            ToFieldPath is the path of the field on the resource whose value will
-                            be changed with the result of transforms. Leave empty if you'd like to
-                            propagate to the same path as fromFieldPath.
-                          type: string
-                        transforms:
-                          description: |-
-                            Transforms are the list of functions that are used as a FIFO pipe for the
-                            input to be transformed.
-                          items:
-                            description: |-
-                              Transform is a unit of process whose input is transformed into an output with
-                              the supplied configuration.
-                            properties:
-                              convert:
-                                description: Convert is used to cast the input into
-                                  the given output type.
-                                properties:
-                                  format:
-                                    description: |-
-                                      The expected input format.
-
-
-                                      * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
-                                      Only used during `string -> float64` conversions.
-                                      * `json` - parses the input as a JSON string.
-                                      Only used during `string -> object` or `string -> list` conversions.
-
-
-                                      If this property is null, the default conversion is applied.
-                                    enum:
-                                    - none
-                                    - quantity
-                                    - json
-                                    type: string
-                                  toType:
-                                    description: ToType is the type of the output
-                                      of this transform.
-                                    enum:
-                                    - string
-                                    - int
-                                    - int64
-                                    - bool
-                                    - float64
-                                    - object
-                                    - array
-                                    type: string
-                                required:
-                                - toType
-                                type: object
-                              map:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                description: Map uses the input as a key in the given
-                                  map and returns the value.
-                                type: object
-                              match:
-                                description: Match is a more complex version of Map
-                                  that matches a list of patterns.
-                                properties:
-                                  fallbackTo:
-                                    default: Value
-                                    description: Determines to what value the transform
-                                      should fallback if no pattern matches.
-                                    enum:
-                                    - Value
-                                    - Input
-                                    type: string
-                                  fallbackValue:
-                                    description: |-
-                                      The fallback value that should be returned by the transform if now pattern
-                                      matches.
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  patterns:
-                                    description: |-
-                                      The patterns that should be tested against the input string.
-                                      Patterns are tested in order. The value of the first match is used as
-                                      result of this transform.
-                                    items:
-                                      description: |-
-                                        MatchTransformPattern is a transform that returns the value that matches a
-                                        pattern.
-                                      properties:
-                                        literal:
-                                          description: |-
-                                            Literal exactly matches the input string (case sensitive).
-                                            Is required if `type` is `literal`.
-                                          type: string
-                                        regexp:
-                                          description: |-
-                                            Regexp to match against the input string.
-                                            Is required if `type` is `regexp`.
-                                          type: string
-                                        result:
-                                          description: The value that is used as result
-                                            of the transform if the pattern matches.
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type:
-                                          default: literal
-                                          description: |-
-                                            Type specifies how the pattern matches the input.
-
-
-                                            * `literal` - the pattern value has to exactly match (case sensitive) the
-                                            input string. This is the default.
-
-
-                                            * `regexp` - the pattern treated as a regular expression against
-                                            which the input string is tested. Crossplane will throw an error if the
-                                            key is not a valid regexp.
-                                          enum:
-                                          - literal
-                                          - regexp
-                                          type: string
-                                      required:
-                                      - result
-                                      - type
-                                      type: object
-                                    type: array
-                                type: object
-                              math:
-                                description: |-
-                                  Math is used to transform the input via mathematical operations such as
-                                  multiplication.
-                                properties:
-                                  clampMax:
-                                    description: ClampMax makes sure that the value
-                                      is not bigger than the given value.
-                                    format: int64
-                                    type: integer
-                                  clampMin:
-                                    description: ClampMin makes sure that the value
-                                      is not smaller than the given value.
-                                    format: int64
-                                    type: integer
-                                  multiply:
-                                    description: Multiply the value.
-                                    format: int64
-                                    type: integer
-                                  type:
-                                    default: Multiply
-                                    description: Type of the math transform to be
-                                      run.
-                                    enum:
-                                    - Multiply
-                                    - ClampMin
-                                    - ClampMax
-                                    type: string
-                                type: object
-                              string:
-                                description: |-
-                                  String is used to transform the input into a string or a different kind
-                                  of string. Note that the input does not necessarily need to be a string.
-                                properties:
-                                  convert:
-                                    description: |-
-                                      Optional conversion method to be specified.
-                                      `ToUpper` and `ToLower` change the letter case of the input string.
-                                      `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
-                                      `ToJson` converts any input value into its raw JSON representation.
-                                      `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
-                                      converted to JSON.
-                                      `ToAdler32` generate a addler32 hash based on the input string.
-                                    enum:
-                                    - ToUpper
-                                    - ToLower
-                                    - ToBase64
-                                    - FromBase64
-                                    - ToJson
-                                    - ToSha1
-                                    - ToSha256
-                                    - ToSha512
-                                    - ToAdler32
-                                    type: string
-                                  fmt:
-                                    description: |-
-                                      Format the input using a Go format string. See
-                                      https://golang.org/pkg/fmt/ for details.
-                                    type: string
-                                  join:
-                                    description: Join defines parameters to join a
-                                      slice of values to a string.
-                                    properties:
-                                      separator:
-                                        description: |-
-                                          Separator defines the character that should separate the values from each
-                                          other in the joined string.
-                                        type: string
-                                    required:
-                                    - separator
-                                    type: object
-                                  regexp:
-                                    description: Extract a match from the input using
-                                      a regular expression.
-                                    properties:
-                                      group:
-                                        description: Group number to match. 0 (the
-                                          default) matches the entire expression.
-                                        type: integer
-                                      match:
-                                        description: |-
-                                          Match string. May optionally include submatches, aka capture groups.
-                                          See https://pkg.go.dev/regexp/ for details.
-                                        type: string
-                                    required:
-                                    - match
-                                    type: object
-                                  trim:
-                                    description: Trim the prefix or suffix from the
-                                      input
-                                    type: string
-                                  type:
-                                    default: Format
-                                    description: Type of the string transform to be
-                                      run.
-                                    enum:
-                                    - Format
-                                    - Convert
-                                    - TrimPrefix
-                                    - TrimSuffix
-                                    - Regexp
-                                    - Join
-                                    type: string
-                                type: object
-                              type:
-                                description: Type of the transform to be run.
-                                enum:
-                                - map
-                                - match
-                                - math
-                                - string
-                                - convert
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          type: array
-                        type:
-                          default: FromCompositeFieldPath
-                          description: |-
-                            Type sets the patching behaviour to be used. Each patch type may require
-                            its own fields to be set on the Patch object.
-                          enum:
-                          - FromCompositeFieldPath
-                          - ToCompositeFieldPath
-                          - CombineFromComposite
-                          - CombineToComposite
-                          type: string
-                      type: object
-                    type: array
-                  policy:
-                    description: |-
-                      Policy represents the Resolve and Resolution policies which apply to
-                      all EnvironmentSourceReferences in EnvironmentConfigs list.
-                    properties:
-                      resolution:
-                        default: Required
-                        description: |-
-                          Resolution specifies whether resolution of this reference is required.
-                          The default is 'Required', which means the reconcile will fail if the
-                          reference cannot be resolved. 'Optional' means this reference will be
-                          a no-op if it cannot be resolved.
-                        enum:
-                        - Required
-                        - Optional
-                        type: string
-                      resolve:
-                        description: |-
-                          Resolve specifies when this reference should be resolved. The default
-                          is 'IfNotPresent', which will attempt to resolve the reference only when
-                          the corresponding field is not present. Use 'Always' to resolve the
-                          reference on every reconcile.
-                        enum:
-                        - Always
-                        - IfNotPresent
-                        type: string
-                    type: object
-                type: object
               mode:
                 default: Resources
                 description: |-
                   Mode controls what type or "mode" of Composition will be used.
 
-
                   "Pipeline" indicates that a Composition specifies a pipeline of
                   Composition Functions, each of which is responsible for producing
                   composed resources that Crossplane should create or update.
 
-
                   "Resources" indicates that a Composition uses what is commonly referred
                   to as "Patch & Transform" or P&T composition. This mode of Composition
                   uses an array of resources, each a template for a composed resource.
-
 
                   All Compositions should use Pipeline mode. Resources mode is deprecated.
                   Resources mode won't be removed in Crossplane 1.x, and will remain the
@@ -2259,10 +1232,8 @@ spec:
                   resource in this Composition. PatchSets cannot themselves refer to other
                   PatchSets.
 
-
                   PatchSets are only used by the "Resources" mode of Composition. They
                   are ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -2285,8 +1256,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -2335,8 +1306,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -2393,12 +1364,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -2474,10 +1443,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -2616,14 +1583,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array
@@ -2637,7 +1600,6 @@ spec:
                   Pipeline is a list of composition function steps that will be used when a
                   composite resource referring to this composition is created. One of
                   resources and pipeline must be specified - you cannot specify both.
-
 
                   The Pipeline is only used by the "Pipeline" mode of Composition. It is
                   ignored by other modes.
@@ -2722,7 +1684,6 @@ spec:
                   with which the connection details of composite resources dynamically
                   provisioned using this composition will be published.
 
-
                   THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
                   unless the relevant Crossplane feature flag is enabled, and may be
                   changed or removed without notice.
@@ -2738,10 +1699,8 @@ spec:
                   Resources is a list of resource templates that will be used when a
                   composite resource referring to this composition is created.
 
-
                   Resources are only used by the "Resources" mode of Composition. They are
                   ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -2825,8 +1784,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -2875,8 +1834,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -2933,12 +1892,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -3014,10 +1971,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -3156,14 +2111,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array
@@ -3234,12 +2185,15 @@ spec:
                   type: object
                 type: array
               revision:
-                description: Revision number. Newer revisions have larger numbers.
+                description: |-
+                  Revision number. Newer revisions have larger numbers.
+
+                  This number can change. When a Composition transitions from state A
+                  -> B -> A there will be only two CompositionRevisions. Crossplane will
+                  edit the original CompositionRevision to change its revision number from
+                  0 to 2.
                 format: int64
                 type: integer
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               writeConnectionSecretsToNamespace:
                 description: |-
                   WriteConnectionSecretsToNamespace specifies the namespace in which the

--- a/content/master/api/crds/apiextensions.crossplane.io_compositions.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_compositions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: compositions.apiextensions.crossplane.io
 spec:
   group: apiextensions.crossplane.io
@@ -34,7 +34,6 @@ spec:
         description: |-
           A Composition defines a collection of managed resources or functions that
           Crossplane uses to create and manage new composite resources.
-
 
           Read the Crossplane documentation for
           [more information about Compositions](https://docs.crossplane.io/latest/concepts/compositions).
@@ -77,521 +76,18 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              environment:
-                description: |-
-                  Environment configures the environment in which resources are rendered.
-
-
-                  THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
-                  unless the relevant Crossplane feature flag is enabled, and may be
-                  changed or removed without notice.
-                properties:
-                  defaultData:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
-                    description: |-
-                      DefaultData statically defines the initial state of the environment.
-                      It has the same schema-less structure as the data field in
-                      environment configs.
-                      It is overwritten by the selected environment configs.
-                    type: object
-                  environmentConfigs:
-                    description: |-
-                      EnvironmentConfigs selects a list of `EnvironmentConfig`s. The resolved
-                      resources are stored in the composite resource at
-                      `spec.environmentConfigRefs` and is only updated if it is null.
-
-
-                      The list of references is used to compute an in-memory environment at
-                      compose time. The data of all object is merged in the order they are
-                      listed, meaning the values of EnvironmentConfigs with a larger index take
-                      priority over ones with smaller indices.
-
-
-                      The computed environment can be accessed in a composition using
-                      `FromEnvironmentFieldPath` and `CombineFromEnvironment` patches.
-                    items:
-                      description: EnvironmentSource selects a EnvironmentConfig resource.
-                      properties:
-                        ref:
-                          description: |-
-                            Ref is a named reference to a single EnvironmentConfig.
-                            Either Ref or Selector is required.
-                          properties:
-                            name:
-                              description: The name of the object.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        selector:
-                          description: Selector selects EnvironmentConfig(s) via labels.
-                          properties:
-                            matchLabels:
-                              description: MatchLabels ensures an object with matching
-                                labels is selected.
-                              items:
-                                description: |-
-                                  An EnvironmentSourceSelectorLabelMatcher acts like a k8s label selector but
-                                  can draw the label value from a different path.
-                                properties:
-                                  fromFieldPathPolicy:
-                                    default: Required
-                                    description: |-
-                                      FromFieldPathPolicy specifies the policy for the valueFromFieldPath.
-                                      The default is Required, meaning that an error will be returned if the
-                                      field is not found in the composite resource.
-                                      Optional means that if the field is not found in the composite resource,
-                                      that label pair will just be skipped. N.B. other specified label
-                                      matchers will still be used to retrieve the desired
-                                      environment config, if any.
-                                    enum:
-                                    - Optional
-                                    - Required
-                                    type: string
-                                  key:
-                                    description: Key of the label to match.
-                                    type: string
-                                  type:
-                                    default: FromCompositeFieldPath
-                                    description: Type specifies where the value for
-                                      a label comes from.
-                                    enum:
-                                    - FromCompositeFieldPath
-                                    - Value
-                                    type: string
-                                  value:
-                                    description: Value specifies a literal label value.
-                                    type: string
-                                  valueFromFieldPath:
-                                    description: ValueFromFieldPath specifies the
-                                      field path to look for the label value.
-                                    type: string
-                                required:
-                                - key
-                                type: object
-                              type: array
-                            maxMatch:
-                              description: MaxMatch specifies the number of extracted
-                                EnvironmentConfigs in Multiple mode, extracts all
-                                if nil.
-                              format: int64
-                              type: integer
-                            minMatch:
-                              description: MinMatch specifies the required minimum
-                                of extracted EnvironmentConfigs in Multiple mode.
-                              format: int64
-                              type: integer
-                            mode:
-                              default: Single
-                              description: 'Mode specifies retrieval strategy: "Single"
-                                or "Multiple".'
-                              enum:
-                              - Single
-                              - Multiple
-                              type: string
-                            sortByFieldPath:
-                              default: metadata.name
-                              description: SortByFieldPath is the path to the field
-                                based on which list of EnvironmentConfigs is alphabetically
-                                sorted.
-                              type: string
-                          type: object
-                        type:
-                          default: Reference
-                          description: |-
-                            Type specifies the way the EnvironmentConfig is selected.
-                            Default is `Reference`
-                          enum:
-                          - Reference
-                          - Selector
-                          type: string
-                      type: object
-                    type: array
-                  patches:
-                    description: |-
-                      Patches is a list of environment patches that are executed before a
-                      composition's resources are composed.
-                    items:
-                      description: EnvironmentPatch is a patch for a Composition environment.
-                      properties:
-                        combine:
-                          description: |-
-                            Combine is the patch configuration for a CombineFromComposite or
-                            CombineToComposite patch.
-                          properties:
-                            strategy:
-                              description: |-
-                                Strategy defines the strategy to use to combine the input variable values.
-                                Currently only string is supported.
-                              enum:
-                              - string
-                              type: string
-                            string:
-                              description: |-
-                                String declares that input variables should be combined into a single
-                                string, using the relevant settings for formatting purposes.
-                              properties:
-                                fmt:
-                                  description: |-
-                                    Format the input using a Go format string. See
-                                    https://golang.org/pkg/fmt/ for details.
-                                  type: string
-                              required:
-                              - fmt
-                              type: object
-                            variables:
-                              description: |-
-                                Variables are the list of variables whose values will be retrieved and
-                                combined.
-                              items:
-                                description: |-
-                                  A CombineVariable defines the source of a value that is combined with
-                                  others to form and patch an output value. Currently, this only supports
-                                  retrieving values from a field path.
-                                properties:
-                                  fromFieldPath:
-                                    description: |-
-                                      FromFieldPath is the path of the field on the source whose value is
-                                      to be used as input.
-                                    type: string
-                                required:
-                                - fromFieldPath
-                                type: object
-                              minItems: 1
-                              type: array
-                          required:
-                          - strategy
-                          - variables
-                          type: object
-                        fromFieldPath:
-                          description: |-
-                            FromFieldPath is the path of the field on the resource whose value is
-                            to be used as input. Required when type is FromCompositeFieldPath or
-                            ToCompositeFieldPath.
-                          type: string
-                        policy:
-                          description: Policy configures the specifics of patching
-                            behaviour.
-                          properties:
-                            fromFieldPath:
-                              description: |-
-                                FromFieldPath specifies how to patch from a field path. The default is
-                                'Optional', which means the patch will be a no-op if the specified
-                                fromFieldPath does not exist. Use 'Required' if the patch should fail if
-                                the specified path does not exist.
-                              enum:
-                              - Optional
-                              - Required
-                              type: string
-                            mergeOptions:
-                              description: MergeOptions Specifies merge options on
-                                a field path.
-                              properties:
-                                appendSlice:
-                                  description: Specifies that already existing elements
-                                    in a merged slice should be preserved
-                                  type: boolean
-                                keepMapValues:
-                                  description: Specifies that already existing values
-                                    in a merged map should be preserved
-                                  type: boolean
-                              type: object
-                          type: object
-                        toFieldPath:
-                          description: |-
-                            ToFieldPath is the path of the field on the resource whose value will
-                            be changed with the result of transforms. Leave empty if you'd like to
-                            propagate to the same path as fromFieldPath.
-                          type: string
-                        transforms:
-                          description: |-
-                            Transforms are the list of functions that are used as a FIFO pipe for the
-                            input to be transformed.
-                          items:
-                            description: |-
-                              Transform is a unit of process whose input is transformed into an output with
-                              the supplied configuration.
-                            properties:
-                              convert:
-                                description: Convert is used to cast the input into
-                                  the given output type.
-                                properties:
-                                  format:
-                                    description: |-
-                                      The expected input format.
-
-
-                                      * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
-                                      Only used during `string -> float64` conversions.
-                                      * `json` - parses the input as a JSON string.
-                                      Only used during `string -> object` or `string -> list` conversions.
-
-
-                                      If this property is null, the default conversion is applied.
-                                    enum:
-                                    - none
-                                    - quantity
-                                    - json
-                                    type: string
-                                  toType:
-                                    description: ToType is the type of the output
-                                      of this transform.
-                                    enum:
-                                    - string
-                                    - int
-                                    - int64
-                                    - bool
-                                    - float64
-                                    - object
-                                    - array
-                                    type: string
-                                required:
-                                - toType
-                                type: object
-                              map:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
-                                description: Map uses the input as a key in the given
-                                  map and returns the value.
-                                type: object
-                              match:
-                                description: Match is a more complex version of Map
-                                  that matches a list of patterns.
-                                properties:
-                                  fallbackTo:
-                                    default: Value
-                                    description: Determines to what value the transform
-                                      should fallback if no pattern matches.
-                                    enum:
-                                    - Value
-                                    - Input
-                                    type: string
-                                  fallbackValue:
-                                    description: |-
-                                      The fallback value that should be returned by the transform if now pattern
-                                      matches.
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  patterns:
-                                    description: |-
-                                      The patterns that should be tested against the input string.
-                                      Patterns are tested in order. The value of the first match is used as
-                                      result of this transform.
-                                    items:
-                                      description: |-
-                                        MatchTransformPattern is a transform that returns the value that matches a
-                                        pattern.
-                                      properties:
-                                        literal:
-                                          description: |-
-                                            Literal exactly matches the input string (case sensitive).
-                                            Is required if `type` is `literal`.
-                                          type: string
-                                        regexp:
-                                          description: |-
-                                            Regexp to match against the input string.
-                                            Is required if `type` is `regexp`.
-                                          type: string
-                                        result:
-                                          description: The value that is used as result
-                                            of the transform if the pattern matches.
-                                          x-kubernetes-preserve-unknown-fields: true
-                                        type:
-                                          default: literal
-                                          description: |-
-                                            Type specifies how the pattern matches the input.
-
-
-                                            * `literal` - the pattern value has to exactly match (case sensitive) the
-                                            input string. This is the default.
-
-
-                                            * `regexp` - the pattern treated as a regular expression against
-                                            which the input string is tested. Crossplane will throw an error if the
-                                            key is not a valid regexp.
-                                          enum:
-                                          - literal
-                                          - regexp
-                                          type: string
-                                      required:
-                                      - result
-                                      - type
-                                      type: object
-                                    type: array
-                                type: object
-                              math:
-                                description: |-
-                                  Math is used to transform the input via mathematical operations such as
-                                  multiplication.
-                                properties:
-                                  clampMax:
-                                    description: ClampMax makes sure that the value
-                                      is not bigger than the given value.
-                                    format: int64
-                                    type: integer
-                                  clampMin:
-                                    description: ClampMin makes sure that the value
-                                      is not smaller than the given value.
-                                    format: int64
-                                    type: integer
-                                  multiply:
-                                    description: Multiply the value.
-                                    format: int64
-                                    type: integer
-                                  type:
-                                    default: Multiply
-                                    description: Type of the math transform to be
-                                      run.
-                                    enum:
-                                    - Multiply
-                                    - ClampMin
-                                    - ClampMax
-                                    type: string
-                                type: object
-                              string:
-                                description: |-
-                                  String is used to transform the input into a string or a different kind
-                                  of string. Note that the input does not necessarily need to be a string.
-                                properties:
-                                  convert:
-                                    description: |-
-                                      Optional conversion method to be specified.
-                                      `ToUpper` and `ToLower` change the letter case of the input string.
-                                      `ToBase64` and `FromBase64` perform a base64 conversion based on the input string.
-                                      `ToJson` converts any input value into its raw JSON representation.
-                                      `ToSha1`, `ToSha256` and `ToSha512` generate a hash value based on the input
-                                      converted to JSON.
-                                      `ToAdler32` generate a addler32 hash based on the input string.
-                                    enum:
-                                    - ToUpper
-                                    - ToLower
-                                    - ToBase64
-                                    - FromBase64
-                                    - ToJson
-                                    - ToSha1
-                                    - ToSha256
-                                    - ToSha512
-                                    - ToAdler32
-                                    type: string
-                                  fmt:
-                                    description: |-
-                                      Format the input using a Go format string. See
-                                      https://golang.org/pkg/fmt/ for details.
-                                    type: string
-                                  join:
-                                    description: Join defines parameters to join a
-                                      slice of values to a string.
-                                    properties:
-                                      separator:
-                                        description: |-
-                                          Separator defines the character that should separate the values from each
-                                          other in the joined string.
-                                        type: string
-                                    required:
-                                    - separator
-                                    type: object
-                                  regexp:
-                                    description: Extract a match from the input using
-                                      a regular expression.
-                                    properties:
-                                      group:
-                                        description: Group number to match. 0 (the
-                                          default) matches the entire expression.
-                                        type: integer
-                                      match:
-                                        description: |-
-                                          Match string. May optionally include submatches, aka capture groups.
-                                          See https://pkg.go.dev/regexp/ for details.
-                                        type: string
-                                    required:
-                                    - match
-                                    type: object
-                                  trim:
-                                    description: Trim the prefix or suffix from the
-                                      input
-                                    type: string
-                                  type:
-                                    default: Format
-                                    description: Type of the string transform to be
-                                      run.
-                                    enum:
-                                    - Format
-                                    - Convert
-                                    - TrimPrefix
-                                    - TrimSuffix
-                                    - Regexp
-                                    - Join
-                                    type: string
-                                type: object
-                              type:
-                                description: Type of the transform to be run.
-                                enum:
-                                - map
-                                - match
-                                - math
-                                - string
-                                - convert
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          type: array
-                        type:
-                          default: FromCompositeFieldPath
-                          description: |-
-                            Type sets the patching behaviour to be used. Each patch type may require
-                            its own fields to be set on the Patch object.
-                          enum:
-                          - FromCompositeFieldPath
-                          - ToCompositeFieldPath
-                          - CombineFromComposite
-                          - CombineToComposite
-                          type: string
-                      type: object
-                    type: array
-                  policy:
-                    description: |-
-                      Policy represents the Resolve and Resolution policies which apply to
-                      all EnvironmentSourceReferences in EnvironmentConfigs list.
-                    properties:
-                      resolution:
-                        default: Required
-                        description: |-
-                          Resolution specifies whether resolution of this reference is required.
-                          The default is 'Required', which means the reconcile will fail if the
-                          reference cannot be resolved. 'Optional' means this reference will be
-                          a no-op if it cannot be resolved.
-                        enum:
-                        - Required
-                        - Optional
-                        type: string
-                      resolve:
-                        description: |-
-                          Resolve specifies when this reference should be resolved. The default
-                          is 'IfNotPresent', which will attempt to resolve the reference only when
-                          the corresponding field is not present. Use 'Always' to resolve the
-                          reference on every reconcile.
-                        enum:
-                        - Always
-                        - IfNotPresent
-                        type: string
-                    type: object
-                type: object
               mode:
                 default: Resources
                 description: |-
                   Mode controls what type or "mode" of Composition will be used.
 
-
                   "Pipeline" indicates that a Composition specifies a pipeline of
                   Composition Functions, each of which is responsible for producing
                   composed resources that Crossplane should create or update.
 
-
                   "Resources" indicates that a Composition uses what is commonly referred
                   to as "Patch & Transform" or P&T composition. This mode of Composition
                   uses an array of resources, each a template for a composed resource.
-
 
                   All Compositions should use Pipeline mode. Resources mode is deprecated.
                   Resources mode won't be removed in Crossplane 1.x, and will remain the
@@ -607,10 +103,8 @@ spec:
                   resource in this Composition. PatchSets cannot themselves refer to other
                   PatchSets.
 
-
                   PatchSets are only used by the "Resources" mode of Composition. They
                   are ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -633,8 +127,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -683,8 +177,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -741,12 +235,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -822,10 +314,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -964,14 +454,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array
@@ -985,7 +471,6 @@ spec:
                   Pipeline is a list of composition function steps that will be used when a
                   composite resource referring to this composition is created. One of
                   resources and pipeline must be specified - you cannot specify both.
-
 
                   The Pipeline is only used by the "Pipeline" mode of Composition. It is
                   ignored by other modes.
@@ -1070,7 +555,6 @@ spec:
                   with which the connection details of composite resources dynamically
                   provisioned using this composition will be published.
 
-
                   THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
                   unless the relevant Crossplane feature flag is enabled, and may be
                   changed or removed without notice.
@@ -1086,10 +570,8 @@ spec:
                   Resources is a list of resource templates that will be used when a
                   composite resource referring to this composition is created.
 
-
                   Resources are only used by the "Resources" mode of Composition. They are
                   ignored by other modes.
-
 
                   Deprecated: Use Composition Functions instead.
                 items:
@@ -1173,8 +655,8 @@ spec:
                         properties:
                           combine:
                             description: |-
-                              Combine is the patch configuration for a CombineFromComposite,
-                              CombineFromEnvironment, CombineToComposite or CombineToEnvironment patch.
+                              Combine is the patch configuration for a CombineFromComposite or
+                              CombineToComposite patch.
                             properties:
                               strategy:
                                 description: |-
@@ -1223,8 +705,8 @@ spec:
                           fromFieldPath:
                             description: |-
                               FromFieldPath is the path of the field on the resource whose value is
-                              to be used as input. Required when type is FromCompositeFieldPath,
-                              FromEnvironmentFieldPath, ToCompositeFieldPath, ToEnvironmentFieldPath.
+                              to be used as input. Required when type is FromCompositeFieldPath or
+                              ToCompositeFieldPath.
                             type: string
                           patchSetName:
                             description: PatchSetName to include patches from. Required
@@ -1281,12 +763,10 @@ spec:
                                       description: |-
                                         The expected input format.
 
-
                                         * `quantity` - parses the input as a K8s [`resource.Quantity`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity).
                                         Only used during `string -> float64` conversions.
                                         * `json` - parses the input as a JSON string.
                                         Only used during `string -> object` or `string -> list` conversions.
-
 
                                         If this property is null, the default conversion is applied.
                                       enum:
@@ -1362,10 +842,8 @@ spec:
                                             description: |-
                                               Type specifies how the pattern matches the input.
 
-
                                               * `literal` - the pattern value has to exactly match (case sensitive) the
                                               input string. This is the default.
-
 
                                               * `regexp` - the pattern treated as a regular expression against
                                               which the input string is tested. Crossplane will throw an error if the
@@ -1504,14 +982,10 @@ spec:
                               its own fields to be set on the Patch object.
                             enum:
                             - FromCompositeFieldPath
-                            - FromEnvironmentFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
-                            - ToEnvironmentFieldPath
-                            - CombineFromEnvironment
                             - CombineFromComposite
                             - CombineToComposite
-                            - CombineToEnvironment
                             type: string
                         type: object
                       type: array

--- a/content/master/api/crds/apiextensions.crossplane.io_environmentconfigs.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_environmentconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: environmentconfigs.apiextensions.crossplane.io
 spec:
   group: apiextensions.crossplane.io
@@ -29,6 +29,47 @@ spec:
           An EnvironmentConfig contains user-defined unstructured values for
           use in a Composition.
 
+          Read the Crossplane documentation for
+          [more information about EnvironmentConfigs](https://docs.crossplane.io/latest/concepts/environment-configs).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          data:
+            additionalProperties:
+              x-kubernetes-preserve-unknown-fields: true
+            description: |-
+              The data of this EnvironmentConfig.
+              This may contain any kind of structure that can be serialized into JSON.
+            type: object
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          An EnvironmentConfig contains user-defined unstructured values for
+          use in a Composition.
 
           Read the Crossplane documentation for
           [more information about EnvironmentConfigs](https://docs.crossplane.io/latest/concepts/environment-configs).

--- a/content/master/api/crds/apiextensions.crossplane.io_usages.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_usages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: usages.apiextensions.crossplane.io
 spec:
   group: apiextensions.crossplane.io
@@ -32,10 +32,8 @@ spec:
         description: |-
           A Usage defines a deletion blocking relationship between two resources.
 
-
           Usages prevent accidental deletion of a single resource or deletion of
           resources with dependent resources.
-
 
           Read the Crossplane documentation for
           [more information about Compositions](https://docs.crossplane.io/latest/concepts/usages).

--- a/content/master/api/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: configurationrevisions.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -45,7 +45,6 @@ spec:
         description: |-
           A ConfigurationRevision represents a revision of a Configuration. Crossplane
           creates new revisions when there are changes to a Configuration.
-
 
           Crossplane creates and manages ConfigurationRevision. Don't directly edit
           ConfigurationRevisions.
@@ -113,10 +112,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_configurations.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_configurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: configurations.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -37,7 +37,6 @@ spec:
           A Configuration installs an OCI compatible Crossplane package, extending
           Crossplane with support for new kinds of CompositeResourceDefinitions and
           Compositions.
-
 
           Read the Crossplane documentation for
           [more information about Configuration packages](https://docs.crossplane.io/latest/concepts/packages).
@@ -99,10 +98,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_controllerconfigs.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_controllerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: controllerconfigs.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -29,7 +29,6 @@ spec:
           Deprecated: Use the
           [DeploymentRuntimeConfig](https://docs.crossplane.io/latest/concepts/providers#runtime-configuration)
           instead.
-
 
           Read the
           [Package Runtime Configuration](https://github.com/crossplane/crossplane/blob/11bbe13ea3604928cc4e24e8d0d18f3f5f7e847c/design/one-pager-package-runtime-config.md)
@@ -342,7 +341,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -357,7 +356,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -523,7 +522,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -538,7 +537,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -701,7 +700,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -716,7 +715,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -882,7 +881,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -897,7 +896,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -1025,10 +1024,13 @@ spec:
                               description: The key to select.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -1087,10 +1089,13 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -1120,10 +1125,13 @@ spec:
                       description: The ConfigMap to select from
                       properties:
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
                           description: Specify whether the ConfigMap must be defined
@@ -1138,10 +1146,13 @@ spec:
                       description: The Secret to select from
                       properties:
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
                           description: Specify whether the Secret must be defined
@@ -1179,10 +1190,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -1259,11 +1273,9 @@ spec:
                       Some volume types allow the Kubelet to change the ownership of that volume
                       to be owned by the pod:
 
-
                       1. The owning GID will be the FSGroup
                       2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
                       3. The permission bits are OR'd with rw-rw----
-
 
                       If unset, the Kubelet will not modify the ownership and permissions of any volume.
                       Note that this field cannot be set when spec.os.name is windows.
@@ -1351,7 +1363,6 @@ spec:
                           type indicates which kind of seccomp profile will be applied.
                           Valid options are:
 
-
                           Localhost - a profile defined in a file on the node should be used.
                           RuntimeDefault - the container runtime default profile should be used.
                           Unconfined - no profile should be applied.
@@ -1361,18 +1372,28 @@ spec:
                     type: object
                   supplementalGroups:
                     description: |-
-                      A list of groups applied to the first process run in each container, in addition
-                      to the container's primary GID, the fsGroup (if specified), and group memberships
-                      defined in the container image for the uid of the container process. If unspecified,
-                      no additional groups are added to any container. Note that group memberships
-                      defined in the container image for the uid of the container process are still effective,
-                      even if they are not included in this list.
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if specified).  If
+                      the SupplementalGroupsPolicy feature is enabled, the
+                      supplementalGroupsPolicy field determines whether these are in addition
+                      to or instead of any group memberships defined in the container image.
+                      If unspecified, no additional groups are added, though group memberships
+                      defined in the container image may still be used, depending on the
+                      supplementalGroupsPolicy field.
                       Note that this field cannot be set when spec.os.name is windows.
                     items:
                       format: int64
                       type: integer
                     type: array
                     x-kubernetes-list-type: atomic
+                  supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                      (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                      and the container runtime must implement support for this feature.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
                   sysctls:
                     description: |-
                       Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -1494,10 +1515,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -1508,6 +1527,12 @@ spec:
                             Name must match the name of one entry in pod.spec.resourceClaims of
                             the Pod where this field is used. It makes that resource available
                             inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -1620,7 +1645,7 @@ spec:
                   procMount:
                     description: |-
                       procMount denotes the type of proc mount to use for the containers.
-                      The default is DefaultProcMount which uses the container runtime defaults for
+                      The default value is Default which uses the container runtime defaults for
                       readonly paths and masked paths.
                       This requires the ProcMountType feature flag to be enabled.
                       Note that this field cannot be set when spec.os.name is windows.
@@ -1701,7 +1726,6 @@ spec:
                         description: |-
                           type indicates which kind of seccomp profile will be applied.
                           Valid options are:
-
 
                           Localhost - a profile defined in a file on the node should be used.
                           RuntimeDefault - the container runtime default profile should be used.
@@ -1832,9 +1856,7 @@ spec:
                         RecursiveReadOnly specifies whether read-only mounts should be handled
                         recursively.
 
-
                         If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                         If ReadOnly is true, and this field is set to Disabled, the mount is not made
                         recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -1843,10 +1865,8 @@ spec:
                         supported by the container runtime, otherwise the pod will not be started and
                         an error will be generated to indicate the reason.
 
-
                         If this field is set to IfPossible or Enabled, MountPropagation must be set to
                         None (or be unspecified, which defaults to None).
-
 
                         If this field is not specified, it is treated as an equivalent of Disabled.
                       type: string
@@ -1887,7 +1907,6 @@ spec:
                             Tip: Ensure that the filesystem type is supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
                           description: |-
@@ -1927,6 +1946,7 @@ spec:
                             storage
                           type: string
                         fsType:
+                          default: ext4
                           description: |-
                             fsType is Filesystem type to mount.
                             Must be a filesystem type supported by the host operating system.
@@ -1939,6 +1959,7 @@ spec:
                             disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
+                          default: false
                           description: |-
                             readOnly Defaults to false (read/write). ReadOnly here will force
                             the ReadOnly setting in VolumeMounts.
@@ -2000,10 +2021,13 @@ spec:
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2039,10 +2063,13 @@ spec:
                             to OpenStack.
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2108,10 +2135,13 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         name:
+                          default: ""
                           description: |-
                             Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
                           description: optional specify whether the ConfigMap or its
@@ -2144,10 +2174,13 @@ spec:
                             secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2284,7 +2317,6 @@ spec:
                         The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                         and deleted when the pod is removed.
 
-
                         Use this if:
                         a) the volume is only needed while the pod runs,
                         b) features of normal volumes like restoring from snapshot or capacity
@@ -2295,16 +2327,13 @@ spec:
                            information on the connection between this volume type
                            and PersistentVolumeClaim).
 
-
                         Use PersistentVolumeClaim or one of the vendor-specific
                         APIs for volumes that persist for longer than the lifecycle
                         of an individual pod.
 
-
                         Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                         be used that way - see the documentation of the driver for
                         more information.
-
 
                         A pod can use both types of ephemeral volumes and
                         persistent volumes at the same time.
@@ -2319,7 +2348,6 @@ spec:
                             entry. Pod validation will reject the pod if the concatenated name
                             is not valid for a PVC (for example, too long).
 
-
                             An existing PVC with that name that is not owned by the pod
                             will *not* be used for the pod to avoid using an unrelated
                             volume by mistake. Starting the pod is then blocked until
@@ -2329,10 +2357,8 @@ spec:
                             this should not be necessary, but it may be useful when
                             manually reconstructing a broken cluster.
 
-
                             This field is read-only and no changes will be made by Kubernetes
                             to the PVC after it has been created.
-
 
                             Required, must not be nil.
                           properties:
@@ -2553,7 +2579,7 @@ spec:
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -2579,7 +2605,6 @@ spec:
                             fsType is the filesystem type to mount.
                             Must be a filesystem type supported by the host operating system.
                             Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
                           description: 'lun is Optional: FC target lun number'
@@ -2641,10 +2666,13 @@ spec:
                             scripts.
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2678,7 +2706,6 @@ spec:
                             Tip: Ensure that the filesystem type is supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
                           description: |-
@@ -2759,9 +2786,6 @@ spec:
                         used for system agents or other privileged things that are allowed
                         to see the host machine. Most containers will NOT need this.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
                           description: |-
@@ -2777,6 +2801,41 @@ spec:
                           type: string
                       required:
                       - path
+                      type: object
+                    image:
+                      description: |-
+                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                      properties:
+                        pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          type: string
+                        reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
+                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
                       type: object
                     iscsi:
                       description: |-
@@ -2798,7 +2857,6 @@ spec:
                             Tip: Ensure that the filesystem type is supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
                           description: |-
@@ -2810,6 +2868,7 @@ spec:
                           description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
+                          default: default
                           description: |-
                             iscsiInterface is the interface Name that uses an iSCSI transport.
                             Defaults to 'default' (tcp).
@@ -2836,10 +2895,13 @@ spec:
                             and initiator authentication
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2956,23 +3018,23 @@ spec:
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
                             properties:
                               clusterTrustBundle:
                                 description: |-
                                   ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                   of ClusterTrustBundle objects in an auto-updating file.
 
-
                                   Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                   ClusterTrustBundle objects can either be selected by name, or by the
                                   combination of signer name and a label selector.
-
 
                                   Kubelet performs aggressive normalization of the PEM contents written
                                   into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -3101,10 +3163,13 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: optional specify whether the ConfigMap
@@ -3236,10 +3301,13 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   name:
+                                    default: ""
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: optional field specify whether the
@@ -3329,7 +3397,6 @@ spec:
                             Tip: Ensure that the filesystem type is supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
                           description: |-
@@ -3337,6 +3404,7 @@ spec:
                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
+                          default: /etc/ceph/keyring
                           description: |-
                             keyring is the path to key ring for RBDUser.
                             Default is /etc/ceph/keyring.
@@ -3351,6 +3419,7 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         pool:
+                          default: rbd
                           description: |-
                             pool is the rados pool name.
                             Default is rbd.
@@ -3370,14 +3439,18 @@ spec:
                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
+                          default: admin
                           description: |-
                             user is the rados user name.
                             Default is admin.
@@ -3392,6 +3465,7 @@ spec:
                         attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          default: xfs
                           description: |-
                             fsType is the filesystem type to mount.
                             Must be a filesystem type supported by the host operating system.
@@ -3417,10 +3491,13 @@ spec:
                             sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3429,6 +3506,7 @@ spec:
                             with Gateway, default false
                           type: boolean
                         storageMode:
+                          default: ThinProvisioned
                           description: |-
                             storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                             Default is ThinProvisioned.
@@ -3536,10 +3614,13 @@ spec:
                             credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
+                              default: ""
                               description: |-
                                 Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: deploymentruntimeconfigs.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -25,7 +25,6 @@ spec:
         description: |-
           The DeploymentRuntimeConfig provides settings for the Kubernetes Deployment
           of a Provider or composition function package.
-
 
           Read the Crossplane documentation for
           [more information about DeploymentRuntimeConfigs](https://docs.crossplane.io/latest/concepts/providers/#runtime-configuration).
@@ -177,9 +176,6 @@ spec:
                             description: |-
                               Rolling update config params. Present only if DeploymentStrategyType =
                               RollingUpdate.
-                              ---
-                              TODO: Update this to follow our convention for oneOf, whatever we decide it
-                              to be.
                             properties:
                               maxSurge:
                                 anyOf:
@@ -553,7 +549,7 @@ spec:
                                                     pod labels will be ignored. The default value is empty.
                                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                   items:
                                                     type: string
                                                   type: array
@@ -568,7 +564,7 @@ spec:
                                                     pod labels will be ignored. The default value is empty.
                                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                   items:
                                                     type: string
                                                   type: array
@@ -738,7 +734,7 @@ spec:
                                                 pod labels will be ignored. The default value is empty.
                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                               items:
                                                 type: string
                                               type: array
@@ -753,7 +749,7 @@ spec:
                                                 pod labels will be ignored. The default value is empty.
                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                               items:
                                                 type: string
                                               type: array
@@ -922,7 +918,7 @@ spec:
                                                     pod labels will be ignored. The default value is empty.
                                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                   items:
                                                     type: string
                                                   type: array
@@ -937,7 +933,7 @@ spec:
                                                     pod labels will be ignored. The default value is empty.
                                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                   items:
                                                     type: string
                                                   type: array
@@ -1107,7 +1103,7 @@ spec:
                                                 pod labels will be ignored. The default value is empty.
                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                               items:
                                                 type: string
                                               type: array
@@ -1122,7 +1118,7 @@ spec:
                                                 pod labels will be ignored. The default value is empty.
                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                               items:
                                                 type: string
                                               type: array
@@ -1284,10 +1280,13 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1354,10 +1353,13 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1391,10 +1393,13 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -1411,10 +1416,13 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1719,10 +1727,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -1940,10 +1948,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -2098,10 +2106,8 @@ spec:
                                             Claims lists the names of resources, defined in spec.resourceClaims,
                                             that are used by this container.
 
-
                                             This is an alpha field and requires enabling the
                                             DynamicResourceAllocation feature gate.
-
 
                                             This field is immutable. It can only be set for containers.
                                           items:
@@ -2113,6 +2119,12 @@ spec:
                                                   Name must match the name of one entry in pod.spec.resourceClaims of
                                                   the Pod where this field is used. It makes that resource available
                                                   inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
                                                 type: string
                                             required:
                                             - name
@@ -2237,7 +2249,7 @@ spec:
                                         procMount:
                                           description: |-
                                             procMount denotes the type of proc mount to use for the containers.
-                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
                                             This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
@@ -2318,7 +2330,6 @@ spec:
                                               description: |-
                                                 type indicates which kind of seccomp profile will be applied.
                                                 Valid options are:
-
 
                                                 Localhost - a profile defined in a file on the node should be used.
                                                 RuntimeDefault - the container runtime default profile should be used.
@@ -2404,10 +2415,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -2629,9 +2640,7 @@ spec:
                                               RecursiveReadOnly specifies whether read-only mounts should be handled
                                               recursively.
 
-
                                               If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                               If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                               recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -2640,10 +2649,8 @@ spec:
                                               supported by the container runtime, otherwise the pod will not be started and
                                               an error will be generated to indicate the reason.
 
-
                                               If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                               None (or be unspecified, which defaults to None).
-
 
                                               If this field is not specified, it is treated as an equivalent of Disabled.
                                             type: string
@@ -2753,7 +2760,6 @@ spec:
                                     removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
                                     Pod to exceed its resource allocation.
 
-
                                     To add an ephemeral container, use the ephemeralcontainers subresource of an existing
                                     Pod. Ephemeral containers may not be removed or restarted.
                                   properties:
@@ -2821,10 +2827,13 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2891,10 +2900,13 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2928,10 +2940,13 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -2948,10 +2963,13 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3250,10 +3268,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -3461,10 +3479,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -3618,10 +3636,8 @@ spec:
                                             Claims lists the names of resources, defined in spec.resourceClaims,
                                             that are used by this container.
 
-
                                             This is an alpha field and requires enabling the
                                             DynamicResourceAllocation feature gate.
-
 
                                             This field is immutable. It can only be set for containers.
                                           items:
@@ -3633,6 +3649,12 @@ spec:
                                                   Name must match the name of one entry in pod.spec.resourceClaims of
                                                   the Pod where this field is used. It makes that resource available
                                                   inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
                                                 type: string
                                             required:
                                             - name
@@ -3745,7 +3767,7 @@ spec:
                                         procMount:
                                           description: |-
                                             procMount denotes the type of proc mount to use for the containers.
-                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
                                             This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
@@ -3827,7 +3849,6 @@ spec:
                                                 type indicates which kind of seccomp profile will be applied.
                                                 Valid options are:
 
-
                                                 Localhost - a profile defined in a file on the node should be used.
                                                 RuntimeDefault - the container runtime default profile should be used.
                                                 Unconfined - no profile should be applied.
@@ -3906,10 +3927,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -4052,7 +4073,6 @@ spec:
                                         The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
                                         If not set then the ephemeral container uses the namespaces configured in the Pod spec.
 
-
                                         The container runtime must implement support for this feature. If the runtime does not
                                         support namespace targeting then the result of setting this field is undefined.
                                       type: string
@@ -4141,9 +4161,7 @@ spec:
                                               RecursiveReadOnly specifies whether read-only mounts should be handled
                                               recursively.
 
-
                                               If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                               If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                               recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -4152,10 +4170,8 @@ spec:
                                               supported by the container runtime, otherwise the pod will not be started and
                                               an error will be generated to indicate the reason.
 
-
                                               If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                               None (or be unspecified, which defaults to None).
-
 
                                               If this field is not specified, it is treated as an equivalent of Disabled.
                                             type: string
@@ -4262,10 +4278,13 @@ spec:
                                     referenced object inside the same namespace.
                                   properties:
                                     name:
+                                      default: ""
                                       description: |-
                                         Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   required:
                                   - name
@@ -4358,10 +4377,13 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4428,10 +4450,13 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4465,10 +4490,13 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -4485,10 +4513,13 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
+                                                default: ""
                                                 description: |-
                                                   Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4793,10 +4824,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -5014,10 +5045,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -5172,10 +5203,8 @@ spec:
                                             Claims lists the names of resources, defined in spec.resourceClaims,
                                             that are used by this container.
 
-
                                             This is an alpha field and requires enabling the
                                             DynamicResourceAllocation feature gate.
-
 
                                             This field is immutable. It can only be set for containers.
                                           items:
@@ -5187,6 +5216,12 @@ spec:
                                                   Name must match the name of one entry in pod.spec.resourceClaims of
                                                   the Pod where this field is used. It makes that resource available
                                                   inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
                                                 type: string
                                             required:
                                             - name
@@ -5311,7 +5346,7 @@ spec:
                                         procMount:
                                           description: |-
                                             procMount denotes the type of proc mount to use for the containers.
-                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
                                             This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
@@ -5392,7 +5427,6 @@ spec:
                                               description: |-
                                                 type indicates which kind of seccomp profile will be applied.
                                                 Valid options are:
-
 
                                                 Localhost - a profile defined in a file on the node should be used.
                                                 RuntimeDefault - the container runtime default profile should be used.
@@ -5478,10 +5512,10 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
+                                              default: ""
                                               description: |-
                                                 Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                                 If this is not specified, the default behavior is defined by gRPC.
                                               type: string
@@ -5703,9 +5737,7 @@ spec:
                                               RecursiveReadOnly specifies whether read-only mounts should be handled
                                               recursively.
 
-
                                               If ReadOnly is false, this field has no meaning and must be unspecified.
-
 
                                               If ReadOnly is true, and this field is set to Disabled, the mount is not made
                                               recursively read-only.  If this field is set to IfPossible, the mount is made
@@ -5714,10 +5746,8 @@ spec:
                                               supported by the container runtime, otherwise the pod will not be started and
                                               an error will be generated to indicate the reason.
 
-
                                               If this field is set to IfPossible or Enabled, MountPropagation must be set to
                                               None (or be unspecified, which defaults to None).
-
 
                                               If this field is not specified, it is treated as an equivalent of Disabled.
                                             type: string
@@ -5757,9 +5787,11 @@ spec:
                                 x-kubernetes-list-type: map
                               nodeName:
                                 description: |-
-                                  NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
-                                  the scheduler simply schedules this pod onto that node, assuming that it fits resource
-                                  requirements.
+                                  NodeName indicates in which node this pod is scheduled.
+                                  If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                                  Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                                  This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                                  https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                                 type: string
                               nodeSelector:
                                 additionalProperties:
@@ -5775,10 +5807,8 @@ spec:
                                   Specifies the OS of the containers in the pod.
                                   Some pod and container fields are restricted if this is set.
 
-
                                   If the OS field is set to linux, the following fields must be unset:
                                   -securityContext.windowsOptions
-
 
                                   If the OS field is set to windows, following fields must be unset:
                                   - spec.hostPID
@@ -5794,6 +5824,7 @@ spec:
                                   - spec.securityContext.runAsUser
                                   - spec.securityContext.runAsGroup
                                   - spec.securityContext.supplementalGroups
+                                  - spec.securityContext.supplementalGroupsPolicy
                                   - spec.containers[*].securityContext.appArmorProfile
                                   - spec.containers[*].securityContext.seLinuxOptions
                                   - spec.containers[*].securityContext.seccompProfile
@@ -5882,15 +5913,16 @@ spec:
                                   will be made available to those containers which consume them
                                   by name.
 
-
                                   This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
-
 
                                   This field is immutable.
                                 items:
                                   description: |-
-                                    PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                    PodResourceClaim references exactly one ResourceClaim, either directly
+                                    or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                                    for the pod.
+
                                     It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                                     Containers that need access to the ResourceClaim reference it with this name.
                                   properties:
@@ -5899,33 +5931,32 @@ spec:
                                         Name uniquely identifies this resource claim inside the pod.
                                         This must be a DNS_LABEL.
                                       type: string
-                                    source:
-                                      description: Source describes where to find
-                                        the ResourceClaim.
-                                      properties:
-                                        resourceClaimName:
-                                          description: |-
-                                            ResourceClaimName is the name of a ResourceClaim object in the same
-                                            namespace as this pod.
-                                          type: string
-                                        resourceClaimTemplateName:
-                                          description: |-
-                                            ResourceClaimTemplateName is the name of a ResourceClaimTemplate
-                                            object in the same namespace as this pod.
+                                    resourceClaimName:
+                                      description: |-
+                                        ResourceClaimName is the name of a ResourceClaim object in the same
+                                        namespace as this pod.
 
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      description: |-
+                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                        object in the same namespace as this pod.
 
-                                            The template will be used to create a new ResourceClaim, which will
-                                            be bound to this pod. When this pod is deleted, the ResourceClaim
-                                            will also be deleted. The pod name and resource name, along with a
-                                            generated component, will be used to form a unique name for the
-                                            ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+                                        The template will be used to create a new ResourceClaim, which will
+                                        be bound to this pod. When this pod is deleted, the ResourceClaim
+                                        will also be deleted. The pod name and resource name, along with a
+                                        generated component, will be used to form a unique name for the
+                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
 
+                                        This field is immutable and no changes will be made to the
+                                        corresponding ResourceClaim by the control plane after creating the
+                                        ResourceClaim.
 
-                                            This field is immutable and no changes will be made to the
-                                            corresponding ResourceClaim by the control plane after creating the
-                                            ResourceClaim.
-                                          type: string
-                                      type: object
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
                                   required:
                                   - name
                                   type: object
@@ -5958,7 +5989,6 @@ spec:
                                   SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
                                   If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
                                   scheduler will not attempt to schedule the pod.
-
 
                                   SchedulingGates can only be set at pod creation time, and be removed only afterwards.
                                 items:
@@ -6011,11 +6041,9 @@ spec:
                                       Some volume types allow the Kubelet to change the ownership of that volume
                                       to be owned by the pod:
 
-
                                       1. The owning GID will be the FSGroup
                                       2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
                                       3. The permission bits are OR'd with rw-rw----
-
 
                                       If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                       Note that this field cannot be set when spec.os.name is windows.
@@ -6103,7 +6131,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -6113,18 +6140,28 @@ spec:
                                     type: object
                                   supplementalGroups:
                                     description: |-
-                                      A list of groups applied to the first process run in each container, in addition
-                                      to the container's primary GID, the fsGroup (if specified), and group memberships
-                                      defined in the container image for the uid of the container process. If unspecified,
-                                      no additional groups are added to any container. Note that group memberships
-                                      defined in the container image for the uid of the container process are still effective,
-                                      even if they are not included in this list.
+                                      A list of groups applied to the first process run in each container, in
+                                      addition to the container's primary GID and fsGroup (if specified).  If
+                                      the SupplementalGroupsPolicy feature is enabled, the
+                                      supplementalGroupsPolicy field determines whether these are in addition
+                                      to or instead of any group memberships defined in the container image.
+                                      If unspecified, no additional groups are added, though group memberships
+                                      defined in the container image may still be used, depending on the
+                                      supplementalGroupsPolicy field.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     items:
                                       format: int64
                                       type: integer
                                     type: array
                                     x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    description: |-
+                                      Defines how supplemental groups of the first container processes are calculated.
+                                      Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                      (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                      and the container runtime must implement support for this feature.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
                                   sysctls:
                                     description: |-
                                       Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -6332,7 +6369,6 @@ spec:
                                         Keys that don't exist in the incoming pod labels will
                                         be ignored. A null or empty list means only match against labelSelector.
 
-
                                         This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                       items:
                                         type: string
@@ -6372,7 +6408,6 @@ spec:
                                         Valid values are integers greater than 0.
                                         When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                                         For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                                         labelSelector spread as 2/2/2:
                                         | zone1 | zone2 | zone3 |
@@ -6390,7 +6425,6 @@ spec:
                                         - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
-
                                         If this value is nil, the behavior is equivalent to the Honor policy.
                                         This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                       type: string
@@ -6401,7 +6435,6 @@ spec:
                                         - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                                         has a toleration, are included.
                                         - Ignore: node taints are ignored. All nodes are included.
-
 
                                         If this value is nil, the behavior is equivalent to the Ignore policy.
                                         This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -6471,7 +6504,6 @@ spec:
                                             Tip: Ensure that the filesystem type is supported by the host operating system.
                                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
                                           description: |-
@@ -6512,6 +6544,7 @@ spec:
                                             disk in the blob storage
                                           type: string
                                         fsType:
+                                          default: ext4
                                           description: |-
                                             fsType is Filesystem type to mount.
                                             Must be a filesystem type supported by the host operating system.
@@ -6525,6 +6558,7 @@ spec:
                                             availability set). defaults to shared'
                                           type: string
                                         readOnly:
+                                          default: false
                                           description: |-
                                             readOnly Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
@@ -6590,10 +6624,13 @@ spec:
                                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -6629,10 +6666,13 @@ spec:
                                             to OpenStack.
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -6699,10 +6739,13 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         name:
+                                          default: ""
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description: optional specify whether the
@@ -6735,10 +6778,13 @@ spec:
                                             secret object contains more than one secret, all secret references are passed.
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -6886,7 +6932,6 @@ spec:
                                         The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                         and deleted when the pod is removed.
 
-
                                         Use this if:
                                         a) the volume is only needed while the pod runs,
                                         b) features of normal volumes like restoring from snapshot or capacity
@@ -6897,16 +6942,13 @@ spec:
                                            information on the connection between this volume type
                                            and PersistentVolumeClaim).
 
-
                                         Use PersistentVolumeClaim or one of the vendor-specific
                                         APIs for volumes that persist for longer than the lifecycle
                                         of an individual pod.
 
-
                                         Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                                         be used that way - see the documentation of the driver for
                                         more information.
-
 
                                         A pod can use both types of ephemeral volumes and
                                         persistent volumes at the same time.
@@ -6921,7 +6963,6 @@ spec:
                                             entry. Pod validation will reject the pod if the concatenated name
                                             is not valid for a PVC (for example, too long).
 
-
                                             An existing PVC with that name that is not owned by the pod
                                             will *not* be used for the pod to avoid using an unrelated
                                             volume by mistake. Starting the pod is then blocked until
@@ -6931,10 +6972,8 @@ spec:
                                             this should not be necessary, but it may be useful when
                                             manually reconstructing a broken cluster.
 
-
                                             This field is read-only and no changes will be made by Kubernetes
                                             to the PVC after it has been created.
-
 
                                             Required, must not be nil.
                                           properties:
@@ -7158,7 +7197,7 @@ spec:
                                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                                     exists.
                                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                                   type: string
                                                 volumeMode:
                                                   description: |-
@@ -7185,7 +7224,6 @@ spec:
                                             fsType is the filesystem type to mount.
                                             Must be a filesystem type supported by the host operating system.
                                             Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         lun:
                                           description: 'lun is Optional: FC target
@@ -7248,10 +7286,13 @@ spec:
                                             scripts.
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -7287,7 +7328,6 @@ spec:
                                             Tip: Ensure that the filesystem type is supported by the host operating system.
                                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
                                           description: |-
@@ -7368,9 +7408,6 @@ spec:
                                         used for system agents or other privileged things that are allowed
                                         to see the host machine. Most containers will NOT need this.
                                         More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        ---
-                                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                        mount host directories as read/write.
                                       properties:
                                         path:
                                           description: |-
@@ -7386,6 +7423,41 @@ spec:
                                           type: string
                                       required:
                                       - path
+                                      type: object
+                                    image:
+                                      description: |-
+                                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                      properties:
+                                        pullPolicy:
+                                          description: |-
+                                            Policy for pulling OCI objects. Possible values are:
+                                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                          type: string
+                                        reference:
+                                          description: |-
+                                            Required: Image or artifact reference to be used.
+                                            Behaves in the same way as pod.spec.containers[*].image.
+                                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                            More info: https://kubernetes.io/docs/concepts/containers/images
+                                            This field is optional to allow higher level config management to default or override
+                                            container images in workload controllers like Deployments and StatefulSets.
+                                          type: string
                                       type: object
                                     iscsi:
                                       description: |-
@@ -7407,7 +7479,6 @@ spec:
                                             Tip: Ensure that the filesystem type is supported by the host operating system.
                                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         initiatorName:
                                           description: |-
@@ -7420,6 +7491,7 @@ spec:
                                             Name.
                                           type: string
                                         iscsiInterface:
+                                          default: default
                                           description: |-
                                             iscsiInterface is the interface Name that uses an iSCSI transport.
                                             Defaults to 'default' (tcp).
@@ -7447,10 +7519,13 @@ spec:
                                             for iSCSI target and initiator authentication
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -7571,24 +7646,23 @@ spec:
                                           format: int32
                                           type: integer
                                         sources:
-                                          description: sources is the list of volume
-                                            projections
+                                          description: |-
+                                            sources is the list of volume projections. Each entry in this list
+                                            handles one source.
                                           items:
-                                            description: Projection that may be projected
-                                              along with other supported volume types
+                                            description: |-
+                                              Projection that may be projected along with other supported volume types.
+                                              Exactly one of these fields must be set.
                                             properties:
                                               clusterTrustBundle:
                                                 description: |-
                                                   ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                                   of ClusterTrustBundle objects in an auto-updating file.
 
-
                                                   Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                                   ClusterTrustBundle objects can either be selected by name, or by the
                                                   combination of signer name and a label selector.
-
 
                                                   Kubelet performs aggressive normalization of the PEM contents written
                                                   into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -7722,10 +7796,13 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: optional specify
@@ -7873,10 +7950,13 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                   name:
+                                                    default: ""
                                                     description: |-
                                                       Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: optional field specify
@@ -7968,7 +8048,6 @@ spec:
                                             Tip: Ensure that the filesystem type is supported by the host operating system.
                                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         image:
                                           description: |-
@@ -7976,6 +8055,7 @@ spec:
                                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         keyring:
+                                          default: /etc/ceph/keyring
                                           description: |-
                                             keyring is the path to key ring for RBDUser.
                                             Default is /etc/ceph/keyring.
@@ -7990,6 +8070,7 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         pool:
+                                          default: rbd
                                           description: |-
                                             pool is the rados pool name.
                                             Default is rbd.
@@ -8009,14 +8090,18 @@ spec:
                                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
+                                          default: admin
                                           description: |-
                                             user is the rados user name.
                                             Default is admin.
@@ -8032,6 +8117,7 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
+                                          default: xfs
                                           description: |-
                                             fsType is the filesystem type to mount.
                                             Must be a filesystem type supported by the host operating system.
@@ -8058,10 +8144,13 @@ spec:
                                             sensitive information. If this is not provided, Login operation will fail.
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -8071,6 +8160,7 @@ spec:
                                             false
                                           type: boolean
                                         storageMode:
+                                          default: ThinProvisioned
                                           description: |-
                                             storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                             Default is ThinProvisioned.
@@ -8181,10 +8271,13 @@ spec:
                                             credentials.  If not specified, default values will be attempted.
                                           properties:
                                             name:
+                                              default: ""
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_functionrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_functionrevisions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: functionrevisions.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -45,7 +45,6 @@ spec:
         description: |-
           A FunctionRevision represents a revision of a Function. Crossplane
           creates new revisions when there are changes to the Function.
-
 
           Crossplane creates and manages FunctionRevisions. Don't directly edit
           FunctionRevisions.
@@ -125,10 +124,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -362,7 +364,6 @@ spec:
           A FunctionRevision represents a revision of a Function. Crossplane
           creates new revisions when there are changes to the Function.
 
-
           Crossplane creates and manages FunctionRevisions. Don't directly edit
           FunctionRevisions.
         properties:
@@ -441,10 +442,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_functions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_functions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: functions.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -36,7 +36,6 @@ spec:
         description: |-
           A Function installs an OCI compatible Crossplane package, extending
           Crossplane with support for a new kind of composition function.
-
 
           Read the Crossplane documentation for
           [more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).
@@ -108,10 +107,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -253,7 +255,6 @@ spec:
           A Function installs an OCI compatible Crossplane package, extending
           Crossplane with support for a new kind of composition function.
 
-
           Read the Crossplane documentation for
           [more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).
         properties:
@@ -324,10 +325,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_imageconfigs.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_imageconfigs.yaml
@@ -1,0 +1,230 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: imageconfigs.pkg.crossplane.io
+spec:
+  group: pkg.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: ImageConfig
+    listKind: ImageConfigList
+    plural: imageconfigs
+    singular: imageconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: The ImageConfig resource is used to configure settings for package
+          images.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageConfigSpec contains the configuration for matching images.
+            properties:
+              matchImages:
+                description: MatchImages is a list of image matching rules that should
+                  be satisfied.
+                items:
+                  description: ImageMatch defines a rule for matching image.
+                  properties:
+                    prefix:
+                      description: Prefix is the prefix that should be matched.
+                      type: string
+                    type:
+                      default: Prefix
+                      description: Type is the type of match.
+                      enum:
+                      - Prefix
+                      type: string
+                  required:
+                  - prefix
+                  type: object
+                type: array
+                x-kubernetes-validations:
+                - message: matchImages should have at least one element.
+                  rule: size(self) > 0
+              registry:
+                description: Registry is the configuration for the registry.
+                properties:
+                  authentication:
+                    description: Authentication is the authentication information
+                      for the registry.
+                    properties:
+                      pullSecretRef:
+                        description: |-
+                          PullSecretRef is a reference to a secret that contains the credentials for
+                          the registry.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - pullSecretRef
+                    type: object
+                type: object
+              verification:
+                description: Verification contains the configuration for verifying
+                  the image.
+                properties:
+                  cosign:
+                    description: Cosign is the configuration for verifying the image
+                      using cosign.
+                    properties:
+                      authorities:
+                        description: Authorities defines the rules for discovering
+                          and validating signatures.
+                        items:
+                          description: CosignAuthority defines the rules for discovering
+                            and validating signatures.
+                          properties:
+                            attestations:
+                              description: |-
+                                Attestations is a list of individual attestations for this authority,
+                                once the signature for this authority has been verified.
+                              items:
+                                description: |-
+                                  Attestation defines the type of attestation to validate and optionally
+                                  apply a policy decision to it. Authority block is used to verify the
+                                  specified attestation types, and if Policy is specified, then it's applied
+                                  only after the validation of the Attestation signature has been verified.
+                                properties:
+                                  name:
+                                    description: Name of the attestation.
+                                    type: string
+                                  predicateType:
+                                    description: |-
+                                      PredicateType defines which predicate type to verify. Matches cosign
+                                      verify-attestation options.
+                                    type: string
+                                required:
+                                - name
+                                - predicateType
+                                type: object
+                              type: array
+                            key:
+                              description: Key defines the type of key to validate
+                                the image.
+                              properties:
+                                hashAlgorithm:
+                                  default: sha256
+                                  description: HashAlgorithm always defaults to sha256
+                                    if the algorithm hasn't been explicitly set
+                                  type: string
+                                secretRef:
+                                  description: SecretRef sets a reference to a secret
+                                    with the key.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: Name of the secret.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - hashAlgorithm
+                              - secretRef
+                              type: object
+                            keyless:
+                              description: |-
+                                Keyless sets the configuration to verify the authority against a Fulcio
+                                instance.
+                              properties:
+                                identities:
+                                  description: Identities sets a list of identities.
+                                  items:
+                                    description: |-
+                                      Identity may contain the issuer and/or the subject found in the transparency
+                                      log.
+                                      Issuer/Subject uses a strict match, while IssuerRegExp and SubjectRegExp
+                                      apply a regexp for matching.
+                                    properties:
+                                      issuer:
+                                        description: Issuer defines the issuer for
+                                          this identity.
+                                        type: string
+                                      issuerRegExp:
+                                        description: |-
+                                          IssuerRegExp specifies a regular expression to match the issuer for this identity.
+                                          This has precedence over the Issuer field.
+                                        type: string
+                                      subject:
+                                        description: Subject defines the subject for
+                                          this identity.
+                                        type: string
+                                      subjectRegExp:
+                                        description: |-
+                                          SubjectRegExp specifies a regular expression to match the subject for this identity.
+                                          This has precedence over the Subject field.
+                                        type: string
+                                    type: object
+                                  type: array
+                                insecureIgnoreSCT:
+                                  description: InsecureIgnoreSCT omits verifying if
+                                    a certificate contains an embedded SCT
+                                  type: boolean
+                              required:
+                              - identities
+                              type: object
+                            name:
+                              description: Name is the name for this authority.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - authorities
+                    type: object
+                  provider:
+                    description: Provider is the provider that should be used to verify
+                      the image.
+                    enum:
+                    - Cosign
+                    type: string
+                required:
+                - provider
+                type: object
+            required:
+            - matchImages
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/content/master/api/crds/pkg.crossplane.io_locks.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_locks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: locks.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -54,7 +54,7 @@ spec:
                     properties:
                       constraints:
                         description: |-
-                          Constraints is a valid semver range, which will be used to select a valid
+                          Constraints is a valid semver range or a digest, which will be used to select a valid
                           dependency version.
                         type: string
                       package:
@@ -93,6 +93,56 @@ spec:
               - version
               type: object
             type: array
+          status:
+            description: Status of the Lock.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
         type: object
     served: true
     storage: true

--- a/content/master/api/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: providerrevisions.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -45,7 +45,6 @@ spec:
         description: |-
           A ProviderRevision represents a revision of a Provider. Crossplane
           creates new revisions when there are changes to a Provider.
-
 
           Crossplane creates and manages ProviderRevisions. Don't directly edit
           ProviderRevisions.
@@ -125,10 +124,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/pkg.crossplane.io_providers.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_providers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: providers.pkg.crossplane.io
 spec:
   group: pkg.crossplane.io
@@ -36,7 +36,6 @@ spec:
         description: |-
           A Provider installs an OCI compatible Crossplane package, extending
           Crossplane with support for new kinds of managed resources.
-
 
           Read the Crossplane documentation for
           [more information about Providers](https://docs.crossplane.io/latest/concepts/providers).
@@ -110,10 +109,13 @@ spec:
                     referenced object inside the same namespace.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/content/master/api/crds/secrets.crossplane.io_storeconfigs.yaml
+++ b/content/master/api/crds/secrets.crossplane.io_storeconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: storeconfigs.secrets.crossplane.io
 spec:
   group: secrets.crossplane.io

--- a/content/master/concepts/_index.md
+++ b/content/master/concepts/_index.md
@@ -68,3 +68,6 @@ building and managing external resources through Kubernetes.
 * [**Packages**]({{<ref "./packages">}}) are a convenient way to package up an
   entire custom platform and define any other Crossplane related requirements.
   Packages define how to install Providers, custom APIs or composition functions.
+
+* [**ImageConfigs**]({{<ref "./image-configs">}}) are for centralized control
+  of the configuration of Crossplane package images.

--- a/content/master/concepts/image-configs.md
+++ b/content/master/concepts/image-configs.md
@@ -1,0 +1,214 @@
+---
+title: Image Configs
+weight: 400
+description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+---
+
+<!-- vale write-good.Passive = NO -->
+
+`ImageConfig` is an API for centralized control over the configuration of
+Crossplane package images. It allows you to configure package manager behavior
+for images globally, without needing to be referenced by other objects.
+
+## Configuring a pull secret
+
+You can use `ImageConfig` to inject a pull secret into the Crossplane package
+manager registry client whenever it interacts with the registry, such as for
+dependency resolution or image pulls.
+
+In the following example, the `ImageConfig` resource named `acme-packages` is
+configured to inject the pull secret named `acme-registry-credentials` whenever
+it needs to interact with the registry for images with the prefix
+`registry1.com/acme-co/`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/
+  registry:
+    authentication:
+      pullSecretRef:
+        name: acme-registry-credentials
+```
+
+`spec.registry.authentication.pullSecretRef` is a reference to the pull secret
+that should be injected into the registry client. The secret must be of type
+`kubernetes.io/dockerconfigjson` and must be in the Crossplane installation
+namespace, typically `crossplane-system`. One can create the secret using the
+following command:
+
+```shell
+kubectl -n crossplane-system create secret docker-registry acme-registry-credentials --docker-server=registry1.com --docker-username=<user> --docker-password=<password>
+```
+
+### Matching image references
+
+`spec.matchImages` is a list of image references that the `ImageConfig` applies
+to. Each item in the list specifies the type and configuration of the image
+reference to match. The only supported type is `Prefix`, which matches the
+prefix of the image reference. No wildcards are supported. The `type` defaults
+to `Prefix` and can be omitted.
+
+When there are multiple `ImageConfigs`  matching an image reference, the one
+with the longest matching prefix is selected. If there are multiple
+`ImageConfigs` with the same longest matching prefix, one of them is selected
+arbitrarily. Please note that this situation occurs only if there are
+overlapping prefixes in the `matchImages` lists of different `ImageConfig`
+resources, which should be avoided.
+
+### Debugging
+
+When the package manager selects an `ImageConfig` for a package, it throws an
+event with the reason `ImageConfigSelection` and the name of the selected
+`ImageConfig` and injected pull secret. You can find these events both on the
+package and package revision resources.
+
+For example, the following event indicates that the `ImageConfig` named
+`acme-packages` was selected for the configuration named `acme-configuration-foo`:
+
+```shell
+$ kubectl describe configuration acme-configuration-foo
+...
+Events:
+  Type     Reason                Age                From                                              Message
+  ----     ------                ----               ----                                              -------
+  Normal   ImageConfigSelection  45s                packages/configuration.pkg.crossplane.io          Selected pullSecret "acme-registry-credentials" from ImageConfig "acme-packages" for registry authentication
+```
+
+If you can't find the expected event, ensure the prefix of the image reference
+matches the `matchImages` list of any `ImageConfig` resources in the cluster.
+
+## Configuring signature verification
+
+{{<hint "important" >}}
+Signature verification is an alpha feature and needs to be enabled with the
+`--enable-signature-verification` feature flag.
+{{< /hint >}}
+
+You can use `ImageConfig` to configure signature verification for images. When
+signature verification is enabled, the package manager verifies the signature of
+each image before pulling it. If the signature isn't valid, the package manager
+rejects the package deployment.
+
+In the following example, the `ImageConfig` resource named `verify-acme-packages`
+is configured to verify the signature of images with the prefixes
+`registry1.com/acme-co/configuration-foo` and
+`registry1.com/acme-co/configuration-bar`. 
+
+In the example below, the `ImageConfig` resource named `verify-acme-packages` is
+set up to verify the signatures of images with the prefixes
+`registry1.com/acme-co/configuration-foo` and `registry1.com/acme-co/configuration-bar`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: verify-acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/configuration-foo
+    - type: Prefix
+      prefix: registry1.com/acme-co/configuration-bar
+  verification:
+    provider: Cosign
+    cosign:
+      authorities:
+        - name: verify acme packages
+          keyless:
+            identities:
+              - issuer: https://token.actions.githubusercontent.com
+                subject: https://github.com/acme-co/crossplane-packages/.github/workflows/supplychain.yml@refs/heads/main
+          attestations:
+            - name: verify attestations
+              predicateType: spdxjson
+```
+
+`spec.verification.provider` specifies the signature verification provider.
+The only supported provider is `Cosign`. `spec.verification.cosign` contains the
+configuration for the Cosign provider. The `authorities` field contains the
+configuration for the authorities that sign the images. The `attestations` field
+contains the configuration for verifying the attestations of the images.
+
+The `ImageConfig` API follows the same API shape as [Policy Controller](https://docs.sigstore.dev/policy-controller/overview/)
+from [Sigstore](https://docs.sigstore.dev/). Crossplane initially supports a
+subset of the Policy Controller configuration options which can be found in the
+[API reference](https://docs.crossplane.io/master/api/#ImageConfig-spec-verification-cosign)
+for the `ImageConfig` resource together with their descriptions.
+
+When multiple authorities are provided, the package manager verifies the
+signature against each authority until it finds a valid one. If any of the
+authorities' signatures are valid, the package manager accepts the image.
+Similarly, when multiple identities or attestations are provided, the package
+manager verifies until it finds a valid match and fails if none of them matches.
+
+Matching the image reference to the `ImageConfig` works similarly to the pull
+secret configuration, as described in the previous section.
+
+### Checking the signature verification status
+
+When signature verification is enabled, the respective controller reports the
+verification status as a condition of type `Verified` on the package revision
+resources. This condition indicates whether the signature verification was
+successful, failed, skipped, or incomplete due to an error.
+
+#### Example conditions
+
+**Verification skipped:** The package manager skipped signature verification for
+the package revision because there were no matching `ImageConfig` with signature
+verification configuration.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:38:51Z"
+    reason: SignatureVerificationSkipped
+    status: "True"
+    type: Verified
+```
+
+**Verification successful:** The package manager successfully verified the
+signature of the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:43:05Z"
+    message: Signature verification succeeded with ImageConfig named "verify-acme-packages"
+    reason: VerificationSucceeded
+    status: "True"
+    type: Verified
+```
+
+**Verification failed:** The package manager failed to verify the signature of
+the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:42:44Z"
+    message: 'Signature verification failed with ImageConfig named "verify-acme-packages":
+      [signature keyless validation failed for authority verify acme packages
+      for registry1.com/acme-co/configuration-foo:v0.2.0: no signatures found: ]'
+    reason: SignatureVerificationFailed
+    status: "False"
+    type: Verified
+```
+
+**Verification incomplete:** The package manager encountered an error while
+verifying the signature of the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:44:22Z"
+    message: 'Error occurred during signature verification cannot get image verification
+      config: cannot get cosign verification config: no data found for key "cosign.pub"
+      in secret "cosign-public-key"'
+    reason: SignatureVerificationIncomplete
+    status: "False"
+    type: Verified
+```
+
+If you can't see this condition on the package revision resource, namely
+`ProviderRevision`, `ConfigurationRevision`, or `FunctionRevision`, ensure that
+the feature is enabled.
+
+<!-- vale write-good.Passive = YES -->

--- a/content/v1.16/concepts/_index.md
+++ b/content/v1.16/concepts/_index.md
@@ -78,3 +78,6 @@ building and managing external resources through Kubernetes.
 * [**Packages**]({{<ref "./packages">}}) are a convenient way to package up an
   entire custom platform and define any other Crossplane related requirements.
   Packages define how to install Providers, custom APIs or composition functions.
+
+* [**ImageConfigs**]({{<ref "./image-configs">}}) are for centralized control
+  of the configuration of Crossplane package images.

--- a/content/v1.16/concepts/image-configs.md
+++ b/content/v1.16/concepts/image-configs.md
@@ -1,0 +1,86 @@
+---
+title: Image Configs
+weight: 400
+description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+---
+
+<!-- vale write-good.Passive = NO -->
+
+`ImageConfig` is an API for centralized control over the configuration of
+Crossplane package images. It allows you to configure package manager behavior
+for images globally, without needing to be referenced by other objects.
+
+## Configuring a pull secret
+
+You can use `ImageConfig` to inject a pull secret into the Crossplane package
+manager registry client whenever it interacts with the registry, such as for
+dependency resolution or image pulls.
+
+In the following example, the `ImageConfig` resource named `acme-packages` is
+configured to inject the pull secret named `acme-registry-credentials` whenever
+it needs to interact with the registry for images with the prefix
+`registry1.com/acme-co/`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/
+  registry:
+    authentication:
+      pullSecretRef:
+        name: acme-registry-credentials
+```
+
+`spec.registry.authentication.pullSecretRef` is a reference to the pull secret
+that should be injected into the registry client. The secret must be of type
+`kubernetes.io/dockerconfigjson` and must be in the Crossplane installation
+namespace, typically `crossplane-system`. One can create the secret using the
+following command:
+
+```shell
+kubectl -n crossplane-system create secret docker-registry acme-registry-credentials --docker-server=registry1.com --docker-username=<user> --docker-password=<password>
+```
+
+### Matching image references
+
+`spec.matchImages` is a list of image references that the `ImageConfig` applies
+to. Each item in the list specifies the type and configuration of the image
+reference to match. The only supported type is `Prefix`, which matches the
+prefix of the image reference. No wildcards are supported. The `type` defaults
+to `Prefix` and can be omitted.
+
+When there are multiple `ImageConfigs`  matching an image reference, the one
+with the longest matching prefix is selected. If there are multiple
+`ImageConfigs` with the same longest matching prefix, one of them is selected
+arbitrarily. Please note that this situation occurs only if there are
+overlapping prefixes in the `matchImages` lists of different `ImageConfig`
+resources, which should be avoided.
+
+### Debugging
+
+When the package manager selects an `ImageConfig` for a package, it throws an
+event with the reason `ImageConfigSelection` and the name of the selected
+`ImageConfig` and injected pull secret. You can find these events both on the
+package and package revision resources.
+
+For example, the following event indicates that the `ImageConfig` named
+`acme-packages` was selected for the configuration named `acme-configuration-foo`:
+
+```shell
+$ kubectl describe configuration acme-configuration-foo
+...
+Events:
+  Type     Reason                Age                From                                              Message
+  ----     ------                ----               ----                                              -------
+  Normal   ImageConfigSelection  45s                packages/configuration.pkg.crossplane.io          Selected pullSecret "acme-registry-credentials" from ImageConfig "acme-packages" for registry authentication
+```
+
+If you can't find the expected event, ensure the prefix of the image reference
+matches the `matchImages` list of any `ImageConfig` resources in the cluster.
+
+<!-- vale write-good.Passive = YES -->

--- a/content/v1.17/concepts/_index.md
+++ b/content/v1.17/concepts/_index.md
@@ -68,3 +68,6 @@ building and managing external resources through Kubernetes.
 * [**Packages**]({{<ref "./packages">}}) are a convenient way to package up an
   entire custom platform and define any other Crossplane related requirements.
   Packages define how to install Providers, custom APIs or composition functions.
+
+* [**ImageConfigs**]({{<ref "./image-configs">}}) are for centralized control
+  of the configuration of Crossplane package images.

--- a/content/v1.17/concepts/image-configs.md
+++ b/content/v1.17/concepts/image-configs.md
@@ -1,0 +1,86 @@
+---
+title: Image Configs
+weight: 400
+description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+---
+
+<!-- vale write-good.Passive = NO -->
+
+`ImageConfig` is an API for centralized control over the configuration of
+Crossplane package images. It allows you to configure package manager behavior
+for images globally, without needing to be referenced by other objects.
+
+## Configuring a pull secret
+
+You can use `ImageConfig` to inject a pull secret into the Crossplane package
+manager registry client whenever it interacts with the registry, such as for
+dependency resolution or image pulls.
+
+In the following example, the `ImageConfig` resource named `acme-packages` is
+configured to inject the pull secret named `acme-registry-credentials` whenever
+it needs to interact with the registry for images with the prefix
+`registry1.com/acme-co/`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/
+  registry:
+    authentication:
+      pullSecretRef:
+        name: acme-registry-credentials
+```
+
+`spec.registry.authentication.pullSecretRef` is a reference to the pull secret
+that should be injected into the registry client. The secret must be of type
+`kubernetes.io/dockerconfigjson` and must be in the Crossplane installation
+namespace, typically `crossplane-system`. One can create the secret using the
+following command:
+
+```shell
+kubectl -n crossplane-system create secret docker-registry acme-registry-credentials --docker-server=registry1.com --docker-username=<user> --docker-password=<password>
+```
+
+### Matching image references
+
+`spec.matchImages` is a list of image references that the `ImageConfig` applies
+to. Each item in the list specifies the type and configuration of the image
+reference to match. The only supported type is `Prefix`, which matches the
+prefix of the image reference. No wildcards are supported. The `type` defaults
+to `Prefix` and can be omitted.
+
+When there are multiple `ImageConfigs`  matching an image reference, the one
+with the longest matching prefix is selected. If there are multiple
+`ImageConfigs` with the same longest matching prefix, one of them is selected
+arbitrarily. Please note that this situation occurs only if there are
+overlapping prefixes in the `matchImages` lists of different `ImageConfig`
+resources, which should be avoided.
+
+### Debugging
+
+When the package manager selects an `ImageConfig` for a package, it throws an
+event with the reason `ImageConfigSelection` and the name of the selected
+`ImageConfig` and injected pull secret. You can find these events both on the
+package and package revision resources.
+
+For example, the following event indicates that the `ImageConfig` named
+`acme-packages` was selected for the configuration named `acme-configuration-foo`:
+
+```shell
+$ kubectl describe configuration acme-configuration-foo
+...
+Events:
+  Type     Reason                Age                From                                              Message
+  ----     ------                ----               ----                                              -------
+  Normal   ImageConfigSelection  45s                packages/configuration.pkg.crossplane.io          Selected pullSecret "acme-registry-credentials" from ImageConfig "acme-packages" for registry authentication
+```
+
+If you can't find the expected event, ensure the prefix of the image reference
+matches the `matchImages` list of any `ImageConfig` resources in the cluster.
+
+<!-- vale write-good.Passive = YES -->

--- a/content/v1.18/concepts/_index.md
+++ b/content/v1.18/concepts/_index.md
@@ -68,3 +68,6 @@ building and managing external resources through Kubernetes.
 * [**Packages**]({{<ref "./packages">}}) are a convenient way to package up an
   entire custom platform and define any other Crossplane related requirements.
   Packages define how to install Providers, custom APIs or composition functions.
+
+* [**ImageConfigs**]({{<ref "./image-configs">}}) are for centralized control
+  of the configuration of Crossplane package images.

--- a/content/v1.18/concepts/image-configs.md
+++ b/content/v1.18/concepts/image-configs.md
@@ -1,0 +1,215 @@
+---
+title: Image Configs
+weight: 400
+description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+---
+
+<!-- vale write-good.Passive = NO -->
+
+`ImageConfig` is an API for centralized control over the configuration of
+Crossplane package images. It allows you to configure package manager behavior
+for images globally, without needing to be referenced by other objects.
+
+## Configuring a pull secret
+
+You can use `ImageConfig` to inject a pull secret into the Crossplane package
+manager registry client whenever it interacts with the registry, such as for
+dependency resolution or image pulls.
+
+In the following example, the `ImageConfig` resource named `acme-packages` is
+configured to inject the pull secret named `acme-registry-credentials` whenever
+it needs to interact with the registry for images with the prefix
+`registry1.com/acme-co/`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/
+  registry:
+    authentication:
+      pullSecretRef:
+        name: acme-registry-credentials
+```
+
+`spec.registry.authentication.pullSecretRef` is a reference to the pull secret
+that should be injected into the registry client. The secret must be of type
+`kubernetes.io/dockerconfigjson` and must be in the Crossplane installation
+namespace, typically `crossplane-system`. One can create the secret using the
+following command:
+
+```shell
+kubectl -n crossplane-system create secret docker-registry acme-registry-credentials --docker-server=registry1.com --docker-username=<user> --docker-password=<password>
+```
+
+### Matching image references
+
+`spec.matchImages` is a list of image references that the `ImageConfig` applies
+to. Each item in the list specifies the type and configuration of the image
+reference to match. The only supported type is `Prefix`, which matches the
+prefix of the image reference. No wildcards are supported. The `type` defaults
+to `Prefix` and can be omitted.
+
+When there are multiple `ImageConfigs`  matching an image reference, the one
+with the longest matching prefix is selected. If there are multiple
+`ImageConfigs` with the same longest matching prefix, one of them is selected
+arbitrarily. Please note that this situation occurs only if there are
+overlapping prefixes in the `matchImages` lists of different `ImageConfig`
+resources, which should be avoided.
+
+### Debugging
+
+When the package manager selects an `ImageConfig` for a package, it throws an
+event with the reason `ImageConfigSelection` and the name of the selected
+`ImageConfig` and injected pull secret. You can find these events both on the
+package and package revision resources.
+
+For example, the following event indicates that the `ImageConfig` named
+`acme-packages` was selected for the configuration named `acme-configuration-foo`:
+
+```shell
+$ kubectl describe configuration acme-configuration-foo
+...
+Events:
+  Type     Reason                Age                From                                              Message
+  ----     ------                ----               ----                                              -------
+  Normal   ImageConfigSelection  45s                packages/configuration.pkg.crossplane.io          Selected pullSecret "acme-registry-credentials" from ImageConfig "acme-packages" for registry authentication
+```
+
+If you can't find the expected event, ensure the prefix of the image reference
+matches the `matchImages` list of any `ImageConfig` resources in the cluster.
+
+## Configuring signature verification
+
+{{<hint "important" >}}
+Signature verification is an alpha feature and needs to be enabled with the
+`--enable-signature-verification` feature flag.
+{{< /hint >}}
+
+You can use `ImageConfig` to configure signature verification for images. When
+signature verification is enabled, the package manager verifies the signature of
+each image before pulling it. If the signature isn't valid, the package manager
+rejects the package deployment.
+
+In the following example, the `ImageConfig` resource named `verify-acme-packages`
+is configured to verify the signature of images with the prefixes
+`registry1.com/acme-co/configuration-foo` and
+`registry1.com/acme-co/configuration-bar`.
+
+In the example below, the `ImageConfig` resource named `verify-acme-packages` is
+set up to verify the signatures of images with the prefixes
+`registry1.com/acme-co/configuration-foo` and `registry1.com/acme-co/configuration-bar`.
+
+```yaml
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ImageConfig
+metadata:
+  name: verify-acme-packages
+spec:
+  matchImages:
+    - type: Prefix
+      prefix: registry1.com/acme-co/configuration-foo
+    - type: Prefix
+      prefix: registry1.com/acme-co/configuration-bar
+  verification:
+    provider: Cosign
+    cosign:
+      authorities:
+        - name: verify acme packages
+          keyless:
+            url: https://fulcio.sigstore.dev
+            identities:
+              - issuer: https://token.actions.githubusercontent.com
+                subjectRegExp: https://github.com/acme-co/crossplane-packages/*
+          attestations:
+            - name: verify attestations
+              predicateType: spdxjson
+```
+
+`spec.verification.provider` specifies the signature verification provider.
+The only supported provider is `Cosign`. `spec.verification.cosign` contains the
+configuration for the Cosign provider. The `authorities` field contains the
+configuration for the authorities that sign the images. The `attestations` field
+contains the configuration for verifying the attestations of the images.
+
+The `ImageConfig` API follows the same API shape as [Policy Controller](https://docs.sigstore.dev/policy-controller/overview/)
+from [Sigstore](https://docs.sigstore.dev/). Crossplane initially supports a
+subset of the Policy Controller configuration options which can be found in the
+[API reference](https://docs.crossplane.io/master/api/#ImageConfig-spec-verification-cosign)
+for the `ImageConfig` resource together with their descriptions.
+
+When multiple authorities are provided, the package manager verifies the
+signature against each authority until it finds a valid one. If any of the
+authorities' signatures are valid, the package manager accepts the image.
+Similarly, when multiple identities or attestations are provided, the package
+manager verifies until it finds a valid match and fails if none of them matches.
+
+Matching the image reference to the `ImageConfig` works similarly to the pull
+secret configuration, as described in the previous section.
+
+### Checking the signature verification status
+
+When signature verification is enabled, the respective controller reports the
+verification status as a condition of type `Verified` on the package revision
+resources. This condition indicates whether the signature verification was
+successful, failed, skipped, or incomplete due to an error.
+
+#### Example conditions
+
+**Verification skipped:** The package manager skipped signature verification for
+the package revision because there were no matching `ImageConfig` with signature
+verification configuration.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:38:51Z"
+    reason: SignatureVerificationSkipped
+    status: "True"
+    type: Verified
+```
+
+**Verification successful:** The package manager successfully verified the
+signature of the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:43:05Z"
+    message: Signature verification succeeded with ImageConfig named "verify-acme-packages"
+    reason: VerificationSucceeded
+    status: "True"
+    type: Verified
+```
+
+**Verification failed:** The package manager failed to verify the signature of
+the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:42:44Z"
+    message: 'Signature verification failed with ImageConfig named "verify-acme-packages":
+      [signature keyless validation failed for authority verify acme packages
+      for registry1.com/acme-co/configuration-foo:v0.2.0: no signatures found: ]'
+    reason: SignatureVerificationFailed
+    status: "False"
+    type: Verified
+```
+
+**Verification incomplete:** The package manager encountered an error while
+verifying the signature of the image in the package revision.
+
+```yaml
+  - lastTransitionTime: "2024-10-23T16:44:22Z"
+    message: 'Error occurred during signature verification cannot get image verification
+      config: cannot get cosign verification config: no data found for key "cosign.pub"
+      in secret "cosign-public-key"'
+    reason: SignatureVerificationIncomplete
+    status: "False"
+    type: Verified
+```
+
+If you can't see this condition on the package revision resource, namely
+`ProviderRevision`, `ConfigurationRevision`, or `FunctionRevision`, ensure that
+the feature is enabled.
+
+<!-- vale write-good.Passive = YES -->

--- a/utils/vale/styles/Crossplane/crossplane-words.txt
+++ b/utils/vale/styles/Crossplane/crossplane-words.txt
@@ -44,6 +44,8 @@ function-go-templating
 function-patch-and-transform
 HealthyPackageRevision
 Helm-like
+ImageConfig
+ImageConfigs
 InactivePackageRevision
 initProvider
 KCL
@@ -58,6 +60,7 @@ ProviderConfigs
 ProviderRevision
 RunFunctionRequest
 RunFunctionResponse
+Sigstore
 StoreConfig
 StoreConfigs
 ToCompositeFieldPath


### PR DESCRIPTION
Adds documentation for ImageConfig:

- Authentication goes to all master, v1.16, v1.17 and v1.18 version.
- Signature verification goes to master and v1.18 only.

It also updates `content/master/api/crds` with latest CRDs.