### PR TITLE
Update docs to point to providers sourced from xpkg.crossplane.io. Remove terminology related to Upbound Marketplace

### DIFF
--- a/content/contribute/features.md
+++ b/content/contribute/features.md
@@ -195,7 +195,7 @@ without using the
 
 For example, 
 ```markdown
-[Go to Upbound](http://upbound.io)
+[Go to Crossplane](http://crossplane.io)
 ```
 
 ## Tables

--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -377,7 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
+Use `xpkg login` to authenticate to registries that host Crossplane packages.
 
 #### Flags
 
@@ -428,7 +428,7 @@ Authenticate to a registered organization in the Upbound Marketplace with the
 `--account` option, along with the username and password or token. 
 
 For example, 
-`crossplane xpkg login --account=Upbound --username=my-user --password -`. -->
+`crossplane xpkg login --account=Upbound --username=my-user --password -`.
 
 ### xpkg logout
 
@@ -495,9 +495,6 @@ Specify the package kind, package file and optionally the name of the package
 already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
-
-The package file must be an organization, image and tag on the `xpkg.crossplane.io`
-GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):

--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -240,9 +240,6 @@ For example,
 
 Include YAML files demonstrating how to use the package with `--examples-root`. 
 
-[Upbound Marketplace](https://marketplace.upbound.io/) uses files included with 
-`--examples-root` as documentation for published packages.
-
 #### Include a runtime image
 
 Functions and Providers require YAML files describing their dependencies and 
@@ -326,9 +323,9 @@ inside Crossplane.
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
 For example, to install the latest version of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -380,11 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.upbound.io`, the 
-[Upbound Marketplace](https://marketplace.upbound.io/) container registry.
-
-[Register with the Upbound Marketplace](https://accounts.upbound.io/register) 
-to push packages and create private repositories. 
+Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
 
 #### Flags
 
@@ -435,7 +428,7 @@ Authenticate to a registered organization in the Upbound Marketplace with the
 `--account` option, along with the username and password or token. 
 
 For example, 
-`crossplane xpkg login --account=Upbound --username=my-user --password -`.
+`crossplane xpkg login --account=Upbound --username=my-user --password -`. -->
 
 ### xpkg logout
 
@@ -451,8 +444,7 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the 
-[Upbound Marketplace](https://marketplace.upbound.io/) at `xpkg.upbound.io` by 
+The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
 default.
 
 {{< hint "note" >}}
@@ -504,13 +496,13 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-The package file must be an organization, image and tag on the `xpkg.upbound.io`
-registry on [Upbound Marketplace](https://marketplace.upbound.io/).
+The package file must be an organization, image and tag on the `xpkg.crossplane.io`
+GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 
 ## beta
@@ -569,11 +561,11 @@ related pods.
 
 ```shell
 crossplane beta top 
-TYPE         NAMESPACE   NAME                                                       CPU(cores)   MEMORY
-crossplane   default     crossplane-f98f9ddfd-tnm46                                 4m           32Mi
-crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                   4m           14Mi
-provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq              3m           108Mi
-provider     default     upbound-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
+TYPE         NAMESPACE   NAME                                                                  CPU(cores)   MEMORY
+crossplane   default     crossplane-f98f9ddfd-tnm46                                            4m           32Mi
+crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                              4m           14Mi
+provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq                         3m           108Mi
+provider     default     crossplane-contrib-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
 ```
 
 {{<hint "important" >}}
@@ -942,7 +934,7 @@ To clear the cache and download the CRD files again use the `--clean-cache` flag
 To validate a managed resource against a provider,
 first, create a provider manifest file. For example, to validate an IAM role
 from Provider AWS, use the 
-[Provider AWS IAM](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/v1.0.0) 
+[Provider AWS IAM](https://github.com/crossplane-contrib/provider-upjet-aws) 
 manifest.
 
 {{<hint "tip" >}}
@@ -957,7 +949,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -444,9 +444,6 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
-default.
-
 {{< hint "note" >}}
 Pushing a package may require authentication with 
 [`crossplane xpkg login`](#xpkg-login)

--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip">}}

--- a/content/master/concepts/connection-details.md
+++ b/content/master/concepts/connection-details.md
@@ -49,7 +49,7 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions and Claims.
 
 All examples rely on 
-[Upbound provider-aws-iam](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/)
+[provider-aws-iam](https://github.com/REPLACEME)
 to create resources.
 
 {{<expand "Reference Composition" >}}

--- a/content/master/concepts/connection-details.md
+++ b/content/master/concepts/connection-details.md
@@ -49,7 +49,7 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions and Claims.
 
 All examples rely on 
-[provider-aws-iam](https://github.com/REPLACEME)
+[provider-aws-iam](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{<expand "Reference Composition" >}}

--- a/content/master/concepts/managed-resources.md
+++ b/content/master/concepts/managed-resources.md
@@ -15,9 +15,9 @@ external object inside the Provider an _external resource_.
 {{< /hint >}}
 
 Examples of managed resources include:
-* Amazon AWS EC2 [`Instance`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/ec2.aws.upbound.io/Instance/v1beta1)
-* Google Cloud GKE [`Cluster`](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/resources/container.gcp.upbound.io/Cluster/v1beta1)
-* Microsoft Azure PostgreSQL [`Database`](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/resources/dbforpostgresql.azure.upbound.io/Database/v1beta1)
+* Amazon AWS EC2 `Instance` defined in [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
+* Google Cloud GKE `Cluster` defined in [provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
+* Microsoft Azure PostgreSQL `Database` defined in [provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 {{< hint "tip" >}}
 
@@ -35,7 +35,7 @@ Provider also define the available settings of a managed resource.
 Each managed resource is a unique API endpoint with their own
 group, kind and version. 
 
-For example the [Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/)
+For example the [AWS Provider](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines the {{<hover label="gkv" line="2">}}Instance{{</hover>}} kind from the
 group {{<hover label="gkv" line="1">}}ec2.aws.upbound.io{{</hover>}}
 
@@ -529,7 +529,7 @@ Crossplane stores these details in a Kubernetes Secret object specified by the
 `writeConnectionSecretToRef` values. 
 
 For example, when creating an AWS RDS database instance with the Crossplane 
-[community AWS provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.40.0) 
+[community AWS provider](https://github.com/crossplane-contrib/provider-aws) 
 generates an endpoint, password, port and username data. The Provider saves
 these variables in the Kubernetes secret 
 {{<hover label="secretname" line="9" >}}rds-secret{{</hover>}}, referenced by

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -42,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: configuration-getting-started
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
 ```
 
 {{<hint "tip" >}}
@@ -61,9 +61,9 @@ and repeatable installations.
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -86,7 +86,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0}'
 ```
 
 ### Install offline
@@ -349,7 +349,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   54s
 ```
 
 ### Manage dependencies
@@ -366,7 +366,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -380,7 +380,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -63,7 +63,7 @@ kind: Configuration
 metadata:
   name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:ef9795d146190637351a5c5848e0bab5e0c190fec7780f6c426fbffa0cb68358
 ```
 {{< /hint >}}
 

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -34,8 +34,7 @@ the {{<hover line="6" label="install">}}spec.package{{</hover>}} value to the
 location of the configuration package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -43,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Upbound AWS reference platform](https://marketplace.upbound.io/configurations/upbound/platform-ref-aws/v0.6.0).
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-getting-started
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
 ```
 
 {{<hint "tip" >}}
@@ -64,7 +63,7 @@ kind: Configuration
 metadata:
   name: platform-ref-aws
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -80,14 +79,14 @@ Use the
 {{<hover label="helm" line="5" >}}--set configuration.packages{{</hover >}}
 argument with `helm install`.
 
-For example, to install the Upbound AWS reference platform,
+For example, to install the Getting Started configuration,
 
 ```shell {label="helm"}
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
 ```
 
 ### Install offline
@@ -116,8 +115,8 @@ View the configuration revisions with
 ```shell {label="rev",copy-lines="1"}
 kubectl get configurationrevisions
 NAME                            HEALTHY   REVISION   IMAGE                                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
-platform-ref-aws-1735d56cd88d   True      2          xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0   Active     2           2               46s
-platform-ref-aws-3ac761211893   True      1          xpkg.upbound.io/upbound/platform-ref-aws:v0.4.1   Inactive                               5m13s
+platform-ref-aws-1735d56cd88d   True      2          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.5.0   Active     2           2               46s
+platform-ref-aws-3ac761211893   True      1          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.4.1   Inactive                               5m13s
 ```
 
 Only a single revision is active at a time. The active revision determines the
@@ -350,7 +349,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
 ```
 
 ### Manage dependencies
@@ -361,13 +360,13 @@ Functions, Providers or other Configurations.
 If Crossplane can't meet the dependencies of a Configuration the Configuration
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -381,7 +380,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
   Revision:                       1
 Status:
   Conditions:
@@ -467,7 +466,7 @@ spec:
   dependsOn:
     - apiVersion: pkg.crossplane.io/v1
       kind: Provider
-      package: xpkg.upbound.io/crossplane-contrib/provider-aws
+      package: xpkg.crossplane.io/crossplane-contrib/provider-aws
       version: ">=v0.36.0"
   crossplane:
     version: ">=v1.12.1-0"

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -379,7 +379,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -392,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
   Revision:                       1
 Status:
   Conditions:
@@ -430,10 +430,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
 ```
 
 By default Crossplane keeps a single 

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -48,8 +48,7 @@ Install a Provider with a Crossplane
 location of the provider package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -65,7 +64,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0
 ```
 
 By default, the Provider pod installs in the same namespace as Crossplane
@@ -113,7 +112,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
+--set provider.packages='{xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install offline
@@ -140,7 +139,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
 ```
 {{< /hint >}}
 
@@ -374,13 +373,13 @@ Configurations or other Providers.
 If Crossplane can't meet the dependencies of a Provider package the Provider
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1.0.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -393,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1.0.0
   Revision:                       1
 Status:
   Conditions:
@@ -431,10 +430,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           Active     1           1               10d
-provider-nop-552a394a8acc                  True      2          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
-provider-nop-7e62d2a1a709                  True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       Active                                 10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
+provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -477,7 +476,7 @@ During the install a Provider report `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        Unknown   xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   63s
+crossplane-contrib-provider-aws   True        Unknown   xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   63s
 ```
 
 After the Provider install completes and it's ready for use the `HEALTHY` status
@@ -486,7 +485,7 @@ reports `True`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   88s
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   88s
 ```
 
 {{<hint "important" >}}
@@ -694,7 +693,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.20.1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/master/getting-started/install-crossplane-include.md
+++ b/content/master/getting-started/install-crossplane-include.md
@@ -71,7 +71,7 @@ function:
 hostNetwork: false
 image:
   pullPolicy: IfNotPresent
-  repository: xpkg.upbound.io/crossplane/crossplane
+  repository: xpkg.crossplane.io/crossplane/crossplane
   tag: ""
 imagePullSecrets: {}
 leaderElection: true
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: crossplane
       hostNetwork: false
       initContainers:
-        - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+        - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
           args:
           - core
           - init
@@ -894,7 +894,7 @@ spec:
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - core
         - start
@@ -1011,7 +1011,7 @@ spec:
     spec:
       serviceAccountName: rbac-manager
       initContainers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - init
@@ -1041,7 +1041,7 @@ spec:
                 containerName: crossplane-init
                 resource: limits.memory
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - start

--- a/content/master/getting-started/introduction.md
+++ b/content/master/getting-started/introduction.md
@@ -107,7 +107,7 @@ defines a
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/master/getting-started/introduction.md
+++ b/content/master/getting-started/introduction.md
@@ -86,9 +86,9 @@ The following sections describe the functions of some of these CRDs.
 A Crossplane _Provider_ creates a second set of CRDs that define how Crossplane
 connects to a non-Kubernetes service. Each external service relies on its own
 Provider. For example, 
-[AWS](https://marketplace.upbound.io/providers/upbound/provider-aws), 
-[Azure](https://marketplace.upbound.io/providers/upbound/provider-azure) 
-and [GCP](https://marketplace.upbound.io/providers/upbound/provider-gcp)
+[AWS](https://github.com/crossplane-contrib/provider-upjet-aws), 
+[Azure](https://github.com/crossplane-contrib/provider-upjet-azure) 
+and [GCP](https://github.com/crossplane-contrib/provider-upjet-gcp)
 are different providers for each cloud service.
 
 {{< hint "tip" >}}
@@ -100,14 +100,14 @@ For example, an AWS Provider defines Kubernetes CRDs for AWS resources like EC2
 compute instances or S3 storage buckets.
 
 The Provider defines the Kubernetes API definition for the external resource.
-For example, the 
-[Upbound Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-aws/)
+For example,  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines a 
-[`bucket`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1) 
+[`bucket`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml) 
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
 ```
 
 ## Create a custom API
