### PR TITLE
Add ImageConfig to Argo lua script

### DIFF
--- a/content/v1.18/guides/crossplane-with-argo-cd.md
+++ b/content/v1.18/guides/crossplane-with-argo-cd.md
@@ -132,8 +132,9 @@ data:
         local has_no_status = {
           "Composition",
           "CompositionRevision",
-          "DeploymentRuntimeConfig",
           "ControllerConfig",
+          "DeploymentRuntimeConfig",
+          "ImageConfig",
           "ProviderConfig",
           "ProviderConfigUsage"
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->
This adds the new ImageConfig resource to the ArgoCD LUA script so that it can be synced properly.
Without this, the sync just spins forever blocking further updates on the ArgoCD App.