### PR TITLE
Updated delete providers command

### DIFF
--- a/content/v1.18/software/uninstall.md
+++ b/content/v1.18/software/uninstall.md
@@ -138,10 +138,10 @@ NAME                   INSTALLED   HEALTHY   PACKAGE                            
 upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0   8h
 ```
 
-Remove the installed _providers_ with `kubectl delete provider`.
+Remove the installed _providers_ with `kubectl delete providers`.
 
 ```shell
-kubectl delete provider upbound-provider-aws
+kubectl delete providers upbound-provider-aws
 ```
 
 ## Uninstall the Crossplane deployment 


### PR DESCRIPTION
The command `kubectl delete provider <provider_name>` gives errors, the correct command to delete provider was `kubectl delete providers <provider_name>` replaced provider with providers.
I have attached the relevant screenshots.

`kubectl delete provider`
<img width="763" alt="Screenshot 2025-01-22 at 11 50 33 AM" src="https://github.com/user-attachments/assets/537186d9-05ab-4740-8e46-c842b2ef3fce" />

`kubectl delete providers`
<img width="786" alt="Screenshot 2025-01-22 at 11 50 08 AM" src="https://github.com/user-attachments/assets/39cf186c-2daf-4ac1-90e3-011396a40bbb" />


<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/