### PR TITLE
Fix documented Feature Flags for main, 1.18 and 1.17

### DIFF
--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -250,16 +250,14 @@ at the table below.
 {{< table caption="Feature flags" >}}
 | Status | Flag | Description |
 | --- | --- | --- |
-| Beta | `--enable-composition-functions` | Enable support for Composition Functions. |
-| Beta | `--enable-composition-functions-extra-resources` | Enable support for Composition Functions Extra Resources. Only respected with `--enable-composition-functions` enabled. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
 | Beta | `--enable-deployment-runtime-configs` | Enable support for DeploymentRuntimeConfigs. |
-| Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |
+| Beta | `--enable-usages` | Enable support for Usages. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |
 | Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-ssa-claims` | Enable support for using server-side apply to sync claims with XRs. |
-| Alpha | `--enable-usages` | Enable support for Usages. |
 | Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
+| Alpha | `--enable-signature-verification` | Enable support for package signature verification via ImageConfig API. |
 {{< /table >}}
 {{< /expand >}}
 

--- a/content/v1.17/software/install.md
+++ b/content/v1.17/software/install.md
@@ -250,8 +250,6 @@ at the table below.
 {{< table caption="Feature flags" >}}
 | Status | Flag | Description |
 | --- | --- | --- |
-| Beta | `--enable-composition-functions` | Enable support for Composition Functions. |
-| Beta | `--enable-composition-functions-extra-resources` | Enable support for Composition Functions Extra Resources. Only respected with `--enable-composition-functions` enabled. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
 | Beta | `--enable-deployment-runtime-configs` | Enable support for DeploymentRuntimeConfigs. |
 | Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |

--- a/content/v1.18/software/install.md
+++ b/content/v1.18/software/install.md
@@ -250,16 +250,14 @@ at the table below.
 {{< table caption="Feature flags" >}}
 | Status | Flag | Description |
 | --- | --- | --- |
-| Beta | `--enable-composition-functions` | Enable support for Composition Functions. |
-| Beta | `--enable-composition-functions-extra-resources` | Enable support for Composition Functions Extra Resources. Only respected with `--enable-composition-functions` enabled. |
 | Beta | `--enable-composition-webhook-schema-validation` | Enable Composition validation using schemas. |
 | Beta | `--enable-deployment-runtime-configs` | Enable support for DeploymentRuntimeConfigs. |
-| Alpha | `--enable-environment-configs` | Enable support for EnvironmentConfigs. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |
 | Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-ssa-claims` | Enable support for using server-side apply to sync claims with XRs. |
 | Alpha | `--enable-usages` | Enable support for Usages. |
 | Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
+| Alpha | `--enable-signature-verification` | Enable support for package signature verification via ImageConfig API. |
 {{< /table >}}
 {{< /expand >}}
 


### PR DESCRIPTION
I noticed that Feature Flags documentation heavily deviates from reality.

I built and looked into the output of `./crossplane core start --help` from https://github.com/crossplane/crossplane/ `main,` `v1.18.2`, and `v1.17.4` tags.

e.g.
```
git checkout v1.18.2
cd cmd/crossplane
go build -o crossplane
./crossplane core start --help
...
Alpha Features:
  --enable-external-secret-stores         Enable support for External Secret Stores.
  --enable-usages                         Enable support for deletion ordering and resource protection with Usages.
  --enable-realtime-compositions          Enable support for realtime compositions, i.e. watching composed resources and reconciling compositions
                                          immediately when any of the composed resources is updated.
  --enable-ssa-claims                     Enable support for using Kubernetes server-side apply to sync claims with composite resources (XRs).
  --enable-dependency-version-upgrades    Enable support for upgrading dependency versions when the parent package is updated.
  --enable-signature-verification         Enable support for package signature verification via ImageConfig API.

Beta Features:
  --enable-composition-webhook-schema-validation    Enable support for Composition validation using schemas.
  --enable-deployment-runtime-configs               Enable support for Deployment Runtime Configs.
```

and documented according to the output from each version.