### PR TITLE
Update quickstarts to use the latest provider versions for AWS,Azure,GCP

### DIFF
--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -325,7 +325,7 @@ For example, this installation of the Upbound AWS reference platform is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0   12s
+provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -338,7 +338,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0
+  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.1.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.1.0       13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.16.0    3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.16.0          13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.16.0      13m
 ```
 
 ## Create a custom API

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0
+  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.16.0
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.16.0         97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.16.0     88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    3h
 ```
 
 ## Access the custom API

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v1.7.0).
 {{< /hint >}}
 
 

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    12m
 ```
 
 

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.16/concepts/providers.md
+++ b/content/v1.16/concepts/providers.md
@@ -325,7 +325,7 @@ For example, this installation of the Upbound AWS reference platform is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0   12s
+provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -338,7 +338,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0
+  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.16/getting-started/provider-aws-part-2.md
+++ b/content/v1.16/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.1.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.1.0       13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.16.0    3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.16.0          13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.16.0      13m
 ```
 
 ## Create a custom API

--- a/content/v1.16/getting-started/provider-aws.md
+++ b/content/v1.16/getting-started/provider-aws.md
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.16.0        97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.16.0    88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/v1.16/getting-started/provider-azure-part-2.md
+++ b/content/v1.16/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -468,7 +468,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0
 EOF
 ```
 
@@ -478,9 +478,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    3h
 ```
 
 ## Access the custom API

--- a/content/v1.16/getting-started/provider-azure.md
+++ b/content/v1.16/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v1.7.0).
 {{< /hint >}}
 
 

--- a/content/v1.16/getting-started/provider-gcp-part-2.md
+++ b/content/v1.16/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    12m
 ```
 
 

--- a/content/v1.16/getting-started/provider-gcp.md
+++ b/content/v1.16/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -325,7 +325,7 @@ For example, this installation of the Upbound AWS reference platform is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0   12s
+provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -338,7 +338,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0
+  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.17/getting-started/provider-aws-part-2.md
+++ b/content/v1.17/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.1.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.1.0       13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.16.0    3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.16.0          13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.16.0      13m
 ```
 
 ## Create a custom API

--- a/content/v1.17/getting-started/provider-aws.md
+++ b/content/v1.17/getting-started/provider-aws.md
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.16.0        97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.16.0    88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/v1.17/getting-started/provider-azure-part-2.md
+++ b/content/v1.17/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    3h
 ```
 
 ## Access the custom API

--- a/content/v1.17/getting-started/provider-azure.md
+++ b/content/v1.17/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v1.7.0).
 {{< /hint >}}
 
 

--- a/content/v1.17/getting-started/provider-gcp-part-2.md
+++ b/content/v1.17/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    12m
 ```
 
 

--- a/content/v1.17/getting-started/provider-gcp.md
+++ b/content/v1.17/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.18/concepts/providers.md
+++ b/content/v1.18/concepts/providers.md
@@ -325,7 +325,7 @@ For example, this installation of the Upbound AWS reference platform is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0   12s
+provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -338,7 +338,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v0.41.0
+  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.9.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.18/getting-started/provider-aws-part-2.md
+++ b/content/v1.18/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.1.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.1.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.1.0       13m
+provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.16.0    3m55s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.16.0          13m
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.16.0      13m
 ```
 
 ## Create a custom API

--- a/content/v1.18/getting-started/provider-aws.md
+++ b/content/v1.18/getting-started/provider-aws.md
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.1.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.1.0     88s
+provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.16.0        97s
+upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.16.0    88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/v1.18/getting-started/provider-azure-part-2.md
+++ b/content/v1.18/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v0.42.1   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    3h
+provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.7.0   25s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   3h
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    3h
 ```
 
 ## Access the custom API

--- a/content/v1.18/getting-started/provider-azure.md
+++ b/content/v1.18/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v0.42.1
+  package: xpkg.upbound.io/upbound/provider-azure-network:v1.7.0
 EOF
 ```
 
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v0.42.1    26s
+provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.7.0   38s
+upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.7.0    26s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v1.7.0).
 {{< /hint >}}
 
 

--- a/content/v1.18/getting-started/provider-gcp-part-2.md
+++ b/content/v1.18/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v0.41.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    12m
+provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.9.0    39s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   13m
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    12m
 ```
 
 

--- a/content/v1.18/getting-started/provider-gcp.md
+++ b/content/v1.18/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0
+  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0
 EOF
 ```
 
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v0.41.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v0.41.0    29s
+provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.9.0   36s
+upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.9.0    29s
 ```
 
 The Storage Provider installs a second Provider, the


### PR DESCRIPTION
Updates the provider versions used in all 3 quickstarts to the latest from Upbound Official Providers