@@ -421,7 +421,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -596,7 +596,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
 ```
 
 ## Create a custom API

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -4,8 +4,8 @@ weight: 100
 ---
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
+with  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1
 EOF
 ```
 
@@ -52,12 +52,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.0.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-aws{{</hover >}}.   
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-aws{{</hover >}}.   
 The family provider manages authentication to AWS across all AWS family
 Providers. 
 
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/tree/main/examples).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -239,6 +239,6 @@ bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 * [**Continue to part 2**]({{< ref "provider-aws-part-2">}}) to create and use a 
   custom API with Crossplane.
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.20.1         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.20.1     88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.0.0    25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0    3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0     3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0    25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0    3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0     3h
 ```
 
 ## Access the custom API
@@ -694,7 +694,7 @@ No resources found
 
 ## Next steps
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out

--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0    25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0    3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0     3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1     3h
 ```
 
 ## Access the custom API

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -4,8 +4,8 @@ weight: 110
 ---
 
 Connect Crossplane to Azure to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound Azure Provider](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+with  
+[provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -54,12 +54,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
 ```
 
 The Network Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-azure{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-azure{{</hover>}} 
 provider.   
 The family provider manages authentication to Azure across all Azure family
 Providers. 
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/examples).
 {{< /hint >}}
 
 
@@ -234,6 +234,6 @@ virtualnetwork.network.azure.upbound.io "crossplane-quickstart-network" deleted
 * [**Continue to part 2**]({{< ref "provider-azure-part-2">}}) to create and use
   a custom API with Crossplane.
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.0.0     39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0    13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0     12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4.0.0     39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4.0.0    13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.11.4.0.0     12m
 ```
 
 
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -601,7 +601,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -4,8 +4,8 @@ weight: 140
 ---
 
 Connect Crossplane to GCP to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound GCP Provider](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+with  
+[provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -51,12 +51,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
 ```
 
 The Storage Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-gcp{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-gcp{{</hover>}} 
 provider.   
 The family provider manages authentication to GCP across all GCP family
 Providers. 
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/examples).
 {{< /hint >}}
 
 
@@ -246,6 +246,6 @@ bucket.storage.gcp.upbound.io "crossplane-bucket-8b7gw" deleted
 * [**Continue to part 2**]({{< ref "provider-gcp-part-2">}}) to create a 
 Crossplane _Composite Resource_ and _Claim_.
 * Explore GCP resources that can Crossplane can configure in the 
-[Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
 Crossplane users and contributors.

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/master/guides/function-patch-and-transform.md
+++ b/content/master/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip" >}}
@@ -122,7 +122,7 @@ The contents of the `base` are identical to creating a standalone
 [managed resource]({{<ref "../concepts/managed-resources">}}).
 
 This example uses
-[Upbound's Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-family-aws/v1.17.0)
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 to define a S3 storage `Bucket` and EC2 compute `Instance`.
 
 After defining the `apiVersion` and `kind`, define the `spec.forProvider` fields
@@ -507,8 +507,8 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions, Claims and EnvironmentConfigs.
 Only the applied patches change between examples.
 
-All examples rely on Upbound
-[provider-aws-s3](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/)
+All examples rely on 
+[provider-aws-s3](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{< expand "Reference Composition" >}}

--- a/content/master/guides/multi-tenant.md
+++ b/content/master/guides/multi-tenant.md
@@ -315,9 +315,9 @@ dedicated control planes to many tenants within a single organization.
 [Multiple Source Field patching]: https://github.com/crossplane/crossplane/pull/2093
 [Configuration packages]: {{<ref "../../master/concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
-[EKS Cluster]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/latest/resources/eks.aws.crossplane.io/Cluster/v1beta1
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
-[provider-helm]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-helm/
+[EKS Cluster]: https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples/eks/v1beta2/cluster.yaml
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
+[provider-helm]: https://github.com/crossplane-contrib/provider-helm
 [Open Service Broker API]: https://github.com/openservicebrokerapi/servicebroker
 [Crossplane Service Broker]: https://github.com/vshn/crossplane-service-broker
 [Cloudfoundry]: https://www.cloudfoundry.org/

--- a/content/master/guides/troubleshoot-crossplane.md
+++ b/content/master/guides/troubleshoot-crossplane.md
@@ -5,8 +5,8 @@ weight: 306
 ## Requested Resource Not Found
 
 If you use the Crossplane CLI to install a `Provider` or
-`Configuration` (for example, `crossplane install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+`Configuration` (for example, `crossplane xpkg install provider
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old

--- a/content/master/guides/troubleshoot-crossplane.md
+++ b/content/master/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane install provider
-xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
@@ -103,7 +103,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -365,7 +365,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/content/master/guides/vault-as-secret-store.md
+++ b/content/master/guides/vault-as-secret-store.md
@@ -217,7 +217,7 @@ Next, install the Crossplane ESS Plugin pod to the `crossplane-system` namespace
 and apply the Vault annotations.
 
 ```shell
-helm upgrade --install ess-plugin-vault oci://xpkg.upbound.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
+helm upgrade --install ess-plugin-vault oci://xpkg.crossplane.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
 ```
 
 ## Configure Crossplane
@@ -255,7 +255,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -341,7 +341,7 @@ Check that Crossplane installed the Provider and the Provider is healthy.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME           INSTALLED   HEALTHY   PACKAGE                                                                     AGE
-provider-gcp   True        True      xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
+provider-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
 ```
 
 ### Create a CompositeResourceDefinition

--- a/content/master/guides/vault-injection.md
+++ b/content/master/guides/vault-injection.md
@@ -310,7 +310,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.22.0
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -418,7 +418,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   controllerConfigRef:
     name: aws-vault-config" | kubectl apply -f -
 ```
@@ -491,8 +491,8 @@ kubectl get bucket -w
 [Vault Kubernetes Sidecar]: https://learn.hashicorp.com/tutorials/vault/kubernetes-sidecar
 [Vault]: https://www.vaultproject.io/
 [Vault Kubernetes Sidecar]: https://www.vaultproject.io/docs/platform/k8s/injector
-[provider-gcp]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-gcp
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
+[provider-gcp]: https://github.com/crossplane-contrib/provider-upjet-gcp
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
 [GCP]: https://www.vaultproject.io/docs/secrets/gcp 

--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -425,7 +425,7 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+The code uses the `v1beta1.Bucket` type from the [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
 One advantage of writing a function in Go is that you can compose resources
 using the same strongly typed structs Crossplane uses in its providers.
 
@@ -671,7 +671,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -783,7 +783,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -863,11 +863,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/master/guides/write-a-composition-function-in-python.md
+++ b/content/master/guides/write-a-composition-function-in-python.md
@@ -533,7 +533,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -644,7 +644,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -732,11 +732,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -133,7 +133,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `function.packages` | A list of Function packages to install. | `[]` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
-| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.upbound.io/crossplane/crossplane"` |
+| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `{}` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
@@ -267,9 +267,8 @@ args='{"--enable-composition-functions","--enable-composition-webhook-schema-val
 
 #### Change the default package registry
 
-Beginning with Crossplane version 1.15.0 Crossplane downloads packages from the
-[Upbound Marketplace](https://marketplace.upbound.io) at `xpkg.upbound.io`
-instead of DockerHub.
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
+installing packages. 
 
 Change the default registry location during the Crossplane install with
 `--set args='{"--registry=index.docker.io"}'`.
@@ -326,15 +325,3 @@ Community Crossplane distribution.
 The CNCF certified third-party distributions as
 "[conformant](https://github.com/cncf/crossplane-conformance)" with the
 Community Crossplane distribution.
-
-### Vendors
-Below are vendors providing conformant Crossplane distributions.
-
-#### Upbound
-Upbound, the founders of Crossplane, maintains a free and open source
-distribution of Crossplane called
-[Universal Crossplane](https://www.upbound.io/product/universal-crossplane)
-(`UXP`).
-
-Find information on UXP in the
-[Upbound UXP documentation](https://docs.upbound.io/uxp/install/).

--- a/content/master/software/uninstall.md
+++ b/content/master/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/master/software/uninstall.md
+++ b/content/master/software/uninstall.md
@@ -135,13 +135,13 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.
 
 ```shell
-kubectl delete provider upbound-provider-aws
+kubectl delete provider crossplane-contrib-provider-aws
 ```
 
 ## Uninstall the Crossplane deployment 

--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -48,7 +48,7 @@ upgrade` command.
 
 For example, in v1.20.0 Crossplane changed the default image registry from 
 `index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
-before v1.15.0 updates the default package registry. 
+before v1.20.0 updates the default package registry. 
 
 Override new defaults by 
 [customizing the Helm chart]({{<ref "install#customize-the-crossplane-helm-chart" >}}) 

--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -46,7 +46,7 @@ Crossplane.
 Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
-For example, in v1.15.0 Crossplane changed the default image registry from 
+For example, in v1.20.0 Crossplane changed the default image registry from 
 `index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
 before v1.15.0 updates the default package registry. 
 

--- a/content/master/software/upgrade.md
+++ b/content/master/software/upgrade.md
@@ -47,7 +47,7 @@ Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 
-`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+`index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
 before v1.15.0 updates the default package registry. 
 
 Override new defaults by 

--- a/content/v1.17/cli/command-reference.md
+++ b/content/v1.17/cli/command-reference.md
@@ -240,9 +240,6 @@ For example,
 
 Include YAML files demonstrating how to use the package with `--examples-root`. 
 
-[Upbound Marketplace](https://marketplace.upbound.io/) uses files included with 
-`--examples-root` as documentation for published packages.
-
 #### Include a runtime image
 
 Functions and Providers require YAML files describing their dependencies and 
@@ -326,9 +323,9 @@ inside Crossplane.
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
 For example, to install to the latest version of the
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -380,11 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.upbound.io`, the 
-[Upbound Marketplace](https://marketplace.upbound.io/) container registry.
-
-[Register with the Upbound Marketplace](https://accounts.upbound.io/register) 
-to push packages and create private repositories. 
+Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
 
 #### Flags
 
@@ -451,8 +444,7 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the 
-[Upbound Marketplace](https://marketplace.upbound.io/) at `xpkg.upbound.io` by 
+The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
 default.
 
 {{< hint "note" >}}
@@ -504,13 +496,13 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-The package file must be an organization, image and tag on the `xpkg.upbound.io`
-registry on [Upbound Marketplace](https://marketplace.upbound.io/).
+The package file must be an organization, image and tag on the `xpkg.crossplane.io`
+GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
-For example, to update to the latest version of the
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+For example, to update to the latest version of the 
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 
 ## beta
@@ -569,11 +561,11 @@ related pods.
 
 ```shell
 crossplane beta top 
-TYPE         NAMESPACE   NAME                                                       CPU(cores)   MEMORY
-crossplane   default     crossplane-f98f9ddfd-tnm46                                 4m           32Mi
-crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                   4m           14Mi
-provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq              3m           108Mi
-provider     default     upbound-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
+TYPE         NAMESPACE   NAME                                                                  CPU(cores)   MEMORY
+crossplane   default     crossplane-f98f9ddfd-tnm46                                            4m           32Mi
+crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                              4m           14Mi
+provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq                         3m           108Mi
+provider     default     crossplane-contrib-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
 ```
 
 {{<hint "important" >}}
@@ -942,7 +934,7 @@ To clear the cache and download the CRD files again use the `--clean-cache` flag
 To validate a managed resource against a provider,
 first, create a provider manifest file. For example, to validate an IAM role
 from Provider AWS, use the 
-[Provider AWS IAM](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/v1.0.0) 
+[Provider AWS IAM](https://github.com/crossplane-contrib/provider-upjet-aws) 
 manifest.
 
 {{<hint "tip" >}}
@@ -957,7 +949,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.17/cli/command-reference.md
+++ b/content/v1.17/cli/command-reference.md
@@ -377,7 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
+Use `xpkg login` to authenticate to registries that host Crossplane packages.
 
 #### Flags
 
@@ -495,9 +495,6 @@ Specify the package kind, package file and optionally the name of the package
 already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
-
-The package file must be an organization, image and tag on the `xpkg.crossplane.io`
-GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):

--- a/content/v1.17/cli/command-reference.md
+++ b/content/v1.17/cli/command-reference.md
@@ -444,9 +444,6 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
-default.
-
 {{< hint "note" >}}
 Pushing a package may require authentication with 
 [`crossplane xpkg login`](#xpkg-login)

--- a/content/v1.17/concepts/compositions.md
+++ b/content/v1.17/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip">}}

--- a/content/v1.17/concepts/connection-details.md
+++ b/content/v1.17/concepts/connection-details.md
@@ -49,7 +49,7 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions and Claims.
 
 All examples rely on 
-[Upbound provider-aws-iam](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/)
+[provider-aws-iam](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{<expand "Reference Composition" >}}

--- a/content/v1.17/concepts/managed-resources.md
+++ b/content/v1.17/concepts/managed-resources.md
@@ -15,9 +15,9 @@ external object inside the Provider an _external resource_.
 {{< /hint >}}
 
 Examples of managed resources include:
-* Amazon AWS EC2 [`Instance`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/ec2.aws.upbound.io/Instance/v1beta1)
-* Google Cloud GKE [`Cluster`](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/resources/container.gcp.upbound.io/Cluster/v1beta1)
-* Microsoft Azure PostgreSQL [`Database`](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/resources/dbforpostgresql.azure.upbound.io/Database/v1beta1)
+* Amazon AWS EC2 `Instance` defined in [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
+* Google Cloud GKE `Cluster` defined in [provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
+* Microsoft Azure PostgreSQL `Database` defined in [provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 {{< hint "tip" >}}
 
@@ -35,7 +35,7 @@ Provider also define the available settings of a managed resource.
 Each managed resource is a unique API endpoint with their own
 group, kind and version. 
 
-For example the [Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/)
+For example [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines the {{<hover label="gkv" line="2">}}Instance{{</hover>}} kind from the
 group {{<hover label="gkv" line="1">}}ec2.aws.upbound.io{{</hover>}}
 
@@ -529,7 +529,7 @@ Crossplane stores these details in a Kubernetes Secret object specified by the
 `writeConnectionSecretToRef` values. 
 
 For example, when creating an AWS RDS database instance with the Crossplane 
-[community AWS provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.40.0) 
+[community AWS provider](https://github.com/crossplane-contrib/provider-aws) 
 generates an endpoint, password, port and username data. The Provider saves
 these variables in the Kubernetes secret 
 {{<hover label="secretname" line="9" >}}rds-secret{{</hover>}}, referenced by

--- a/content/v1.17/concepts/packages.md
+++ b/content/v1.17/concepts/packages.md
@@ -42,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: configuration-getting-started
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
 ```
 
 Crossplane installs the Compositions, Composite Resource Definitions and
@@ -72,7 +72,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0}'
 ```
 
 ### Install offline
@@ -294,7 +294,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   54s
 ```
 
 ### Manage dependencies
@@ -311,7 +311,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -325,7 +325,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.17/concepts/packages.md
+++ b/content/v1.17/concepts/packages.md
@@ -34,8 +34,7 @@ the {{<hover line="6" label="install">}}spec.package{{</hover>}} value to the
 location of the configuration package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -43,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Upbound AWS reference platform](https://marketplace.upbound.io/configurations/upbound/platform-ref-aws/v0.6.0), 
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-getting-started
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
 ```
 
 Crossplane installs the Compositions, Composite Resource Definitions and
@@ -66,14 +65,14 @@ Use the
 {{<hover label="helm" line="5" >}}--set configuration.packages{{</hover >}}
 argument with `helm install`.
 
-For example, to install the Upbound AWS reference platform,
+For example, to install the Getting Started Configuration,
 
 ```shell {label="helm"}
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
 ```
 
 ### Install offline
@@ -102,8 +101,8 @@ View the configuration revisions with
 ```shell {label="rev",copy-lines="1"}
 kubectl get configurationrevisions
 NAME                            HEALTHY   REVISION   IMAGE                                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
-platform-ref-aws-1735d56cd88d   True      2          xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0   Active     2           2               46s
-platform-ref-aws-3ac761211893   True      1          xpkg.upbound.io/upbound/platform-ref-aws:v0.4.1   Inactive                               5m13s
+platform-ref-aws-1735d56cd88d   True      2          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.5.0   Active     2           2               46s
+platform-ref-aws-3ac761211893   True      1          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.4.1   Inactive                               5m13s
 ```
 
 Only a single revision is active at a time. The active revision determines the
@@ -295,7 +294,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
 ```
 
 ### Manage dependencies
@@ -306,13 +305,13 @@ Functions, Providers or other Configurations.
 If Crossplane can't meet the dependencies of a Configuration the Configuration
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -326,7 +325,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
   Revision:                       1
 Status:
   Conditions:
@@ -410,7 +409,7 @@ metadata:
   name: test-configuration
 spec:
   dependsOn:
-    - provider: xpkg.upbound.io/crossplane-contrib/provider-aws
+    - provider: xpkg.crossplane.io/crossplane-contrib/provider-aws
       version: ">=v0.36.0"
   crossplane:
     version: ">=v1.12.1-0"

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -324,7 +324,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -337,7 +337,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
   Revision:                       1
 Status:
   Conditions:
@@ -375,10 +375,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -638,7 +638,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -48,8 +48,7 @@ Install a Provider with a Crossplane
 location of the provider package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -65,7 +64,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0
 ```
 
 By default, the Provider pod installs in the same namespace as Crossplane
@@ -113,7 +112,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
+--set provider.packages='{xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install offline
@@ -319,13 +318,13 @@ Configurations or other Providers.
 If Crossplane can't meet the dependencies of a Provider package the Provider
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -338,7 +337,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
   Revision:                       1
 Status:
   Conditions:
@@ -376,10 +375,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           Active     1           1               10d
-provider-nop-552a394a8acc                  True      2          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
-provider-nop-7e62d2a1a709                  True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       Active                                 10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
+provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -422,7 +421,7 @@ During the install a Provider report `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        Unknown   xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   63s
+crossplane-contrib-provider-aws   True        Unknown   xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   63s
 ```
 
 After the Provider install completes and it's ready for use the `HEALTHY` status
@@ -431,7 +430,7 @@ reports `True`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   88s
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   88s
 ```
 
 {{<hint "important" >}}
@@ -639,7 +638,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.0.0
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/v1.17/getting-started/install-crossplane-include.md
+++ b/content/v1.17/getting-started/install-crossplane-include.md
@@ -71,7 +71,7 @@ function:
 hostNetwork: false
 image:
   pullPolicy: IfNotPresent
-  repository: xpkg.upbound.io/crossplane/crossplane
+  repository: xpkg.crossplane.io/crossplane/crossplane
   tag: ""
 imagePullSecrets: {}
 leaderElection: true
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: crossplane
       hostNetwork: false
       initContainers:
-        - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+        - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
           args:
           - core
           - init
@@ -894,7 +894,7 @@ spec:
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - core
         - start
@@ -1011,7 +1011,7 @@ spec:
     spec:
       serviceAccountName: rbac-manager
       initContainers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - init
@@ -1041,7 +1041,7 @@ spec:
                 containerName: crossplane-init
                 resource: limits.memory
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - start

--- a/content/v1.17/getting-started/introduction.md
+++ b/content/v1.17/getting-started/introduction.md
@@ -107,7 +107,7 @@ defines a
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.17/getting-started/introduction.md
+++ b/content/v1.17/getting-started/introduction.md
@@ -86,9 +86,9 @@ The following sections describe the functions of some of these CRDs.
 A Crossplane _Provider_ creates a second set of CRDs that define how Crossplane
 connects to a non-Kubernetes service. Each external service relies on its own
 Provider. For example, 
-[AWS](https://marketplace.upbound.io/providers/upbound/provider-aws), 
-[Azure](https://marketplace.upbound.io/providers/upbound/provider-azure) 
-and [GCP](https://marketplace.upbound.io/providers/upbound/provider-gcp)
+[AWS](https://github.com/crossplane-contrib/provider-upjet-aws), 
+[Azure](https://github.com/crossplane-contrib/provider-upjet-azure) 
+and [GCP](https://github.com/crossplane-contrib/provider-upjet-gcp)
 are different providers for each cloud service.
 
 {{< hint "tip" >}}
@@ -100,14 +100,14 @@ For example, an AWS Provider defines Kubernetes CRDs for AWS resources like EC2
 compute instances or S3 storage buckets.
 
 The Provider defines the Kubernetes API definition for the external resource.
-For example, the 
-[Upbound Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-aws/)
+For example,  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines a 
-[`bucket`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1) 
+[`bucket`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml) 
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.17/getting-started/provider-aws-part-2.md
+++ b/content/v1.17/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
 ```
 
 ## Create a custom API

--- a/content/v1.17/getting-started/provider-aws-part-2.md
+++ b/content/v1.17/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
 ```
 
 ## Create a custom API
@@ -421,7 +421,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -596,7 +596,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.17/getting-started/provider-aws.md
+++ b/content/v1.17/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -52,8 +52,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.20.1         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.20.1     88s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/v1.17/getting-started/provider-aws.md
+++ b/content/v1.17/getting-started/provider-aws.md
@@ -5,7 +5,7 @@ weight: 100
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
 with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1
 EOF
 ```
 
@@ -52,12 +52,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.0.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-aws{{</hover >}}.   
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-aws{{</hover >}}.   
 The family provider manages authentication to AWS across all AWS family
 Providers. 
 
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -239,6 +239,6 @@ bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 * [**Continue to part 2**]({{< ref "provider-aws-part-2">}}) to create and use a 
   custom API with Crossplane.
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.17/getting-started/provider-azure-part-2.md
+++ b/content/v1.17/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.0.0   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0   25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    3h
 ```
 
 ## Access the custom API
@@ -694,7 +694,7 @@ No resources found
 
 ## Next steps
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out

--- a/content/v1.17/getting-started/provider-azure-part-2.md
+++ b/content/v1.17/getting-started/provider-azure-part-2.md
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0   25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    3h
 ```
 
 ## Access the custom API

--- a/content/v1.17/getting-started/provider-azure.md
+++ b/content/v1.17/getting-started/provider-azure.md
@@ -4,8 +4,8 @@ weight: 110
 ---
 
 Connect Crossplane to Azure to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound Azure Provider](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+with  
+[provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -54,12 +54,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
 ```
 
 The Network Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-azure{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-azure{{</hover>}} 
 provider.   
 The family provider manages authentication to Azure across all Azure family
 Providers. 
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[provider CRDs reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 {{< /hint >}}
 
 
@@ -234,6 +234,6 @@ virtualnetwork.network.azure.upbound.io "crossplane-quickstart-network" deleted
 * [**Continue to part 2**]({{< ref "provider-azure-part-2">}}) to create and use
   a custom API with Crossplane.
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.17/getting-started/provider-azure.md
+++ b/content/v1.17/getting-started/provider-azure.md
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/v1.17/getting-started/provider-gcp-part-2.md
+++ b/content/v1.17/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.0.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4.0.0    39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    12m
 ```
 
 
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -601,7 +601,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.17/getting-started/provider-gcp-part-2.md
+++ b/content/v1.17/getting-started/provider-gcp-part-2.md
@@ -124,8 +124,8 @@ View the new PubSub provider with `kubectl get providers`.
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
 provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4.0.0    39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    12m
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    12m
 ```
 
 

--- a/content/v1.17/getting-started/provider-gcp.md
+++ b/content/v1.17/getting-started/provider-gcp.md
@@ -5,7 +5,7 @@ weight: 140
 
 Connect Crossplane to GCP to create and manage cloud resources from Kubernetes 
 with the 
-[Upbound GCP Provider](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -51,12 +51,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
 ```
 
 The Storage Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-gcp{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-gcp{{</hover>}} 
 provider.   
 The family provider manages authentication to GCP across all GCP family
 Providers. 
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[provider CRDs reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
 {{< /hint >}}
 
 
@@ -246,6 +246,6 @@ bucket.storage.gcp.upbound.io "crossplane-bucket-8b7gw" deleted
 * [**Continue to part 2**]({{< ref "provider-gcp-part-2">}}) to create a 
 Crossplane _Composite Resource_ and _Claim_.
 * Explore GCP resources that can Crossplane can configure in the 
-[Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
 Crossplane users and contributors.

--- a/content/v1.17/getting-started/provider-gcp.md
+++ b/content/v1.17/getting-started/provider-gcp.md
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.17/guides/function-patch-and-transform.md
+++ b/content/v1.17/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip" >}}
@@ -122,7 +122,7 @@ The contents of the `base` are identical to creating a standalone
 [managed resource]({{<ref "../concepts/managed-resources">}}).
 
 This example uses 
-[Upbound's Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.35.0)
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 to define a S3 storage `Bucket` and EC2 compute `Instance`.
 
 After defining the `apiVersion` and `kind`, define the `spec.forProvider` fields
@@ -512,8 +512,8 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions, Claims and EnvironmentConfigs.  
 Only the applied patches change between examples. 
 
-All examples rely on Upbound
-[provider-aws-s3](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/)
+All examples rely on 
+[provider-aws-s3](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{< expand "Reference Composition" >}}

--- a/content/v1.17/guides/multi-tenant.md
+++ b/content/v1.17/guides/multi-tenant.md
@@ -315,9 +315,9 @@ dedicated control planes to many tenants within a single organization.
 [Multiple Source Field patching]: https://github.com/crossplane/crossplane/pull/2093
 [Configuration packages]: {{<ref "../../master/concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
-[EKS Cluster]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/latest/resources/eks.aws.crossplane.io/Cluster/v1beta1
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
-[provider-helm]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-helm/
+[EKS Cluster]: https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples/eks/v1beta2/cluster.yaml
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
+[provider-helm]: https://github.com/crossplane-contrib/provider-helm
 [Open Service Broker API]: https://github.com/openservicebrokerapi/servicebroker
 [Crossplane Service Broker]: https://github.com/vshn/crossplane-service-broker
 [Cloudfoundry]: https://www.cloudfoundry.org/

--- a/content/v1.17/guides/troubleshoot-crossplane.md
+++ b/content/v1.17/guides/troubleshoot-crossplane.md
@@ -5,12 +5,13 @@ weight: 306
 ## Requested Resource Not Found
 
 If you use the Crossplane CLI to install a `Provider` or
-`Configuration` (for example, `crossplane install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+`Configuration` (for example, `crossplane xpkg install provider
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
 plugin isn't aware of this change.
+
 
 
 ## Resource Status and Conditions

--- a/content/v1.17/guides/troubleshoot-crossplane.md
+++ b/content/v1.17/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane install provider
-xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
@@ -103,7 +103,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -365,7 +365,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/content/v1.17/guides/vault-as-secret-store.md
+++ b/content/v1.17/guides/vault-as-secret-store.md
@@ -217,7 +217,7 @@ Next, install the Crossplane ESS Plugin pod to the `crossplane-system` namespace
 and apply the Vault annotations.
 
 ```shell
-helm upgrade --install ess-plugin-vault oci://xpkg.upbound.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
+helm upgrade --install ess-plugin-vault oci://xpkg.crossplane.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
 ```
 
 ## Configure Crossplane
@@ -255,7 +255,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -341,7 +341,7 @@ Check that Crossplane installed the Provider and the Provider is healthy.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME           INSTALLED   HEALTHY   PACKAGE                                                                     AGE
-provider-gcp   True        True      xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
+provider-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
 ```
 
 ### Create a CompositeResourceDefinition

--- a/content/v1.17/guides/vault-injection.md
+++ b/content/v1.17/guides/vault-injection.md
@@ -310,7 +310,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.22.0
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -418,7 +418,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   controllerConfigRef:
     name: aws-vault-config" | kubectl apply -f -
 ```
@@ -491,8 +491,8 @@ kubectl get bucket -w
 [Vault Kubernetes Sidecar]: https://learn.hashicorp.com/tutorials/vault/kubernetes-sidecar
 [Vault]: https://www.vaultproject.io/
 [Vault Kubernetes Sidecar]: https://www.vaultproject.io/docs/platform/k8s/injector
-[provider-gcp]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-gcp
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
+[provider-gcp]: https://github.com/crossplane-contrib/provider-upjet-gcp
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
 [GCP]: https://www.vaultproject.io/docs/secrets/gcp 

--- a/content/v1.17/guides/write-a-composition-function-in-go.md
+++ b/content/v1.17/guides/write-a-composition-function-in-go.md
@@ -425,7 +425,7 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+The code uses the `v1beta1.Bucket` type from the [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
 One advantage of writing a function in Go is that you can compose resources
 using the same strongly typed structs Crossplane uses in its providers.
 
@@ -671,7 +671,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -783,7 +783,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -863,11 +863,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.17/guides/write-a-composition-function-in-python.md
+++ b/content/v1.17/guides/write-a-composition-function-in-python.md
@@ -533,7 +533,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -644,7 +644,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -732,11 +732,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.17/software/install.md
+++ b/content/v1.17/software/install.md
@@ -133,7 +133,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `function.packages` | A list of Function packages to install. | `[]` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
-| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.upbound.io/crossplane/crossplane"` |
+| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `{}` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
@@ -266,9 +266,8 @@ args='{"--enable-composition-functions","--enable-composition-webhook-schema-val
 
 #### Change the default package registry
 
-Beginning with Crossplane version 1.15.0 Crossplane downloads packages from the
-[Upbound Marketplace](https://marketplace.upbound.io) at `xpkg.upbound.io` 
-instead of DockerHub. 
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
+installing packages. 
 
 Change the default registry location during the Crossplane install with 
 `--set args='{"--registry=index.docker.io"}'`.
@@ -325,15 +324,3 @@ Community Crossplane distribution.
 The CNCF certified third-party distributions as 
 "[conformant](https://github.com/cncf/crossplane-conformance)" with the 
 Community Crossplane distribution.
-
-### Vendors
-Below are vendors providing conformant Crossplane distributions. 
-
-#### Upbound
-Upbound, the founders of Crossplane, maintains a free and open source 
-distribution of Crossplane called 
-[Universal Crossplane](https://www.upbound.io/product/universal-crossplane)
-(`UXP`). 
-
-Find information on UXP in the 
-[Upbound UXP documentation](https://docs.upbound.io/uxp/install/).

--- a/content/v1.17/software/uninstall.md
+++ b/content/v1.17/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1   8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.17/software/uninstall.md
+++ b/content/v1.17/software/uninstall.md
@@ -135,13 +135,13 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0   8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.
 
 ```shell
-kubectl delete provider upbound-provider-aws
+kubectl delete provider crossplane-contrib-provider-aws
 ```
 
 ## Uninstall the Crossplane deployment 

--- a/content/v1.17/software/upgrade.md
+++ b/content/v1.17/software/upgrade.md
@@ -46,9 +46,9 @@ Crossplane.
 Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
-For example, in v1.15.0 Crossplane changed the default image registry from 
+For example, in v1.20.0 Crossplane changed the default image registry from 
 `index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
-before v1.15.0 updates the default package registry. 
+before v1.20.0 updates the default package registry. 
 
 Override new defaults by 
 [customizing the Helm chart]({{<ref "install#customize-the-crossplane-helm-chart" >}}) 

--- a/content/v1.17/software/upgrade.md
+++ b/content/v1.17/software/upgrade.md
@@ -47,7 +47,7 @@ Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 
-`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+`index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
 before v1.15.0 updates the default package registry. 
 
 Override new defaults by 

--- a/content/v1.18/cli/command-reference.md
+++ b/content/v1.18/cli/command-reference.md
@@ -240,9 +240,6 @@ For example,
 
 Include YAML files demonstrating how to use the package with `--examples-root`. 
 
-[Upbound Marketplace](https://marketplace.upbound.io/) uses files included with 
-`--examples-root` as documentation for published packages.
-
 #### Include a runtime image
 
 Functions and Providers require YAML files describing their dependencies and 
@@ -326,9 +323,9 @@ inside Crossplane.
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
 For example, to install to the latest version of the
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -380,11 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.upbound.io`, the 
-[Upbound Marketplace](https://marketplace.upbound.io/) container registry.
-
-[Register with the Upbound Marketplace](https://accounts.upbound.io/register) 
-to push packages and create private repositories. 
+Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
 
 #### Flags
 
@@ -451,8 +444,7 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the 
-[Upbound Marketplace](https://marketplace.upbound.io/) at `xpkg.upbound.io` by 
+The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
 default.
 
 {{< hint "note" >}}
@@ -504,13 +496,13 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-The package file must be an organization, image and tag on the `xpkg.upbound.io`
-registry on [Upbound Marketplace](https://marketplace.upbound.io/).
+The package file must be an organization, image and tag on the `xpkg.crossplane.io`
+GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
-For example, to update to the latest version of the
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+For example, to update to the latest version of the 
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 
 ## beta
@@ -569,11 +561,11 @@ related pods.
 
 ```shell
 crossplane beta top 
-TYPE         NAMESPACE   NAME                                                       CPU(cores)   MEMORY
-crossplane   default     crossplane-f98f9ddfd-tnm46                                 4m           32Mi
-crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                   4m           14Mi
-provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq              3m           108Mi
-provider     default     upbound-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
+TYPE         NAMESPACE   NAME                                                                  CPU(cores)   MEMORY
+crossplane   default     crossplane-f98f9ddfd-tnm46                                            4m           32Mi
+crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                              4m           14Mi
+provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq                         3m           108Mi
+provider     default     crossplane-contrib-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
 ```
 
 {{<hint "important" >}}
@@ -942,7 +934,7 @@ To clear the cache and download the CRD files again use the `--clean-cache` flag
 To validate a managed resource against a provider,
 first, create a provider manifest file. For example, to validate an IAM role
 from Provider AWS, use the 
-[Provider AWS IAM](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/v1.0.0) 
+[Provider AWS IAM](https://github.com/crossplane-contrib/provider-upjet-aws) 
 manifest.
 
 {{<hint "tip" >}}
@@ -957,7 +949,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.18/cli/command-reference.md
+++ b/content/v1.18/cli/command-reference.md
@@ -377,7 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
+Use `xpkg login` to authenticate to registries that host Crossplane packages.
 
 #### Flags
 
@@ -495,9 +495,6 @@ Specify the package kind, package file and optionally the name of the package
 already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
-
-The package file must be an organization, image and tag on the `xpkg.crossplane.io`
-GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):

--- a/content/v1.18/cli/command-reference.md
+++ b/content/v1.18/cli/command-reference.md
@@ -444,9 +444,6 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
-default.
-
 {{< hint "note" >}}
 Pushing a package may require authentication with 
 [`crossplane xpkg login`](#xpkg-login)

--- a/content/v1.18/concepts/compositions.md
+++ b/content/v1.18/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip">}}

--- a/content/v1.18/concepts/connection-details.md
+++ b/content/v1.18/concepts/connection-details.md
@@ -49,7 +49,7 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions and Claims.
 
 All examples rely on 
-[Upbound provider-aws-iam](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/)
+[provider-aws-iam](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{<expand "Reference Composition" >}}

--- a/content/v1.18/concepts/managed-resources.md
+++ b/content/v1.18/concepts/managed-resources.md
@@ -15,9 +15,9 @@ external object inside the Provider an _external resource_.
 {{< /hint >}}
 
 Examples of managed resources include:
-* Amazon AWS EC2 [`Instance`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/ec2.aws.upbound.io/Instance/v1beta1)
-* Google Cloud GKE [`Cluster`](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/resources/container.gcp.upbound.io/Cluster/v1beta1)
-* Microsoft Azure PostgreSQL [`Database`](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/resources/dbforpostgresql.azure.upbound.io/Database/v1beta1)
+* Amazon AWS EC2 `Instance` defined in [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
+* Google Cloud GKE `Cluster` defined in [provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
+* Microsoft Azure PostgreSQL `Database` defined in [provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 {{< hint "tip" >}}
 
@@ -35,7 +35,7 @@ Provider also define the available settings of a managed resource.
 Each managed resource is a unique API endpoint with their own
 group, kind and version. 
 
-For example the [Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/)
+For example [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines the {{<hover label="gkv" line="2">}}Instance{{</hover>}} kind from the
 group {{<hover label="gkv" line="1">}}ec2.aws.upbound.io{{</hover>}}
 
@@ -529,7 +529,7 @@ Crossplane stores these details in a Kubernetes Secret object specified by the
 `writeConnectionSecretToRef` values. 
 
 For example, when creating an AWS RDS database instance with the Crossplane 
-[community AWS provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.40.0) 
+[community AWS provider](https://github.com/crossplane-contrib/provider-aws) 
 generates an endpoint, password, port and username data. The Provider saves
 these variables in the Kubernetes secret 
 {{<hover label="secretname" line="9" >}}rds-secret{{</hover>}}, referenced by

--- a/content/v1.18/concepts/packages.md
+++ b/content/v1.18/concepts/packages.md
@@ -34,8 +34,7 @@ the {{<hover line="6" label="install">}}spec.package{{</hover>}} value to the
 location of the configuration package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -43,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Upbound AWS reference platform](https://marketplace.upbound.io/configurations/upbound/platform-ref-aws/v0.6.0).
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-getting-started
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
 ```
 
 {{<hint "tip" >}}
@@ -64,7 +63,7 @@ kind: Configuration
 metadata:
   name: platform-ref-aws
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -80,14 +79,14 @@ Use the
 {{<hover label="helm" line="5" >}}--set configuration.packages{{</hover >}}
 argument with `helm install`.
 
-For example, to install the Upbound AWS reference platform,
+For example, to install the Getting Started Configuration,
 
 ```shell {label="helm"}
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
 ```
 
 ### Install offline
@@ -116,8 +115,8 @@ View the configuration revisions with
 ```shell {label="rev",copy-lines="1"}
 kubectl get configurationrevisions
 NAME                            HEALTHY   REVISION   IMAGE                                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
-platform-ref-aws-1735d56cd88d   True      2          xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0   Active     2           2               46s
-platform-ref-aws-3ac761211893   True      1          xpkg.upbound.io/upbound/platform-ref-aws:v0.4.1   Inactive                               5m13s
+platform-ref-aws-1735d56cd88d   True      2          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.5.0   Active     2           2               46s
+platform-ref-aws-3ac761211893   True      1          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.4.1   Inactive                               5m13s
 ```
 
 Only a single revision is active at a time. The active revision determines the
@@ -309,7 +308,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
 ```
 
 ### Manage dependencies
@@ -320,13 +319,13 @@ Functions, Providers or other Configurations.
 If Crossplane can't meet the dependencies of a Configuration the Configuration
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -340,7 +339,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
   Revision:                       1
 Status:
   Conditions:
@@ -424,7 +423,7 @@ metadata:
   name: test-configuration
 spec:
   dependsOn:
-    - provider: xpkg.upbound.io/crossplane-contrib/provider-aws
+    - provider: xpkg.crossplane.io/crossplane-contrib/provider-aws
       version: ">=v0.36.0"
   crossplane:
     version: ">=v1.12.1-0"

--- a/content/v1.18/concepts/packages.md
+++ b/content/v1.18/concepts/packages.md
@@ -63,7 +63,7 @@ kind: Configuration
 metadata:
   name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:ef9795d146190637351a5c5848e0bab5e0c190fec7780f6c426fbffa0cb68358
 ```
 {{< /hint >}}
 

--- a/content/v1.18/concepts/packages.md
+++ b/content/v1.18/concepts/packages.md
@@ -42,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: configuration-getting-started
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
 ```
 
 {{<hint "tip" >}}
@@ -61,9 +61,9 @@ and repeatable installations.
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -86,7 +86,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0}'
 ```
 
 ### Install offline
@@ -308,7 +308,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   54s
 ```
 
 ### Manage dependencies
@@ -325,7 +325,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -339,7 +339,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.18/concepts/providers.md
+++ b/content/v1.18/concepts/providers.md
@@ -48,8 +48,7 @@ Install a Provider with a Crossplane
 location of the provider package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -65,7 +64,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0
 ```
 
 By default, the Provider pod installs in the same namespace as Crossplane
@@ -113,7 +112,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
+--set provider.packages='{xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install offline
@@ -140,7 +139,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
 ```
 {{< /hint >}}
 
@@ -333,13 +332,13 @@ Configurations or other Providers.
 If Crossplane can't meet the dependencies of a Provider package the Provider
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -352,7 +351,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
   Revision:                       1
 Status:
   Conditions:
@@ -390,10 +389,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           Active     1           1               10d
-provider-nop-552a394a8acc                  True      2          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
-provider-nop-7e62d2a1a709                  True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       Active                                 10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
+provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -436,7 +435,7 @@ During the install a Provider report `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        Unknown   xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   63s
+crossplane-contrib-provider-aws   True        Unknown   xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   63s
 ```
 
 After the Provider install completes and it's ready for use the `HEALTHY` status
@@ -445,7 +444,7 @@ reports `True`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   88s
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   88s
 ```
 
 {{<hint "important" >}}
@@ -654,7 +653,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/v1.18/concepts/providers.md
+++ b/content/v1.18/concepts/providers.md
@@ -338,7 +338,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -351,7 +351,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
   Revision:                       1
 Status:
   Conditions:
@@ -389,10 +389,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
 ```
 
 By default Crossplane keeps a single 

--- a/content/v1.18/getting-started/install-crossplane-include.md
+++ b/content/v1.18/getting-started/install-crossplane-include.md
@@ -71,7 +71,7 @@ function:
 hostNetwork: false
 image:
   pullPolicy: IfNotPresent
-  repository: xpkg.upbound.io/crossplane/crossplane
+  repository: xpkg.crossplane.io/crossplane/crossplane
   tag: ""
 imagePullSecrets: {}
 leaderElection: true
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: crossplane
       hostNetwork: false
       initContainers:
-        - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+        - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
           args:
           - core
           - init
@@ -894,7 +894,7 @@ spec:
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - core
         - start
@@ -1011,7 +1011,7 @@ spec:
     spec:
       serviceAccountName: rbac-manager
       initContainers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - init
@@ -1041,7 +1041,7 @@ spec:
                 containerName: crossplane-init
                 resource: limits.memory
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - start

--- a/content/v1.18/getting-started/introduction.md
+++ b/content/v1.18/getting-started/introduction.md
@@ -107,7 +107,7 @@ defines a
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.18/getting-started/introduction.md
+++ b/content/v1.18/getting-started/introduction.md
@@ -86,9 +86,9 @@ The following sections describe the functions of some of these CRDs.
 A Crossplane _Provider_ creates a second set of CRDs that define how Crossplane
 connects to a non-Kubernetes service. Each external service relies on its own
 Provider. For example, 
-[AWS](https://marketplace.upbound.io/providers/upbound/provider-aws), 
-[Azure](https://marketplace.upbound.io/providers/upbound/provider-azure) 
-and [GCP](https://marketplace.upbound.io/providers/upbound/provider-gcp)
+[AWS](https://github.com/crossplane-contrib/provider-upjet-aws), 
+[Azure](https://github.com/crossplane-contrib/provider-upjet-azure) 
+and [GCP](https://github.com/crossplane-contrib/provider-upjet-gcp)
 are different providers for each cloud service.
 
 {{< hint "tip" >}}
@@ -100,14 +100,14 @@ For example, an AWS Provider defines Kubernetes CRDs for AWS resources like EC2
 compute instances or S3 storage buckets.
 
 The Provider defines the Kubernetes API definition for the external resource.
-For example, the 
-[Upbound Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-aws/)
+For example,  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines a 
-[`bucket`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1) 
+[`bucket`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml) 
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.18/getting-started/provider-aws-part-2.md
+++ b/content/v1.18/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
 ```
 
 ## Create a custom API
@@ -421,7 +421,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -596,7 +596,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.18/getting-started/provider-aws-part-2.md
+++ b/content/v1.18/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
 ```
 
 ## Create a custom API

--- a/content/v1.18/getting-started/provider-aws.md
+++ b/content/v1.18/getting-started/provider-aws.md
@@ -4,8 +4,8 @@ weight: 100
 ---
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
+with 
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -52,12 +52,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.0.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-aws{{</hover >}}.   
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-aws{{</hover >}}.   
 The family provider manages authentication to AWS across all AWS family
 Providers. 
 
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -239,6 +239,6 @@ bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 * [**Continue to part 2**]({{< ref "provider-aws-part-2">}}) to create and use a 
   custom API with Crossplane.
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.18/getting-started/provider-azure-part-2.md
+++ b/content/v1.18/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.0.0   25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0   25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    3h
 ```
 
 ## Access the custom API
@@ -694,7 +694,7 @@ No resources found
 
 ## Next steps
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out

--- a/content/v1.18/getting-started/provider-azure-part-2.md
+++ b/content/v1.18/getting-started/provider-azure-part-2.md
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0   25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    3h
 ```
 
 ## Access the custom API

--- a/content/v1.18/getting-started/provider-azure.md
+++ b/content/v1.18/getting-started/provider-azure.md
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/v1.18/getting-started/provider-azure.md
+++ b/content/v1.18/getting-started/provider-azure.md
@@ -4,8 +4,8 @@ weight: 110
 ---
 
 Connect Crossplane to Azure to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound Azure Provider](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+with  
+[provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -54,12 +54,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
 ```
 
 The Network Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-azure{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-azure{{</hover>}} 
 provider.   
 The family provider manages authentication to Azure across all Azure family
 Providers. 
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/blob/main/package/crds).
 {{< /hint >}}
 
 
@@ -234,6 +234,6 @@ virtualnetwork.network.azure.upbound.io "crossplane-quickstart-network" deleted
 * [**Continue to part 2**]({{< ref "provider-azure-part-2">}}) to create and use
   a custom API with Crossplane.
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.18/getting-started/provider-gcp-part-2.md
+++ b/content/v1.18/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.0.0    39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.0.0    39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    12m
 ```
 
 
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -601,7 +601,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.18/getting-started/provider-gcp-part-2.md
+++ b/content/v1.18/getting-started/provider-gcp-part-2.md
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.0.0    39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4    39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    12m
 ```
 
 

--- a/content/v1.18/getting-started/provider-gcp.md
+++ b/content/v1.18/getting-started/provider-gcp.md
@@ -4,8 +4,8 @@ weight: 140
 ---
 
 Connect Crossplane to GCP to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound GCP Provider](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+with  
+[provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -51,12 +51,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
 ```
 
 The Storage Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-gcp{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-gcp{{</hover>}} 
 provider.   
 The family provider manages authentication to GCP across all GCP family
 Providers. 
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/blob/main/package/crds).
 {{< /hint >}}
 
 
@@ -246,6 +246,6 @@ bucket.storage.gcp.upbound.io "crossplane-bucket-8b7gw" deleted
 * [**Continue to part 2**]({{< ref "provider-gcp-part-2">}}) to create a 
 Crossplane _Composite Resource_ and _Claim_.
 * Explore GCP resources that can Crossplane can configure in the 
-[Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
 Crossplane users and contributors.

--- a/content/v1.18/getting-started/provider-gcp.md
+++ b/content/v1.18/getting-started/provider-gcp.md
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.18/guides/function-patch-and-transform.md
+++ b/content/v1.18/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip" >}}
@@ -122,7 +122,7 @@ The contents of the `base` are identical to creating a standalone
 [managed resource]({{<ref "../concepts/managed-resources">}}).
 
 This example uses
-[Upbound's Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-family-aws/v1.17.0)
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 to define a S3 storage `Bucket` and EC2 compute `Instance`.
 
 After defining the `apiVersion` and `kind`, define the `spec.forProvider` fields
@@ -507,8 +507,8 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions, Claims and EnvironmentConfigs.
 Only the applied patches change between examples.
 
-All examples rely on Upbound
-[provider-aws-s3](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/)
+All examples rely on 
+[provider-aws-s3](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{< expand "Reference Composition" >}}

--- a/content/v1.18/guides/multi-tenant.md
+++ b/content/v1.18/guides/multi-tenant.md
@@ -315,9 +315,9 @@ dedicated control planes to many tenants within a single organization.
 [Multiple Source Field patching]: https://github.com/crossplane/crossplane/pull/2093
 [Configuration packages]: {{<ref "../../master/concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
-[EKS Cluster]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/latest/resources/eks.aws.crossplane.io/Cluster/v1beta1
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
-[provider-helm]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-helm/
+[EKS Cluster]: https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples/eks/v1beta2/cluster.yaml
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
+[provider-helm]: https://github.com/crossplane-contrib/provider-helm
 [Open Service Broker API]: https://github.com/openservicebrokerapi/servicebroker
 [Crossplane Service Broker]: https://github.com/vshn/crossplane-service-broker
 [Cloudfoundry]: https://www.cloudfoundry.org/

--- a/content/v1.18/guides/troubleshoot-crossplane.md
+++ b/content/v1.18/guides/troubleshoot-crossplane.md
@@ -5,12 +5,13 @@ weight: 306
 ## Requested Resource Not Found
 
 If you use the Crossplane CLI to install a `Provider` or
-`Configuration` (for example, `crossplane install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+`Configuration` (for example, `crossplane xpkg install provider
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
 plugin isn't aware of this change.
+
 
 
 ## Resource Status and Conditions

--- a/content/v1.18/guides/troubleshoot-crossplane.md
+++ b/content/v1.18/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane install provider
-xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
@@ -103,7 +103,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -365,7 +365,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/content/v1.18/guides/vault-as-secret-store.md
+++ b/content/v1.18/guides/vault-as-secret-store.md
@@ -217,7 +217,7 @@ Next, install the Crossplane ESS Plugin pod to the `crossplane-system` namespace
 and apply the Vault annotations.
 
 ```shell
-helm upgrade --install ess-plugin-vault oci://xpkg.upbound.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
+helm upgrade --install ess-plugin-vault oci://xpkg.crossplane.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
 ```
 
 ## Configure Crossplane
@@ -255,7 +255,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -341,7 +341,7 @@ Check that Crossplane installed the Provider and the Provider is healthy.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME           INSTALLED   HEALTHY   PACKAGE                                                                     AGE
-provider-gcp   True        True      xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
+provider-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
 ```
 
 ### Create a CompositeResourceDefinition

--- a/content/v1.18/guides/vault-injection.md
+++ b/content/v1.18/guides/vault-injection.md
@@ -310,7 +310,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.22.0
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -418,7 +418,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   controllerConfigRef:
     name: aws-vault-config" | kubectl apply -f -
 ```
@@ -491,8 +491,8 @@ kubectl get bucket -w
 [Vault Kubernetes Sidecar]: https://learn.hashicorp.com/tutorials/vault/kubernetes-sidecar
 [Vault]: https://www.vaultproject.io/
 [Vault Kubernetes Sidecar]: https://www.vaultproject.io/docs/platform/k8s/injector
-[provider-gcp]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-gcp
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
+[provider-gcp]: https://github.com/crossplane-contrib/provider-upjet-gcp
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
 [GCP]: https://www.vaultproject.io/docs/secrets/gcp 

--- a/content/v1.18/guides/write-a-composition-function-in-go.md
+++ b/content/v1.18/guides/write-a-composition-function-in-go.md
@@ -425,7 +425,7 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+The code uses the `v1beta1.Bucket` type from the [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
 One advantage of writing a function in Go is that you can compose resources
 using the same strongly typed structs Crossplane uses in its providers.
 
@@ -671,7 +671,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -783,7 +783,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -863,11 +863,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.18/guides/write-a-composition-function-in-python.md
+++ b/content/v1.18/guides/write-a-composition-function-in-python.md
@@ -533,7 +533,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -644,7 +644,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -732,11 +732,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.18/software/install.md
+++ b/content/v1.18/software/install.md
@@ -133,7 +133,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `function.packages` | A list of Function packages to install. | `[]` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
-| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.upbound.io/crossplane/crossplane"` |
+| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `{}` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
@@ -267,9 +267,8 @@ args='{"--enable-composition-functions","--enable-composition-webhook-schema-val
 
 #### Change the default package registry
 
-Beginning with Crossplane version 1.15.0 Crossplane downloads packages from the
-[Upbound Marketplace](https://marketplace.upbound.io) at `xpkg.upbound.io` 
-instead of DockerHub. 
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
+installing packages. 
 
 Change the default registry location during the Crossplane install with 
 `--set args='{"--registry=index.docker.io"}'`.
@@ -326,15 +325,3 @@ Community Crossplane distribution.
 The CNCF certified third-party distributions as 
 "[conformant](https://github.com/cncf/crossplane-conformance)" with the 
 Community Crossplane distribution.
-
-### Vendors
-Below are vendors providing conformant Crossplane distributions. 
-
-#### Upbound
-Upbound, the founders of Crossplane, maintains a free and open source 
-distribution of Crossplane called 
-[Universal Crossplane](https://www.upbound.io/product/universal-crossplane)
-(`UXP`). 
-
-Find information on UXP in the 
-[Upbound UXP documentation](https://docs.upbound.io/uxp/install/).

--- a/content/v1.18/software/uninstall.md
+++ b/content/v1.18/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1   8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.18/software/uninstall.md
+++ b/content/v1.18/software/uninstall.md
@@ -135,13 +135,13 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0   8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.
 
 ```shell
-kubectl delete provider upbound-provider-aws
+kubectl delete provider crossplane-contrib-provider-aws
 ```
 
 ## Uninstall the Crossplane deployment 

--- a/content/v1.18/software/upgrade.md
+++ b/content/v1.18/software/upgrade.md
@@ -46,9 +46,9 @@ Crossplane.
 Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
-For example, in v1.15.0 Crossplane changed the default image registry from 
+For example, in v1.20.0 Crossplane changed the default image registry from 
 `index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
-before v1.15.0 updates the default package registry. 
+before v1.20.0 updates the default package registry. 
 
 Override new defaults by 
 [customizing the Helm chart]({{<ref "install#customize-the-crossplane-helm-chart" >}}) 

--- a/content/v1.18/software/upgrade.md
+++ b/content/v1.18/software/upgrade.md
@@ -47,7 +47,7 @@ Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 
-`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+`index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
 before v1.15.0 updates the default package registry. 
 
 Override new defaults by 

--- a/content/v1.19/cli/command-reference.md
+++ b/content/v1.19/cli/command-reference.md
@@ -377,7 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
+Use `xpkg login` to authenticate to registries that host Crossplane packages.
 
 #### Flags
 
@@ -495,9 +495,6 @@ Specify the package kind, package file and optionally the name of the package
 already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
-
-The package file must be an organization, image and tag on the `xpkg.crossplane.io`
-GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):

--- a/content/v1.19/cli/command-reference.md
+++ b/content/v1.19/cli/command-reference.md
@@ -240,9 +240,6 @@ For example,
 
 Include YAML files demonstrating how to use the package with `--examples-root`. 
 
-[Upbound Marketplace](https://marketplace.upbound.io/) uses files included with 
-`--examples-root` as documentation for published packages.
-
 #### Include a runtime image
 
 Functions and Providers require YAML files describing their dependencies and 
@@ -326,9 +323,9 @@ inside Crossplane.
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
 For example, to install the latest version of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -380,11 +377,7 @@ in the package documentation.
 
 ### xpkg login
 
-Use `xpkg login` to authenticate to `xpkg.upbound.io`, the 
-[Upbound Marketplace](https://marketplace.upbound.io/) container registry.
-
-[Register with the Upbound Marketplace](https://accounts.upbound.io/register) 
-to push packages and create private repositories. 
+Use `xpkg login` to authenticate to `xpkg.crossplane.io`, the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry used by the Crossplane project.
 
 #### Flags
 
@@ -451,8 +444,7 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the 
-[Upbound Marketplace](https://marketplace.upbound.io/) at `xpkg.upbound.io` by 
+The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
 default.
 
 {{< hint "note" >}}
@@ -504,13 +496,13 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-The package file must be an organization, image and tag on the `xpkg.upbound.io`
-registry on [Upbound Marketplace](https://marketplace.upbound.io/).
+The package file must be an organization, image and tag on the `xpkg.crossplane.io`
+GitHub Container Registry in [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub org.
 
 For example, to update to the latest version of the 
-[AWS S3 provider](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/):
+[AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.upbound.io/upbound/provider-aws-s3:v1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
 
 
 ## beta
@@ -569,11 +561,11 @@ related pods.
 
 ```shell
 crossplane beta top 
-TYPE         NAMESPACE   NAME                                                       CPU(cores)   MEMORY
-crossplane   default     crossplane-f98f9ddfd-tnm46                                 4m           32Mi
-crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                   4m           14Mi
-provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq              3m           108Mi
-provider     default     upbound-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
+TYPE         NAMESPACE   NAME                                                                  CPU(cores)   MEMORY
+crossplane   default     crossplane-f98f9ddfd-tnm46                                            4m           32Mi
+crossplane   default     crossplane-rbac-manager-74ff459b88-94p8p                              4m           14Mi
+provider     default     provider-aws-s3-1f1a3fb08cbc-5c49d84447-sggrq                         3m           108Mi
+provider     default     crossplane-contrib-provider-family-aws-48b3b5ccf964-76c9686b6-bgg65   2m           89Mi
 ```
 
 {{<hint "important" >}}
@@ -942,7 +934,7 @@ To clear the cache and download the CRD files again use the `--clean-cache` flag
 To validate a managed resource against a provider,
 first, create a provider manifest file. For example, to validate an IAM role
 from Provider AWS, use the 
-[Provider AWS IAM](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/v1.0.0) 
+[Provider AWS IAM](https://github.com/crossplane-contrib/provider-upjet-aws) 
 manifest.
 
 {{<hint "tip" >}}
@@ -957,7 +949,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.19/cli/command-reference.md
+++ b/content/v1.19/cli/command-reference.md
@@ -444,9 +444,6 @@ Using `crossplane xpkg logout` removes the `session` from the
 
 Push a Crossplane package file to a package registry. 
 
-The Crossplane CLI pushes images to the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by 
-default.
-
 {{< hint "note" >}}
 Pushing a package may require authentication with 
 [`crossplane xpkg login`](#xpkg-login)

--- a/content/v1.19/concepts/compositions.md
+++ b/content/v1.19/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip">}}

--- a/content/v1.19/concepts/connection-details.md
+++ b/content/v1.19/concepts/connection-details.md
@@ -49,7 +49,7 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions and Claims.
 
 All examples rely on 
-[Upbound provider-aws-iam](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/)
+[provider-aws-iam](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{<expand "Reference Composition" >}}

--- a/content/v1.19/concepts/managed-resources.md
+++ b/content/v1.19/concepts/managed-resources.md
@@ -15,9 +15,9 @@ external object inside the Provider an _external resource_.
 {{< /hint >}}
 
 Examples of managed resources include:
-* Amazon AWS EC2 [`Instance`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/ec2.aws.upbound.io/Instance/v1beta1)
-* Google Cloud GKE [`Cluster`](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest/resources/container.gcp.upbound.io/Cluster/v1beta1)
-* Microsoft Azure PostgreSQL [`Database`](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/resources/dbforpostgresql.azure.upbound.io/Database/v1beta1)
+* Amazon AWS EC2 `Instance` defined in [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
+* Google Cloud GKE `Cluster` defined in [provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
+* Microsoft Azure PostgreSQL `Database` defined in [provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 {{< hint "tip" >}}
 
@@ -35,7 +35,7 @@ Provider also define the available settings of a managed resource.
 Each managed resource is a unique API endpoint with their own
 group, kind and version. 
 
-For example the [Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/)
+For example [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines the {{<hover label="gkv" line="2">}}Instance{{</hover>}} kind from the
 group {{<hover label="gkv" line="1">}}ec2.aws.upbound.io{{</hover>}}
 
@@ -529,7 +529,7 @@ Crossplane stores these details in a Kubernetes Secret object specified by the
 `writeConnectionSecretToRef` values. 
 
 For example, when creating an AWS RDS database instance with the Crossplane 
-[community AWS provider](https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.40.0) 
+[community AWS provider](https://github.com/crossplane-contrib/provider-aws) 
 generates an endpoint, password, port and username data. The Provider saves
 these variables in the Kubernetes secret 
 {{<hover label="secretname" line="9" >}}rds-secret{{</hover>}}, referenced by

--- a/content/v1.19/concepts/packages.md
+++ b/content/v1.19/concepts/packages.md
@@ -34,8 +34,7 @@ the {{<hover line="6" label="install">}}spec.package{{</hover>}} value to the
 location of the configuration package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -43,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Upbound AWS reference platform](https://marketplace.upbound.io/configurations/upbound/platform-ref-aws/v0.6.0).
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-getting-started
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
 ```
 
 {{<hint "tip" >}}
@@ -64,7 +63,7 @@ kind: Configuration
 metadata:
   name: platform-ref-aws
 spec:
-  package: xpkg.upbound.io/upbound/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -80,14 +79,14 @@ Use the
 {{<hover label="helm" line="5" >}}--set configuration.packages{{</hover >}}
 argument with `helm install`.
 
-For example, to install the Upbound AWS reference platform,
+For example, to install the Getting Started Configuration,
 
 ```shell {label="helm"}
 helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
 ```
 
 ### Install offline
@@ -116,8 +115,8 @@ View the configuration revisions with
 ```shell {label="rev",copy-lines="1"}
 kubectl get configurationrevisions
 NAME                            HEALTHY   REVISION   IMAGE                                             STATE      DEP-FOUND   DEP-INSTALLED   AGE
-platform-ref-aws-1735d56cd88d   True      2          xpkg.upbound.io/upbound/platform-ref-aws:v0.5.0   Active     2           2               46s
-platform-ref-aws-3ac761211893   True      1          xpkg.upbound.io/upbound/platform-ref-aws:v0.4.1   Inactive                               5m13s
+platform-ref-aws-1735d56cd88d   True      2          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.5.0   Active     2           2               46s
+platform-ref-aws-3ac761211893   True      1          xpkg.crossplane.io/crossplane-contrib/platform-ref-aws:v0.4.1   Inactive                               5m13s
 ```
 
 Only a single revision is active at a time. The active revision determines the
@@ -350,7 +349,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
 ```
 
 ### Manage dependencies
@@ -361,13 +360,13 @@ Functions, Providers or other Configurations.
 If Crossplane can't meet the dependencies of a Configuration the Configuration
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -381,7 +380,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/platform-ref-aws:v0.6.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
   Revision:                       1
 Status:
   Conditions:
@@ -467,7 +466,7 @@ spec:
   dependsOn:
     - apiVersion: pkg.crossplane.io/v1
       kind: Provider
-      package: xpkg.upbound.io/crossplane-contrib/provider-aws
+      package: xpkg.crossplane.io/crossplane-contrib/provider-aws
       version: ">=v0.36.0"
   crossplane:
     version: ">=v1.12.1-0"

--- a/content/v1.19/concepts/packages.md
+++ b/content/v1.19/concepts/packages.md
@@ -42,15 +42,15 @@ registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
 For example to install the 
-[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-getting-started), 
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart), 
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: configuration-getting-started
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
 ```
 
 {{<hint "tip" >}}
@@ -61,9 +61,9 @@ and repeatable installations.
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: platform-ref-aws
+  name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/platform-ref-aws@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
 ```
 {{< /hint >}}
 
@@ -86,7 +86,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1}'
+--set configuration.packages='{xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0}'
 ```
 
 ### Install offline
@@ -349,7 +349,7 @@ A working configuration reports `Installed` and `Healthy` as `True`.
 ```shell {label="verify",copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   54s
+platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   54s
 ```
 
 ### Manage dependencies
@@ -366,7 +366,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get configuration
 NAME               INSTALLED   HEALTHY   PACKAGE                                           AGE
-platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1   71s
+platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   71s
 ```
 
 To see more information on why the Configuration isn't `HEALTHY` use 
@@ -380,7 +380,7 @@ Kind:         ConfigurationRevision
 # Removed for brevity
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-getting-started:v0.0.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0
   Revision:                       1
 Status:
   Conditions:

--- a/content/v1.19/concepts/packages.md
+++ b/content/v1.19/concepts/packages.md
@@ -63,7 +63,7 @@ kind: Configuration
 metadata:
   name: configuration-quickstart
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:a30ad655c7699218d9234285d838d85582f015d02f7f061f8486b28248fd7db7
+  package: xpkg.crossplane.io/crossplane-contrib/configuration-quickstart@sha256:ef9795d146190637351a5c5848e0bab5e0c190fec7780f6c426fbffa0cb68358
 ```
 {{< /hint >}}
 

--- a/content/v1.19/concepts/providers.md
+++ b/content/v1.19/concepts/providers.md
@@ -379,7 +379,7 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -392,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
   Revision:                       1
 Status:
   Conditions:
@@ -430,10 +430,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
 ```
 
 By default Crossplane keeps a single 

--- a/content/v1.19/concepts/providers.md
+++ b/content/v1.19/concepts/providers.md
@@ -48,8 +48,7 @@ Install a Provider with a Crossplane
 location of the provider package.
 
 {{< hint "important" >}}
-Beginning with Crossplane version 1.15.0 Crossplane uses the Upbound Marketplace
-Crossplane package registry at `xpkg.upbound.io` by default for downloading and
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
 installing packages. 
 
 Specify the full domain name with the `package` or change the default Crossplane
@@ -65,7 +64,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0
 ```
 
 By default, the Provider pod installs in the same namespace as Crossplane
@@ -113,7 +112,7 @@ helm install crossplane \
 crossplane-stable/crossplane \
 --namespace crossplane-system \
 --create-namespace \
---set provider.packages='{xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0}'
+--set provider.packages='{xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0}'
 ```
 
 ### Install offline
@@ -140,7 +139,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws@sha256:ee6bece46dbb54cc3f0233961f5baac317fa4e4a81b41198bdc72fc472d113d0
 ```
 {{< /hint >}}
 
@@ -374,13 +373,13 @@ Configurations or other Providers.
 If Crossplane can't meet the dependencies of a Provider package the Provider
 reports `HEALTHY` as `False`. 
 
-For example, this installation of the Upbound AWS reference platform is
+For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0   12s
 ```
 
 To see more information on why the Provider isn't `HEALTHY` use 
@@ -393,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0
   Revision:                       1
 Status:
   Conditions:
@@ -431,10 +430,10 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           Active     1           1               10d
-provider-nop-552a394a8acc                  True      2          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
-provider-nop-7e62d2a1a709                  True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-upbound-provider-family-aws-710d8cfe9f53   True      1          xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       Active                                 10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           Active     1           1               10d
+provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
+provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       Active                                 10d
 ```
 
 By default Crossplane keeps a single 
@@ -477,7 +476,7 @@ During the install a Provider report `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        Unknown   xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   63s
+crossplane-contrib-provider-aws   True        Unknown   xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   63s
 ```
 
 After the Provider install completes and it's ready for use the `HEALTHY` status
@@ -486,7 +485,7 @@ reports `True`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                   AGE
-crossplane-contrib-provider-aws   True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.39.0   88s
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.39.0   88s
 ```
 
 {{<hint "important" >}}
@@ -694,7 +693,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-iam:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/v1.19/getting-started/install-crossplane-include.md
+++ b/content/v1.19/getting-started/install-crossplane-include.md
@@ -71,7 +71,7 @@ function:
 hostNetwork: false
 image:
   pullPolicy: IfNotPresent
-  repository: xpkg.upbound.io/crossplane/crossplane
+  repository: xpkg.crossplane.io/crossplane/crossplane
   tag: ""
 imagePullSecrets: {}
 leaderElection: true
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: crossplane
       hostNetwork: false
       initContainers:
-        - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+        - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
           args:
           - core
           - init
@@ -894,7 +894,7 @@ spec:
           - name: "TLS_CLIENT_SECRET_NAME"
             value: crossplane-tls-client
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - core
         - start
@@ -1011,7 +1011,7 @@ spec:
     spec:
       serviceAccountName: rbac-manager
       initContainers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - init
@@ -1041,7 +1041,7 @@ spec:
                 containerName: crossplane-init
                 resource: limits.memory
       containers:
-      - image: "xpkg.upbound.io/crossplane/crossplane:v1.15.0"
+      - image: "xpkg.crossplane.io/crossplane/crossplane:v1.15.0"
         args:
         - rbac
         - start

--- a/content/v1.19/getting-started/introduction.md
+++ b/content/v1.19/getting-started/introduction.md
@@ -107,7 +107,7 @@ defines a
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.19/getting-started/introduction.md
+++ b/content/v1.19/getting-started/introduction.md
@@ -86,9 +86,9 @@ The following sections describe the functions of some of these CRDs.
 A Crossplane _Provider_ creates a second set of CRDs that define how Crossplane
 connects to a non-Kubernetes service. Each external service relies on its own
 Provider. For example, 
-[AWS](https://marketplace.upbound.io/providers/upbound/provider-aws), 
-[Azure](https://marketplace.upbound.io/providers/upbound/provider-azure) 
-and [GCP](https://marketplace.upbound.io/providers/upbound/provider-gcp)
+[AWS](https://github.com/crossplane-contrib/provider-upjet-aws), 
+[Azure](https://github.com/crossplane-contrib/provider-upjet-azure) 
+and [GCP](https://github.com/crossplane-contrib/provider-upjet-gcp)
 are different providers for each cloud service.
 
 {{< hint "tip" >}}
@@ -100,14 +100,14 @@ For example, an AWS Provider defines Kubernetes CRDs for AWS resources like EC2
 compute instances or S3 storage buckets.
 
 The Provider defines the Kubernetes API definition for the external resource.
-For example, the 
-[Upbound Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-aws/)
+For example,  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 defines a 
-[`bucket`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1) 
+[`bucket`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/release-1.20/package/crds/s3.aws.upbound.io_buckets.yaml) 
 resource for creating and managing AWS S3 storage buckets. 
 
 In the `bucket` CRD is a
-[`spec.forProvider.region`](https://marketplace.upbound.io/providers/upbound/provider-aws/v0.25.0/resources/s3.aws.upbound.io/Bucket/v1beta1#doc:spec-forProvider-region)
+[`spec.forProvider.region`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/d83ef906bd17a7b6df814310e2ed7d674e99b786/package/crds/s3.aws.upbound.io_buckets.yaml#L91)
 value that defines which AWS region to deploy the bucket in.
 
 Crossplane's [public package registries](https://www.crossplane.io/registries) contain a large 

--- a/content/v1.19/getting-started/provider-aws-part-2.md
+++ b/content/v1.19/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-dynamodb:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
 EOF
 ```
 
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.upbound.io/upbound/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:v1.0.0           13m
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
 ```
 
 ## Create a custom API
@@ -421,7 +421,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -596,7 +596,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.19/getting-started/provider-aws-part-2.md
+++ b/content/v1.19/getting-started/provider-aws-part-2.md
@@ -106,9 +106,9 @@ View the new DynamoDB provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.0.0     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.0.0           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.0.0       13m
+provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
 ```
 
 ## Create a custom API

--- a/content/v1.19/getting-started/provider-aws.md
+++ b/content/v1.19/getting-started/provider-aws.md
@@ -4,8 +4,8 @@ weight: 100
 ---
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound AWS Provider](https://marketplace.upbound.io/providers/upbound/provider-family-aws).
+with  
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-s3:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
 EOF
 ```
 
@@ -52,12 +52,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.upbound.io/upbound/provider-aws-s3:1.0.0         97s
-upbound-provider-family-aws   True        True      xpkg.upbound.io/upbound/provider-family-aws:1.0.0     88s
+provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
 ```
 
 The S3 Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-aws{{</hover >}}.   
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-aws{{</hover >}}.   
 The family provider manages authentication to AWS across all AWS family
 Providers. 
 
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.1.0).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -239,6 +239,6 @@ bucket.s3.aws.upbound.io "crossplane-bucket-hhdzh" deleted
 * [**Continue to part 2**]({{< ref "provider-aws-part-2">}}) to create and use a 
   custom API with Crossplane.
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.19/getting-started/provider-azure-part-2.md
+++ b/content/v1.19/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-compute:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.upbound.io/upbound/provider-azure-compute:v1.0.0    25s
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0    3h
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0     3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0    25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0    3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0     3h
 ```
 
 ## Access the custom API
@@ -694,7 +694,7 @@ No resources found
 
 ## Next steps
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out

--- a/content/v1.19/getting-started/provider-azure-part-2.md
+++ b/content/v1.19/getting-started/provider-azure-part-2.md
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
 EOF
 ```
 
@@ -506,9 +506,9 @@ View the new Compute provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.0.0    25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0    3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0     3h
+provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    25s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    3h
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1     3h
 ```
 
 ## Access the custom API

--- a/content/v1.19/getting-started/provider-azure.md
+++ b/content/v1.19/getting-started/provider-azure.md
@@ -54,8 +54,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/v1.19/getting-started/provider-azure.md
+++ b/content/v1.19/getting-started/provider-azure.md
@@ -4,8 +4,8 @@ weight: 110
 ---
 
 Connect Crossplane to Azure to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound Azure Provider](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+with  
+[provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-network:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
 EOF
 ```
 
@@ -54,12 +54,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.upbound.io/upbound/provider-azure-network:v1.0.0   38s
-upbound-provider-family-azure   True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0    26s
+provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.0.0   38s
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.0.0    26s
 ```
 
 The Network Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-azure{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-azure{{</hover>}} 
 provider.   
 The family provider manages authentication to Azure across all Azure family
 Providers. 
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/v0.42.1).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/blob/main/package/crds).
 {{< /hint >}}
 
 
@@ -234,6 +234,6 @@ virtualnetwork.network.azure.upbound.io "crossplane-quickstart-network" deleted
 * [**Continue to part 2**]({{< ref "provider-azure-part-2">}}) to create and use
   a custom API with Crossplane.
 * Explore Azure resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-azure/).
+  [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.

--- a/content/v1.19/getting-started/provider-gcp-part-2.md
+++ b/content/v1.19/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-pubsub:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
 EOF
 ```
 
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.upbound.io/upbound/provider-gcp-pubsub:v1.0.0     39s
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0    13m
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0     12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.0.0     39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0    13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0     12m
 ```
 
 
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 EOF
 ```
 
@@ -601,7 +601,7 @@ No resources found
 
 ## Next steps
 * Explore AWS resources that Crossplane can configure in the 
-  [Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-aws/).
+  [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do

--- a/content/v1.19/getting-started/provider-gcp-part-2.md
+++ b/content/v1.19/getting-started/provider-gcp-part-2.md
@@ -123,9 +123,9 @@ View the new PubSub provider with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.0.0     39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0    13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0     12m
+provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4     39s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4    13m
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4     12m
 ```
 
 

--- a/content/v1.19/getting-started/provider-gcp.md
+++ b/content/v1.19/getting-started/provider-gcp.md
@@ -4,8 +4,8 @@ weight: 140
 ---
 
 Connect Crossplane to GCP to create and manage cloud resources from Kubernetes 
-with the 
-[Upbound GCP Provider](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+with  
+[provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
 
 This guide is in two parts:
 * Part 1 walks through installing Crossplane, configuring the provider to
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1
 EOF
 ```
 
@@ -51,12 +51,12 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.upbound.io/upbound/provider-gcp-storage:v1.0.0   36s
-upbound-provider-family-gcp   True        True      xpkg.upbound.io/upbound/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
 ```
 
 The Storage Provider installs a second Provider, the
-{{<hover label="getProvider" line="4">}}upbound-provider-family-gcp{{</hover>}} 
+{{<hover label="getProvider" line="4">}}crossplane-contrib-provider-family-gcp{{</hover>}} 
 provider.   
 The family provider manages authentication to GCP across all GCP family
 Providers. 
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/blob/main/package/crds).
 {{< /hint >}}
 
 
@@ -246,6 +246,6 @@ bucket.storage.gcp.upbound.io "crossplane-bucket-8b7gw" deleted
 * [**Continue to part 2**]({{< ref "provider-gcp-part-2">}}) to create a 
 Crossplane _Composite Resource_ and _Claim_.
 * Explore GCP resources that can Crossplane can configure in the 
-[Provider CRD reference](https://marketplace.upbound.io/providers/upbound/provider-family-gcp/).
+[Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
 * Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
 Crossplane users and contributors.

--- a/content/v1.19/getting-started/provider-gcp.md
+++ b/content/v1.19/getting-started/provider-gcp.md
@@ -51,8 +51,8 @@ Verify the provider installed with `kubectl get providers`.
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
 NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.0.0   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.0.0    29s
+provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/v1.19/guides/function-patch-and-transform.md
+++ b/content/v1.19/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
 ```
 
 {{<hint "tip" >}}
@@ -122,7 +122,7 @@ The contents of the `base` are identical to creating a standalone
 [managed resource]({{<ref "../concepts/managed-resources">}}).
 
 This example uses
-[Upbound's Provider AWS](https://marketplace.upbound.io/providers/upbound/provider-family-aws/v1.17.0)
+[provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws)
 to define a S3 storage `Bucket` and EC2 compute `Instance`.
 
 After defining the `apiVersion` and `kind`, define the `spec.forProvider` fields
@@ -507,8 +507,8 @@ All the following examples use the same set of Compositions,
 CompositeResourceDefinitions, Claims and EnvironmentConfigs.
 Only the applied patches change between examples.
 
-All examples rely on Upbound
-[provider-aws-s3](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/)
+All examples rely on
+[provider-aws-s3](https://github.com/crossplane-contrib/provider-upjet-aws)
 to create resources.
 
 {{< expand "Reference Composition" >}}

--- a/content/v1.19/guides/multi-tenant.md
+++ b/content/v1.19/guides/multi-tenant.md
@@ -315,9 +315,9 @@ dedicated control planes to many tenants within a single organization.
 [Multiple Source Field patching]: https://github.com/crossplane/crossplane/pull/2093
 [Configuration packages]: {{<ref "../../master/concepts/packages" >}}
 [OCI images]: https://github.com/opencontainers/image-spec
-[EKS Cluster]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/latest/resources/eks.aws.crossplane.io/Cluster/v1beta1
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
-[provider-helm]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-helm/
+[EKS Cluster]: https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples/eks/v1beta2/cluster.yaml
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
+[provider-helm]: https://github.com/crossplane-contrib/provider-helm
 [Open Service Broker API]: https://github.com/openservicebrokerapi/servicebroker
 [Crossplane Service Broker]: https://github.com/vshn/crossplane-service-broker
 [Cloudfoundry]: https://www.cloudfoundry.org/

--- a/content/v1.19/guides/troubleshoot-crossplane.md
+++ b/content/v1.19/guides/troubleshoot-crossplane.md
@@ -5,12 +5,13 @@ weight: 306
 ## Requested Resource Not Found
 
 If you use the Crossplane CLI to install a `Provider` or
-`Configuration` (for example, `crossplane install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+`Configuration` (for example, `crossplane xpkg install provider
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
 plugin isn't aware of this change.
+
 
 
 ## Resource Status and Conditions

--- a/content/v1.19/guides/troubleshoot-crossplane.md
+++ b/content/v1.19/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane install provider
-xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old
@@ -103,7 +103,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig
@@ -365,7 +365,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig

--- a/content/v1.19/guides/vault-as-secret-store.md
+++ b/content/v1.19/guides/vault-as-secret-store.md
@@ -217,7 +217,7 @@ Next, install the Crossplane ESS Plugin pod to the `crossplane-system` namespace
 and apply the Vault annotations.
 
 ```shell
-helm upgrade --install ess-plugin-vault oci://xpkg.upbound.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
+helm upgrade --install ess-plugin-vault oci://xpkg.crossplane.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
 ```
 
 ## Configure Crossplane
@@ -255,7 +255,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -341,7 +341,7 @@ Check that Crossplane installed the Provider and the Provider is healthy.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME           INSTALLED   HEALTHY   PACKAGE                                                                     AGE
-provider-gcp   True        True      xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
+provider-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
 ```
 
 ### Create a CompositeResourceDefinition

--- a/content/v1.19/guides/vault-injection.md
+++ b/content/v1.19/guides/vault-injection.md
@@ -310,7 +310,7 @@ kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp:v0.22.0
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
@@ -418,7 +418,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws:v0.33.0
   controllerConfigRef:
     name: aws-vault-config" | kubectl apply -f -
 ```
@@ -491,8 +491,8 @@ kubectl get bucket -w
 [Vault Kubernetes Sidecar]: https://learn.hashicorp.com/tutorials/vault/kubernetes-sidecar
 [Vault]: https://www.vaultproject.io/
 [Vault Kubernetes Sidecar]: https://www.vaultproject.io/docs/platform/k8s/injector
-[provider-gcp]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-gcp
-[provider-aws]: https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws
+[provider-gcp]: https://github.com/crossplane-contrib/provider-upjet-gcp
+[provider-aws]: https://github.com/crossplane-contrib/provider-upjet-aws
 [AWS]: https://www.vaultproject.io/docs/secrets/aws
 [Azure]: https://www.vaultproject.io/docs/secrets/azure
 [GCP]: https://www.vaultproject.io/docs/secrets/gcp 

--- a/content/v1.19/guides/write-a-composition-function-in-go.md
+++ b/content/v1.19/guides/write-a-composition-function-in-go.md
@@ -425,7 +425,7 @@ This code:
 1. Adds one desired S3 bucket for each bucket name.
 1. Returns the desired S3 buckets in a `RunFunctionResponse`.
 
-The code uses the `v1beta1.Bucket` type from [Upbound's AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
+The code uses the `v1beta1.Bucket` type from the [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws).
 One advantage of writing a function in Go is that you can compose resources
 using the same strongly typed structs Crossplane uses in its providers.
 
@@ -671,7 +671,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -783,7 +783,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -863,11 +863,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.19/guides/write-a-composition-function-in-python.md
+++ b/content/v1.19/guides/write-a-composition-function-in-python.md
@@ -533,7 +533,7 @@ metadata:
 spec:
   # The CLI ignores this package when using the Development runtime.
   # You can set it to any value.
-  package: xpkg.upbound.io/negz/function-xbuckets:v0.1.0
+  package: xpkg.crossplane.io/negz/function-xbuckets:v0.1.0
 ```
 {{</expand>}}
 
@@ -644,7 +644,7 @@ Read the composition functions documentation to learn more about
 You build a function in two stages. First you build the function's runtime. This
 is the Open Container Initiative (OCI) image Crossplane uses to run your
 function. You then embed that runtime in a package, and push it to a package
-registry. The Crossplane CLI uses `xpkg.upbound.io` as its default package
+registry. The Crossplane CLI uses `xpkg.crossplane.io` as its default package
 registry.
 
 A function supports a single platform, like `linux/amd64`, by default. You can
@@ -732,11 +732,4 @@ up continuous integration (CI) using
 [GitHub Actions](https://github.com/features/actions). The CI workflow will
 lint, test, and build your function. You can see how the template configures CI
 by reading `.github/workflows/ci.yaml`.
-
-The CI workflow can automatically push packages to `xpkg.upbound.io`. For this
-to work you must create a repository at https://marketplace.upbound.io. Give the
-CI workflow access to push to the Marketplace by creating an API token and
-[adding it to your repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
-Save your API token access ID as a secret named `XPKG_ACCESS_ID` and your API
-token as a secret named `XPKG_TOKEN`.
 {{</hint>}}

--- a/content/v1.19/software/install.md
+++ b/content/v1.19/software/install.md
@@ -133,7 +133,7 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `function.packages` | A list of Function packages to install. | `[]` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
-| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.upbound.io/crossplane/crossplane"` |
+| `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
 | `image.tag` | The Crossplane image tag. Defaults to the value of `appVersion` in `Chart.yaml`. | `""` |
 | `imagePullSecrets` | The imagePullSecret names to add to the Crossplane ServiceAccount. | `{}` |
 | `leaderElection` | Enable [leader election](https://docs.crossplane.io/latest/concepts/pods/#leader-election) for the Crossplane pod. | `true` |
@@ -267,9 +267,8 @@ args='{"--enable-composition-functions","--enable-composition-webhook-schema-val
 
 #### Change the default package registry
 
-Beginning with Crossplane version 1.15.0 Crossplane downloads packages from the
-[Upbound Marketplace](https://marketplace.upbound.io) at `xpkg.upbound.io`
-instead of DockerHub.
+Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
+installing packages. 
 
 Change the default registry location during the Crossplane install with
 `--set args='{"--registry=index.docker.io"}'`.
@@ -326,15 +325,3 @@ Community Crossplane distribution.
 The CNCF certified third-party distributions as
 "[conformant](https://github.com/cncf/crossplane-conformance)" with the
 Community Crossplane distribution.
-
-### Vendors
-Below are vendors providing conformant Crossplane distributions.
-
-#### Upbound
-Upbound, the founders of Crossplane, maintains a free and open source
-distribution of Crossplane called
-[Universal Crossplane](https://www.upbound.io/product/universal-crossplane)
-(`UXP`).
-
-Find information on UXP in the
-[Upbound UXP documentation](https://docs.upbound.io/uxp/install/).

--- a/content/v1.19/software/uninstall.md
+++ b/content/v1.19/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.19/software/uninstall.md
+++ b/content/v1.19/software/uninstall.md
@@ -135,13 +135,13 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v1.0.0    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.0.0    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.
 
 ```shell
-kubectl delete provider upbound-provider-aws
+kubectl delete provider crossplane-contrib-provider-aws
 ```
 
 ## Uninstall the Crossplane deployment 

--- a/content/v1.19/software/upgrade.md
+++ b/content/v1.19/software/upgrade.md
@@ -46,9 +46,9 @@ Crossplane.
 Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
-For example, in v1.15.0 Crossplane changed the default image registry from 
+For example, in v1.20.0 Crossplane changed the default image registry from 
 `index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
-before v1.15.0 updates the default package registry. 
+before v1.20.0 updates the default package registry. 
 
 Override new defaults by 
 [customizing the Helm chart]({{<ref "install#customize-the-crossplane-helm-chart" >}}) 

--- a/content/v1.19/software/upgrade.md
+++ b/content/v1.19/software/upgrade.md
@@ -47,7 +47,7 @@ Crossplane uses any new default behaviors unless they're changed in the `helm
 upgrade` command.
 
 For example, in v1.15.0 Crossplane changed the default image registry from 
-`index.docker.io` to `xpkg.upbound.io`. Upgrading Crossplane from a version
+`index.docker.io` to `xpkg.crossplane.io`. Upgrading Crossplane from a version
 before v1.15.0 updates the default package registry. 
 
 Override new defaults by 

--- a/utils/vale/styles/Crossplane/crossplane-words.txt
+++ b/utils/vale/styles/Crossplane/crossplane-words.txt
@@ -74,6 +74,7 @@ XCluster
 XNetwork
 xpkg
 xpkg.upbound.io
+xpkg.crossplane.io
 XR
 XR's
 XRC

--- a/utils/vale/styles/Crossplane/provider-words.txt
+++ b/utils/vale/styles/Crossplane/provider-words.txt
@@ -1,3 +1,4 @@
+crossplane-contrib
 Dataflow
 DynmoDB
 EC2
@@ -7,6 +8,9 @@ europe-central2
 GCP
 GCP's
 GKE
+provider-upjet-aws
+provider-upjet-gcp
+provider-upjet-azure
 provider-aws
 provider-aws-iam
 provider-aws-s3
@@ -18,3 +22,4 @@ S3
 us-central1
 us-east-2
 VPC
+xpkg.crossplane.io


### PR DESCRIPTION
This change does two things:

1. It updates all provider usage to refer to only providers published in upstream community in `crossplane-contrib`.
2. It removes terminology related to the Upbound Marketplace, since that's a vendor-backed property.

Both of these are done to align with the proposed policy changes in https://github.com/crossplane/crossplane/pull/6290