### PR TITLE
pkg-mgr: Add digest support and `enable-dependency-version-upgrades` flag

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -54,6 +54,20 @@ spec:
   package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
 ```
 
+{{<hint "tip" >}}
+Crossplane supports installations with image digests instead of tags to get deterministic
+and repeatable installations.
+
+```yaml {label="digest"}
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: platform-ref-aws
+spec:
+  package: xpkg.upbound.io/upbound/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+```
+{{< /hint >}}
+
 Crossplane installs the Compositions, Composite Resource Definitions and
 Providers listed in the Configuration. 
 

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -130,6 +130,20 @@ volumes.
 Providers support multiple configuration options to change installation related
 settings. 
 
+{{<hint "tip" >}}
+Crossplane supports installations with image digests instead of tags to get deterministic
+and repeatable installations.  
+
+```yaml {label="digest"}
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
+```
+{{< /hint >}}
+
 #### Provider pull policy
 
 Use a {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} to

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -259,6 +259,7 @@ at the table below.
 | Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-ssa-claims` | Enable support for using server-side apply to sync claims with XRs. |
 | Alpha | `--enable-usages` | Enable support for Usages. |
+| Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
 {{< /table >}}
 {{< /expand >}}
 

--- a/content/v1.18/concepts/packages.md
+++ b/content/v1.18/concepts/packages.md
@@ -54,6 +54,20 @@ spec:
   package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
 ```
 
+{{<hint "tip" >}}
+Crossplane supports installations with image digests instead of tags to get deterministic
+and repeatable installations.
+
+```yaml {label="digest"}
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: platform-ref-aws
+spec:
+  package: xpkg.upbound.io/upbound/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+```
+{{< /hint >}}
+
 Crossplane installs the Compositions, Composite Resource Definitions and
 Providers listed in the Configuration. 
 

--- a/content/v1.18/concepts/providers.md
+++ b/content/v1.18/concepts/providers.md
@@ -130,6 +130,20 @@ volumes.
 Providers support multiple configuration options to change installation related
 settings. 
 
+{{<hint "tip" >}}
+Crossplane supports installations with image digests instead of tags to get deterministic
+and repeatable installations.
+
+```yaml {label="digest"}
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
+```
+{{< /hint >}}
+
 #### Provider pull policy
 
 Use a {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} to

--- a/content/v1.18/software/install.md
+++ b/content/v1.18/software/install.md
@@ -259,6 +259,7 @@ at the table below.
 | Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-ssa-claims` | Enable support for using server-side apply to sync claims with XRs. |
 | Alpha | `--enable-usages` | Enable support for Usages. |
+| Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
 {{< /table >}}
 {{< /expand >}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->