### PR TITLE
Use new apiVersion and kind style dependencies in example

### DIFF
--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -424,7 +424,9 @@ metadata:
   name: test-configuration
 spec:
   dependsOn:
-    - provider: xpkg.upbound.io/crossplane-contrib/provider-aws
+    - apiVersion: pkg.crossplane.io/v1
+      kind: Provider
+      package: xpkg.upbound.io/crossplane-contrib/provider-aws
       version: ">=v0.36.0"
   crossplane:
     version: ">=v1.12.1-0"


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

These are introduced in https://github.com/crossplane/crossplane/pull/6200.

They replace the old format, which is marked deprecated.