### PR TITLE
bump all community provider versions to latest

### DIFF
--- a/content/master/cli/command-reference.md
+++ b/content/master/cli/command-reference.md
@@ -322,10 +322,10 @@ inside Crossplane.
 
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
-For example, to install the latest version of the 
+For example, to install the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -493,10 +493,10 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-For example, to update to the latest version of the 
+For example, to update to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 
 ## beta
@@ -943,7 +943,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.21.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -379,10 +379,10 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1   12s
 ```
 
-To see more information on why the Provider isn't `HEALTHY` use 
+To see more information on why the Provider isn't `HEALTHY` use
 {{<hover label="depend" line="1">}}kubectl describe providerrevisions{{</hover>}}.
 
 ```yaml {copy-lines="1",label="depend"}
@@ -392,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
   Revision:                       1
 Status:
   Conditions:
@@ -430,13 +430,13 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1        Active                                 10d
 ```
 
-By default Crossplane keeps a single 
+By default Crossplane keeps a single
 {{<hover label="getPR" line="5">}}Inactive{{</hover>}} Provider.
 
 Read the [revision history limit](#package-revision-history-limit) section to
@@ -693,7 +693,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.12.1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/master/getting-started/provider-aws-part-2.md
+++ b/content/master/getting-started/provider-aws-part-2.md
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1
 EOF
 ```
 
@@ -105,10 +105,10 @@ View the new DynamoDB provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                               AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1     15m
+provider-aws-dynamodb                    True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1   22s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1         15m
 ```
 
 ## Create a custom API
@@ -358,8 +358,6 @@ spec:
           base:
             apiVersion: s3.aws.upbound.io/v1beta1
             kind: Bucket
-            metadata:
-              name: crossplane-quickstart-bucket
             spec:
               forProvider:
                 region: us-east-2
@@ -378,8 +376,6 @@ spec:
           base:
             apiVersion: dynamodb.aws.upbound.io/v1beta1
             kind: Table
-            metadata:
-              name: crossplane-quickstart-database
             spec:
               forProvider:
                 region: "us-east-2"

--- a/content/master/getting-started/provider-aws.md
+++ b/content/master/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -51,9 +51,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.20.1         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.20.1     88s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                             AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1   30s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1       34s
 ```
 
 The S3 Provider installs a second Provider, the

--- a/content/master/getting-started/provider-azure-part-2.md
+++ b/content/master/getting-started/provider-azure-part-2.md
@@ -45,7 +45,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2
 EOF
 ```
 
@@ -505,10 +505,10 @@ View the new Compute provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1     3h
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    23m
+provider-azure-compute                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2   2m54s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   23m
 ```
 
 ## Access the custom API

--- a/content/master/getting-started/provider-azure.md
+++ b/content/master/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
@@ -53,9 +53,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    2m18s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   2m23s
 ```
 
 The Network Provider installs a second Provider, the

--- a/content/master/getting-started/provider-gcp-part-2.md
+++ b/content/master/getting-started/provider-gcp-part-2.md
@@ -47,7 +47,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1
 EOF
 ```
 
@@ -122,10 +122,10 @@ View the new PubSub provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4.0.0     39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4.0.0    13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.11.4.0.0     12m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    48m
+provider-gcp-pubsub                      True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1    14s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   48m
 ```
 
 

--- a/content/master/getting-started/provider-gcp.md
+++ b/content/master/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
@@ -50,9 +50,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    33s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   37s
 ```
 
 The Storage Provider installs a second Provider, the

--- a/content/master/guides/troubleshoot-crossplane.md
+++ b/content/master/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane xpkg install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old

--- a/content/master/software/uninstall.md
+++ b/content/master/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.21.1     8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.17/cli/command-reference.md
+++ b/content/v1.17/cli/command-reference.md
@@ -325,7 +325,7 @@ The `<package-kind>` is either a `configuration`, `function` or `provider`.
 For example, to install to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -493,10 +493,10 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-For example, to update to the latest version of the 
+For example, to update to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 
 ## beta
@@ -943,7 +943,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.21.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.17/concepts/compositions.md
+++ b/content/v1.17/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip">}}

--- a/content/v1.17/concepts/providers.md
+++ b/content/v1.17/concepts/providers.md
@@ -324,10 +324,10 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1   12s
 ```
 
-To see more information on why the Provider isn't `HEALTHY` use 
+To see more information on why the Provider isn't `HEALTHY` use
 {{<hover label="depend" line="1">}}kubectl describe providerrevisions{{</hover>}}.
 
 ```yaml {copy-lines="1",label="depend"}
@@ -337,7 +337,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
   Revision:                       1
 Status:
   Conditions:
@@ -375,13 +375,13 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1        Active                                 10d
 ```
 
-By default Crossplane keeps a single 
+By default Crossplane keeps a single
 {{<hover label="getPR" line="5">}}Inactive{{</hover>}} Provider.
 
 Read the [revision history limit](#package-revision-history-limit) section to
@@ -638,7 +638,7 @@ kind: Provider
 metadata:
   name: provider-gcp-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-iam:v1.12.1
   runtimeConfigRef:
     name: enable-ess
 ---

--- a/content/v1.17/getting-started/provider-aws-part-2.md
+++ b/content/v1.17/getting-started/provider-aws-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-aws" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to AWS.
@@ -36,7 +36,7 @@ crossplane-stable/crossplane \
 ```
 
 2. When the Crossplane pods finish installing and are ready, apply the AWS Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -83,11 +83,11 @@ EOF
 
 ## Install the DynamoDB Provider
 
-Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket 
-along with a DynamoDB Table.  
-Deploying a DynamoDB Table requires the DynamoDB Provider as well. 
+Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket
+along with a DynamoDB Table.
+Deploying a DynamoDB Table requires the DynamoDB Provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1
 EOF
 ```
 
@@ -105,10 +105,10 @@ View the new DynamoDB provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                               AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1     15m
+provider-aws-dynamodb                    True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1   22s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1         15m
 ```
 
 ## Create a custom API
@@ -116,10 +116,10 @@ crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -127,39 +127,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -176,10 +176,10 @@ individual kinds representing different resources.
 
 For example a `database` group may have a `Relational` and `NoSQL` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}NoSQL{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -190,51 +190,51 @@ kind: NoSQL
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: database.example.com/v1alpha1
 kind: NoSQL
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -272,20 +272,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}nosql{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -307,20 +307,20 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy. Each entry in the template is a full resource
 definition, defining all the resource settings and metadata like labels and
-annotations. 
+annotations.
 
-This template creates an AWS 
+This template creates an AWS
 {{<hover label="comp" line="13">}}S3{{</hover>}}
-{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="33">}}DynamoDB{{</hover>}}
 {{<hover label="comp" line="34">}}Table{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -336,7 +336,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -358,8 +358,6 @@ spec:
           base:
             apiVersion: s3.aws.upbound.io/v1beta1
             kind: Bucket
-            metadata:
-              name: crossplane-quickstart-bucket
             spec:
               forProvider:
                 region: us-east-2
@@ -371,15 +369,13 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
         - name: dynamoDB
           base:
             apiVersion: dynamodb.aws.upbound.io/v1beta1
             kind: Table
-            metadata:
-              name: crossplane-quickstart-database
             spec:
               forProvider:
                 region: "us-east-2"
@@ -395,7 +391,7 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
   compositeTypeRef:
@@ -421,7 +417,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -429,8 +425,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -459,7 +455,7 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -472,10 +468,10 @@ NAME                SYNCED   READY   COMPOSITION          AGE
 my-nosql-database   True     True    dynamo-with-bucket   14s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -508,17 +504,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `nosql` happens at the cluster scope.  
+Accessing the API `nosql` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -533,7 +529,7 @@ kind: NoSQLClaim
 metadata:
   name: my-nosql-database
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -546,7 +542,7 @@ my-nosql-database   True     True                        17s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -595,9 +591,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.17/getting-started/provider-aws.md
+++ b/content/v1.17/getting-started/provider-aws.md
@@ -4,7 +4,7 @@ weight: 100
 ---
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
-with the 
+with  
 [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -51,9 +51,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.20.1         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.20.1     88s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                             AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1   30s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1       34s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/examples).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/tree/main/examples).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -197,16 +197,16 @@ spec:
 EOF
 ```
 
-The {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and 
-{{< hover label="xr" line="4">}}kind{{</hover >}} are from the provider's CRDs.
+The {{< hover label="xr" line="2">}}apiVersion{{< /hover >}} and 
+{{< hover label="xr" line="3">}}kind{{</hover >}} are from the provider's CRDs.
 
 
-The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the 
+The {{< hover label="xr" line="5">}}metadata.generateName{{< /hover >}} value is the 
 name of the created S3 bucket in AWS.  
 This example uses the generated name `crossplane-bucket-<hash>` in the 
-{{< hover label="xr" line="6">}}$bucket{{</hover >}} variable.
+{{< hover label="xr" line="5">}}$bucket{{</hover >}} variable.
 
-The {{< hover label="xr" line="9">}}spec.forProvider.region{{< /hover >}} tells 
+The {{< hover label="xr" line="8">}}spec.forProvider.region{{< /hover >}} tells 
 AWS which AWS region to use when deploying resources.  
 
 The region can be any 

--- a/content/v1.17/getting-started/provider-azure-part-2.md
+++ b/content/v1.17/getting-started/provider-azure-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-azure" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to Azure.
@@ -35,9 +35,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the Azure 
+2. When the Crossplane pods finish installing and are ready, apply the Azure
    Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -45,11 +45,11 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
-3. Use the Azure CLI to create a service principal and save the JSON output as 
+3. Use the Azure CLI to create a service principal and save the JSON output as
    `azure-crednetials.json`
 {{< editCode >}}
 ```console
@@ -91,10 +91,10 @@ EOF
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -102,39 +102,39 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}compute.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -151,10 +151,10 @@ individual kinds representing different resources.
 
 For example a `compute` group may have a `VirtualMachine` and `BareMetal` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}VirtualMachine{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -165,51 +165,51 @@ kind: VirtualMachine
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -247,20 +247,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}VirtualMachine{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -282,22 +282,22 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates an Azure
 {{<hover label="comp" line="11">}}LinuxVirtualMachine{{</hover>}}
-{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}}, 
+{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}},
 {{<hover label="comp" line="69">}}Subnet{{</hover>}}
 {{<hover label="comp" line="90">}}VirtualNetwork{{</hover>}} and
 {{<hover label="comp" line="110">}}ResourceGroup{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -313,7 +313,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -363,7 +363,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: quickstart-nic
@@ -386,9 +386,9 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
-                    US: "Central US"            
+                    US: "Central US"
         - name: quickstart-subnet
           base:
             apiVersion: network.azure.upbound.io/v1beta1
@@ -418,7 +418,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: crossplane-resourcegroup
@@ -434,7 +434,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
   compositeTypeRef:
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -468,8 +468,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -485,9 +485,9 @@ crossplane-quickstart-vm-with-network   XVirtualMachine   custom-api.example.org
 ## Install the Azure virtual machine provider
 
 Part 1 only installed the Azure Virtual Network Provider. To deploying virtual
-machines requires the Azure Compute provider as well. 
+machines requires the Azure Compute provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2
 EOF
 ```
 
@@ -505,10 +505,10 @@ View the new Compute provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    3h
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    23m
+provider-azure-compute                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2   2m54s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   23m
 ```
 
 ## Access the custom API
@@ -516,7 +516,7 @@ crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane
 With the custom API (XRD) installed and associated to a resource template
 (Composition) users can access the API to create resources.
 
-Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to 
+Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to
 create the cloud resources.
 
 ```yaml {copy-lines="all",label="xr"}
@@ -525,7 +525,7 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -542,10 +542,10 @@ NAME    SYNCED   READY   COMPOSITION                             AGE
 my-vm   True     True    crossplane-quickstart-vm-with-network   3m3s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -568,7 +568,7 @@ virtualnetwork.network.azure.upbound.io/my-vm-pd2sw   True    True     my-vm-pd2
 ```
 
 Accessing the API created all five resources defined in the template and linked
-them together. 
+them together.
 
 Look at a specific resource to see it's created in the location used in the API.
 
@@ -598,17 +598,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `VirtualMachine` happens at the cluster scope.  
+Accessing the API `VirtualMachine` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -623,7 +623,7 @@ kind: VirtualMachineClaim
 metadata:
   name: my-namespaced-vm
   namespace: crossplane-test
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -636,7 +636,7 @@ my-namespaced-vm   True     True                        5m11s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -693,9 +693,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore Azure resources that Crossplane can configure in the 
+* Explore Azure resources that Crossplane can configure in the
   [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out
-  what else you can do with Crossplane. 
+  what else you can do with Crossplane.

--- a/content/v1.17/getting-started/provider-azure.md
+++ b/content/v1.17/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
@@ -53,9 +53,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    2m18s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   2m23s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider CRDs reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.17/getting-started/provider-gcp-part-2.md
+++ b/content/v1.17/getting-started/provider-gcp-part-2.md
@@ -7,20 +7,20 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-gcp" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to GCP.
 
 {{< /hint >}}
 
-This guide walks you through building and accessing a custom API with 
+This guide walks you through building and accessing a custom API with
 Crossplane.
 
 ## Prerequisites
 * Complete [quickstart part 1]({{<ref "provider-gcp" >}}) connecting Kubernetes
   to GCP.
-* a GCP account with permissions to create a GCP 
+* a GCP account with permissions to create a GCP
   [storage bucket](https://cloud.google.com/storage) and a
   [Pub/Sub topic](https://cloud.google.com/pubsub).
 
@@ -37,9 +37,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the GCP 
+2. When the Crossplane pods finish installing and are ready, apply the GCP
 Provider.
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -47,16 +47,16 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
-3. Create a file called `gcp-credentials.json` with your GCP service account 
+3. Create a file called `gcp-credentials.json` with your GCP service account
 JSON file.
 
 {{< hint "tip" >}}
-The 
-[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
+The
+[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 provides information on how to generate a service account JSON file.
 {{< /hint >}}
 
@@ -69,12 +69,12 @@ generic gcp-secret \
 ```
 
 5. Create a _ProviderConfig_
-Include your 
+Include your
 {{< hover label="providerconfig" line="7" >}}GCP project ID{{< /hover >}} in the
 _ProviderConfig_ settings.
 
 {{< hint type="tip" >}}
-Find your GCP project ID from the `project_id` field of the 
+Find your GCP project ID from the `project_id` field of the
 `gcp-credentials.json` file.
 {{< /hint >}}
 
@@ -101,11 +101,11 @@ EOF
 
 ## Install the PubSub Provider
 
-Part 1 only installed the GCP Storage Provider. This section deploys a 
-PubSub Topic along with a GCP storage bucket.  
+Part 1 only installed the GCP Storage Provider. This section deploys a
+PubSub Topic along with a GCP storage bucket.
 First install the GCP PubSub Provider.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1
 EOF
 ```
 
@@ -122,10 +122,10 @@ View the new PubSub provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4.0.0    39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    12m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    48m
+provider-gcp-pubsub                      True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1    14s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   48m
 ```
 
 
@@ -134,10 +134,10 @@ crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -145,39 +145,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -194,10 +194,10 @@ individual kinds representing different resources.
 
 For example a `queue` group may have a `PubSub` and `CloudTask` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}PubSub{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -208,51 +208,51 @@ kind: PubSub
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: queue.example.com/v1alpha1
 kind: PubSub
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -290,20 +290,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}pubsub{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -325,21 +325,21 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates a GCP
 {{<hover label="comp" line="10">}}Storage{{</hover>}}
-{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="25">}}PubSub{{</hover>}}
 {{<hover label="comp" line="26">}}Topic{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -355,7 +355,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -385,7 +385,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "EU"
                     US: "US"
         - name: crossplane-quickstart-topic
@@ -395,14 +395,14 @@ spec:
             spec:
               forProvider:
                 messageStoragePolicy:
-                  - allowedPersistenceRegions: 
+                  - allowedPersistenceRegions:
                     - "us-central1"
           patches:
             - fromFieldPath: "spec.location"
               toFieldPath: "spec.forProvider.messageStoragePolicy[0].allowedPersistenceRegions[0]"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "europe-central2"
                     US: "us-central1"
   compositeTypeRef:
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -436,8 +436,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -464,7 +464,7 @@ apiVersion: queue.example.com/v1alpha1
 kind: PubSub
 metadata:
   name: my-pubsub-queue
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -477,10 +477,10 @@ NAME              SYNCED   READY   COMPOSITION         AGE
 my-pubsub-queue   True     True    topic-with-bucket   2m12s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -513,17 +513,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `pubsub` happens at the cluster scope.  
+Accessing the API `pubsub` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -535,10 +535,10 @@ Then create a Claim in the `crossplane-test` namespace.
 cat <<EOF | kubectl apply -f -
 apiVersion: queue.example.com/v1alpha1
 kind: PubSubClaim
-metadata:  
+metadata:
   name: my-pubsub-queue
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -551,7 +551,7 @@ my-pubsub-queue   True     True                        2m10s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -600,9 +600,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.17/getting-started/provider-gcp.md
+++ b/content/v1.17/getting-started/provider-gcp.md
@@ -4,7 +4,7 @@ weight: 140
 ---
 
 Connect Crossplane to GCP to create and manage cloud resources from Kubernetes 
-with the 
+with  
 [provider-upjet-gcp](https://github.com/crossplane-contrib/provider-upjet-gcp).
 
 This guide is in two parts:
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
@@ -50,9 +50,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    33s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   37s
 ```
 
 The Storage Provider installs a second Provider, the
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[provider CRDs reference](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.17/guides/function-patch-and-transform.md
+++ b/content/v1.17/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip" >}}

--- a/content/v1.17/guides/troubleshoot-crossplane.md
+++ b/content/v1.17/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane xpkg install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old

--- a/content/v1.17/software/uninstall.md
+++ b/content/v1.17/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.21.1   8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.18/cli/command-reference.md
+++ b/content/v1.18/cli/command-reference.md
@@ -325,7 +325,7 @@ The `<package-kind>` is either a `configuration`, `function` or `provider`.
 For example, to install to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -493,10 +493,10 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-For example, to update to the latest version of the 
+For example, to update to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 
 ## beta
@@ -943,7 +943,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.21.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.18/concepts/compositions.md
+++ b/content/v1.18/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip">}}

--- a/content/v1.18/concepts/providers.md
+++ b/content/v1.18/concepts/providers.md
@@ -338,10 +338,10 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1   12s
 ```
 
-To see more information on why the Provider isn't `HEALTHY` use 
+To see more information on why the Provider isn't `HEALTHY` use
 {{<hover label="depend" line="1">}}kubectl describe providerrevisions{{</hover>}}.
 
 ```yaml {copy-lines="1",label="depend"}
@@ -351,7 +351,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
   Revision:                       1
 Status:
   Conditions:
@@ -389,13 +389,13 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1        Active                                 10d
 ```
 
-By default Crossplane keeps a single 
+By default Crossplane keeps a single
 {{<hover label="getPR" line="5">}}Inactive{{</hover>}} Provider.
 
 Read the [revision history limit](#package-revision-history-limit) section to

--- a/content/v1.18/getting-started/provider-aws-part-2.md
+++ b/content/v1.18/getting-started/provider-aws-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-aws" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to AWS.
@@ -36,7 +36,7 @@ crossplane-stable/crossplane \
 ```
 
 2. When the Crossplane pods finish installing and are ready, apply the AWS Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -83,11 +83,11 @@ EOF
 
 ## Install the DynamoDB Provider
 
-Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket 
-along with a DynamoDB Table.  
-Deploying a DynamoDB Table requires the DynamoDB Provider as well. 
+Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket
+along with a DynamoDB Table.
+Deploying a DynamoDB Table requires the DynamoDB Provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1
 EOF
 ```
 
@@ -105,10 +105,10 @@ View the new DynamoDB provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                               AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1     15m
+provider-aws-dynamodb                    True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1   22s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1         15m
 ```
 
 ## Create a custom API
@@ -116,10 +116,10 @@ crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -127,39 +127,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -176,10 +176,10 @@ individual kinds representing different resources.
 
 For example a `database` group may have a `Relational` and `NoSQL` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}NoSQL{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -190,51 +190,51 @@ kind: NoSQL
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: database.example.com/v1alpha1
 kind: NoSQL
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -272,20 +272,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}nosql{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -307,20 +307,20 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy. Each entry in the template is a full resource
 definition, defining all the resource settings and metadata like labels and
-annotations. 
+annotations.
 
-This template creates an AWS 
+This template creates an AWS
 {{<hover label="comp" line="13">}}S3{{</hover>}}
-{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="33">}}DynamoDB{{</hover>}}
 {{<hover label="comp" line="34">}}Table{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -336,7 +336,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -358,8 +358,6 @@ spec:
           base:
             apiVersion: s3.aws.upbound.io/v1beta1
             kind: Bucket
-            metadata:
-              name: crossplane-quickstart-bucket
             spec:
               forProvider:
                 region: us-east-2
@@ -371,15 +369,13 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
         - name: dynamoDB
           base:
             apiVersion: dynamodb.aws.upbound.io/v1beta1
             kind: Table
-            metadata:
-              name: crossplane-quickstart-database
             spec:
               forProvider:
                 region: "us-east-2"
@@ -395,7 +391,7 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
   compositeTypeRef:
@@ -421,7 +417,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -429,8 +425,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -459,7 +455,7 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -472,10 +468,10 @@ NAME                SYNCED   READY   COMPOSITION          AGE
 my-nosql-database   True     True    dynamo-with-bucket   14s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -508,17 +504,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `nosql` happens at the cluster scope.  
+Accessing the API `nosql` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -533,7 +529,7 @@ kind: NoSQLClaim
 metadata:
   name: my-nosql-database
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -546,7 +542,7 @@ my-nosql-database   True     True                        17s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -595,9 +591,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.18/getting-started/provider-aws.md
+++ b/content/v1.18/getting-started/provider-aws.md
@@ -4,7 +4,7 @@ weight: 100
 ---
 
 Connect Crossplane to AWS to create and manage cloud resources from Kubernetes 
-with 
+with  
 [provider-upjet-aws](https://github.com/crossplane-contrib/provider-upjet-aws).
 
 This guide is in two parts:
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -51,9 +51,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                             AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1   30s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1       34s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/tree/main/examples).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -197,16 +197,16 @@ spec:
 EOF
 ```
 
-The {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and 
-{{< hover label="xr" line="4">}}kind{{</hover >}} are from the provider's CRDs.
+The {{< hover label="xr" line="2">}}apiVersion{{< /hover >}} and 
+{{< hover label="xr" line="3">}}kind{{</hover >}} are from the provider's CRDs.
 
 
-The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the 
+The {{< hover label="xr" line="5">}}metadata.generateName{{< /hover >}} value is the 
 name of the created S3 bucket in AWS.  
 This example uses the generated name `crossplane-bucket-<hash>` in the 
-{{< hover label="xr" line="6">}}$bucket{{</hover >}} variable.
+{{< hover label="xr" line="5">}}$bucket{{</hover >}} variable.
 
-The {{< hover label="xr" line="9">}}spec.forProvider.region{{< /hover >}} tells 
+The {{< hover label="xr" line="8">}}spec.forProvider.region{{< /hover >}} tells 
 AWS which AWS region to use when deploying resources.  
 
 The region can be any 

--- a/content/v1.18/getting-started/provider-azure-part-2.md
+++ b/content/v1.18/getting-started/provider-azure-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-azure" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to Azure.
@@ -35,9 +35,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the Azure 
+2. When the Crossplane pods finish installing and are ready, apply the Azure
    Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -45,11 +45,11 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
-3. Use the Azure CLI to create a service principal and save the JSON output as 
+3. Use the Azure CLI to create a service principal and save the JSON output as
    `azure-crednetials.json`
 {{< editCode >}}
 ```console
@@ -91,10 +91,10 @@ EOF
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -102,39 +102,39 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}compute.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -151,10 +151,10 @@ individual kinds representing different resources.
 
 For example a `compute` group may have a `VirtualMachine` and `BareMetal` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}VirtualMachine{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -165,51 +165,51 @@ kind: VirtualMachine
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -247,20 +247,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}VirtualMachine{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -282,22 +282,22 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates an Azure
 {{<hover label="comp" line="11">}}LinuxVirtualMachine{{</hover>}}
-{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}}, 
+{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}},
 {{<hover label="comp" line="69">}}Subnet{{</hover>}}
 {{<hover label="comp" line="90">}}VirtualNetwork{{</hover>}} and
 {{<hover label="comp" line="110">}}ResourceGroup{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -313,7 +313,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -363,7 +363,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: quickstart-nic
@@ -386,9 +386,9 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
-                    US: "Central US"            
+                    US: "Central US"
         - name: quickstart-subnet
           base:
             apiVersion: network.azure.upbound.io/v1beta1
@@ -418,7 +418,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: crossplane-resourcegroup
@@ -434,7 +434,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
   compositeTypeRef:
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -468,8 +468,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -485,9 +485,9 @@ crossplane-quickstart-vm-with-network   XVirtualMachine   custom-api.example.org
 ## Install the Azure virtual machine provider
 
 Part 1 only installed the Azure Virtual Network Provider. To deploying virtual
-machines requires the Azure Compute provider as well. 
+machines requires the Azure Compute provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2
 EOF
 ```
 
@@ -505,10 +505,10 @@ View the new Compute provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    3h
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    23m
+provider-azure-compute                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2   2m54s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   23m
 ```
 
 ## Access the custom API
@@ -516,7 +516,7 @@ crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane
 With the custom API (XRD) installed and associated to a resource template
 (Composition) users can access the API to create resources.
 
-Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to 
+Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to
 create the cloud resources.
 
 ```yaml {copy-lines="all",label="xr"}
@@ -525,7 +525,7 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -542,10 +542,10 @@ NAME    SYNCED   READY   COMPOSITION                             AGE
 my-vm   True     True    crossplane-quickstart-vm-with-network   3m3s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -568,7 +568,7 @@ virtualnetwork.network.azure.upbound.io/my-vm-pd2sw   True    True     my-vm-pd2
 ```
 
 Accessing the API created all five resources defined in the template and linked
-them together. 
+them together.
 
 Look at a specific resource to see it's created in the location used in the API.
 
@@ -598,17 +598,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `VirtualMachine` happens at the cluster scope.  
+Accessing the API `VirtualMachine` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -623,7 +623,7 @@ kind: VirtualMachineClaim
 metadata:
   name: my-namespaced-vm
   namespace: crossplane-test
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -636,7 +636,7 @@ my-namespaced-vm   True     True                        5m11s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -693,9 +693,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore Azure resources that Crossplane can configure in the 
+* Explore Azure resources that Crossplane can configure in the
   [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out
-  what else you can do with Crossplane. 
+  what else you can do with Crossplane.

--- a/content/v1.18/getting-started/provider-azure.md
+++ b/content/v1.18/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
@@ -53,9 +53,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    2m18s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   2m23s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.18/getting-started/provider-gcp-part-2.md
+++ b/content/v1.18/getting-started/provider-gcp-part-2.md
@@ -7,20 +7,20 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-gcp" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to GCP.
 
 {{< /hint >}}
 
-This guide walks you through building and accessing a custom API with 
+This guide walks you through building and accessing a custom API with
 Crossplane.
 
 ## Prerequisites
 * Complete [quickstart part 1]({{<ref "provider-gcp" >}}) connecting Kubernetes
   to GCP.
-* a GCP account with permissions to create a GCP 
+* a GCP account with permissions to create a GCP
   [storage bucket](https://cloud.google.com/storage) and a
   [Pub/Sub topic](https://cloud.google.com/pubsub).
 
@@ -37,9 +37,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the GCP 
+2. When the Crossplane pods finish installing and are ready, apply the GCP
 Provider.
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -47,16 +47,16 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
-3. Create a file called `gcp-credentials.json` with your GCP service account 
+3. Create a file called `gcp-credentials.json` with your GCP service account
 JSON file.
 
 {{< hint "tip" >}}
-The 
-[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
+The
+[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 provides information on how to generate a service account JSON file.
 {{< /hint >}}
 
@@ -69,12 +69,12 @@ generic gcp-secret \
 ```
 
 5. Create a _ProviderConfig_
-Include your 
+Include your
 {{< hover label="providerconfig" line="7" >}}GCP project ID{{< /hover >}} in the
 _ProviderConfig_ settings.
 
 {{< hint type="tip" >}}
-Find your GCP project ID from the `project_id` field of the 
+Find your GCP project ID from the `project_id` field of the
 `gcp-credentials.json` file.
 {{< /hint >}}
 
@@ -101,11 +101,11 @@ EOF
 
 ## Install the PubSub Provider
 
-Part 1 only installed the GCP Storage Provider. This section deploys a 
-PubSub Topic along with a GCP storage bucket.  
+Part 1 only installed the GCP Storage Provider. This section deploys a
+PubSub Topic along with a GCP storage bucket.
 First install the GCP PubSub Provider.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1
 EOF
 ```
 
@@ -122,10 +122,10 @@ View the new PubSub provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4    39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    12m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    48m
+provider-gcp-pubsub                      True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1    14s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   48m
 ```
 
 
@@ -134,10 +134,10 @@ crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -145,39 +145,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -194,10 +194,10 @@ individual kinds representing different resources.
 
 For example a `queue` group may have a `PubSub` and `CloudTask` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}PubSub{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -208,51 +208,51 @@ kind: PubSub
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: queue.example.com/v1alpha1
 kind: PubSub
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -290,20 +290,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}pubsub{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -325,21 +325,21 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates a GCP
 {{<hover label="comp" line="10">}}Storage{{</hover>}}
-{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="25">}}PubSub{{</hover>}}
 {{<hover label="comp" line="26">}}Topic{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -355,7 +355,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -385,7 +385,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "EU"
                     US: "US"
         - name: crossplane-quickstart-topic
@@ -395,14 +395,14 @@ spec:
             spec:
               forProvider:
                 messageStoragePolicy:
-                  - allowedPersistenceRegions: 
+                  - allowedPersistenceRegions:
                     - "us-central1"
           patches:
             - fromFieldPath: "spec.location"
               toFieldPath: "spec.forProvider.messageStoragePolicy[0].allowedPersistenceRegions[0]"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "europe-central2"
                     US: "us-central1"
   compositeTypeRef:
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -436,8 +436,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -464,7 +464,7 @@ apiVersion: queue.example.com/v1alpha1
 kind: PubSub
 metadata:
   name: my-pubsub-queue
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -477,10 +477,10 @@ NAME              SYNCED   READY   COMPOSITION         AGE
 my-pubsub-queue   True     True    topic-with-bucket   2m12s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -513,17 +513,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `pubsub` happens at the cluster scope.  
+Accessing the API `pubsub` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -535,10 +535,10 @@ Then create a Claim in the `crossplane-test` namespace.
 cat <<EOF | kubectl apply -f -
 apiVersion: queue.example.com/v1alpha1
 kind: PubSubClaim
-metadata:  
+metadata:
   name: my-pubsub-queue
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -551,7 +551,7 @@ my-pubsub-queue   True     True                        2m10s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -600,9 +600,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.18/getting-started/provider-gcp.md
+++ b/content/v1.18/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
@@ -50,9 +50,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    33s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   37s
 ```
 
 The Storage Provider installs a second Provider, the
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.18/guides/function-patch-and-transform.md
+++ b/content/v1.18/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip" >}}

--- a/content/v1.18/guides/troubleshoot-crossplane.md
+++ b/content/v1.18/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane xpkg install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old

--- a/content/v1.18/software/uninstall.md
+++ b/content/v1.18/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1   8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.21.1    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.

--- a/content/v1.19/cli/command-reference.md
+++ b/content/v1.19/cli/command-reference.md
@@ -322,10 +322,10 @@ inside Crossplane.
 
 The `<package-kind>` is either a `configuration`, `function` or `provider`.
 
-For example, to install the latest version of the 
+For example, to install the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg install provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 #### Flags
 {{< table "table table-sm table-striped">}}
@@ -493,10 +493,10 @@ already installed in Crossplane.
 
 `crossplane xpkg update <package-kind> <registry package name and tag> [<optional-name>]`
 
-For example, to update to the latest version of the 
+For example, to update to the latest version of the
 [AWS S3 provider](https://github.com/crossplane-contrib/provider-upjet-aws):
 
-`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`
+`crossplane xpkg update provider xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`
 
 
 ## beta
@@ -943,7 +943,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-iam:v1.21.1
 ```
 
 Now include the XR or managed resource to validate.

--- a/content/v1.19/concepts/compositions.md
+++ b/content/v1.19/concepts/compositions.md
@@ -134,7 +134,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{< hint "tip" >}}
@@ -155,7 +155,7 @@ During the install a Function reports `INSTALLED` as `True` and `HEALTHY` as
 ```shell {copy-lines="1"}
 kubectl get functions
 NAME                              INSTALLED   HEALTHY   PACKAGE                                                                  AGE
-function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4   10s
+function-patch-and-transform      True        Unknown   xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2   10s
 ```
 
 After the Function install completes and it's ready for use the `HEALTHY` status
@@ -545,7 +545,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 {{</expand>}}
 
@@ -576,7 +576,7 @@ metadata:
   annotations:
     render.crossplane.io/runtime: Development
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip">}}

--- a/content/v1.19/concepts/providers.md
+++ b/content/v1.19/concepts/providers.md
@@ -379,10 +379,10 @@ For example, this installation of the Getting Started Configuration is
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME              INSTALLED   HEALTHY   PACKAGE                                           AGE
-provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1   12s
+provider-aws-s3   True        False     xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1   12s
 ```
 
-To see more information on why the Provider isn't `HEALTHY` use 
+To see more information on why the Provider isn't `HEALTHY` use
 {{<hover label="depend" line="1">}}kubectl describe providerrevisions{{</hover>}}.
 
 ```yaml {copy-lines="1",label="depend"}
@@ -392,7 +392,7 @@ API Version:  pkg.crossplane.io/v1
 Kind:         ProviderRevision
 Spec:
   Desired State:                  Active
-  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  Image:                          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
   Revision:                       1
 Status:
   Conditions:
@@ -430,13 +430,13 @@ View the `ProviderRevisions` with
 ```shell {label="getPR",copy-lines="1"}
 kubectl get providerrevisions
 NAME                                       HEALTHY   REVISION   IMAGE                                                    STATE      DEP-FOUND   DEP-INSTALLED   AGE
-provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           Active     1           1               10d
+provider-aws-s3-dbc7f981d81f               True      1          xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1           Active     1           1               10d
 provider-nop-552a394a8acc                  True      2          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.3.0   Active                                 11d
 provider-nop-7e62d2a1a709                  True      1          xpkg.crossplane.io/crossplane-contrib/provider-nop:v0.2.0   Inactive                               13d
-crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       Active                                 10d
+crossplane-contrib-provider-family-aws-710d8cfe9f53   True      1          xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1        Active                                 10d
 ```
 
-By default Crossplane keeps a single 
+By default Crossplane keeps a single
 {{<hover label="getPR" line="5">}}Inactive{{</hover>}} Provider.
 
 Read the [revision history limit](#package-revision-history-limit) section to

--- a/content/v1.19/getting-started/provider-aws-part-2.md
+++ b/content/v1.19/getting-started/provider-aws-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-aws" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to AWS.
@@ -36,7 +36,7 @@ crossplane-stable/crossplane \
 ```
 
 2. When the Crossplane pods finish installing and are ready, apply the AWS Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -44,7 +44,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -83,11 +83,11 @@ EOF
 
 ## Install the DynamoDB Provider
 
-Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket 
-along with a DynamoDB Table.  
-Deploying a DynamoDB Table requires the DynamoDB Provider as well. 
+Part 1 only installed the AWS S3 Provider. This section deploys an S3 bucket
+along with a DynamoDB Table.
+Deploying a DynamoDB Table requires the DynamoDB Provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -96,7 +96,7 @@ kind: Provider
 metadata:
   name: provider-aws-dynamodb
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1
 EOF
 ```
 
@@ -105,10 +105,10 @@ View the new DynamoDB provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                 AGE
-provider-aws-dynamodb         True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.20.1     3m55s
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1           13m
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.20.1       13m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                               AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1     15m
+provider-aws-dynamodb                    True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-dynamodb:v1.21.1   22s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1         15m
 ```
 
 ## Create a custom API
@@ -116,10 +116,10 @@ crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -127,39 +127,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -176,10 +176,10 @@ individual kinds representing different resources.
 
 For example a `database` group may have a `Relational` and `NoSQL` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}NoSQL{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -190,51 +190,51 @@ kind: NoSQL
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: database.example.com/v1alpha1
 kind: NoSQL
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -272,20 +272,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}nosql{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}nosqlclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -307,20 +307,20 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy. Each entry in the template is a full resource
 definition, defining all the resource settings and metadata like labels and
-annotations. 
+annotations.
 
-This template creates an AWS 
+This template creates an AWS
 {{<hover label="comp" line="13">}}S3{{</hover>}}
-{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="14">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="33">}}DynamoDB{{</hover>}}
 {{<hover label="comp" line="34">}}Table{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="21">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="16">}}region{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -336,7 +336,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -358,8 +358,6 @@ spec:
           base:
             apiVersion: s3.aws.upbound.io/v1beta1
             kind: Bucket
-            metadata:
-              name: crossplane-quickstart-bucket
             spec:
               forProvider:
                 region: us-east-2
@@ -371,15 +369,13 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
         - name: dynamoDB
           base:
             apiVersion: dynamodb.aws.upbound.io/v1beta1
             kind: Table
-            metadata:
-              name: crossplane-quickstart-database
             spec:
               forProvider:
                 region: "us-east-2"
@@ -395,7 +391,7 @@ spec:
               toFieldPath: "spec.forProvider.region"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "eu-north-1"
                     US: "us-east-2"
   compositeTypeRef:
@@ -421,7 +417,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -429,8 +425,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -459,7 +455,7 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -472,10 +468,10 @@ NAME                SYNCED   READY   COMPOSITION          AGE
 my-nosql-database   True     True    dynamo-with-bucket   14s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -508,17 +504,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `nosql` happens at the cluster scope.  
+Accessing the API `nosql` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -533,7 +529,7 @@ kind: NoSQLClaim
 metadata:
   name: my-nosql-database
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -546,7 +542,7 @@ my-nosql-database   True     True                        17s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -595,9 +591,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.19/getting-started/provider-aws.md
+++ b/content/v1.19/getting-started/provider-aws.md
@@ -37,7 +37,7 @@ kind: Provider
 metadata:
   name: provider-aws-s3
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1
 EOF
 ```
 
@@ -51,9 +51,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                               AGE
-provider-aws-s3               True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:1.0.0         97s
-crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:1.0.0     88s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                             AGE
+crossplane-contrib-provider-family-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-aws:v1.21.1   30s
+provider-aws-s3                          True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1       34s
 ```
 
 The S3 Provider installs a second Provider, the
@@ -67,7 +67,7 @@ Every CRD maps to a unique AWS service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-aws/tree/main/examples).
 {{< /hint >}}
 
 ## Create a Kubernetes secret for AWS
@@ -197,16 +197,16 @@ spec:
 EOF
 ```
 
-The {{< hover label="xr" line="3">}}apiVersion{{< /hover >}} and 
-{{< hover label="xr" line="4">}}kind{{</hover >}} are from the provider's CRDs.
+The {{< hover label="xr" line="2">}}apiVersion{{< /hover >}} and 
+{{< hover label="xr" line="3">}}kind{{</hover >}} are from the provider's CRDs.
 
 
-The {{< hover label="xr" line="6">}}metadata.name{{< /hover >}} value is the 
+The {{< hover label="xr" line="5">}}metadata.generateName{{< /hover >}} value is the 
 name of the created S3 bucket in AWS.  
 This example uses the generated name `crossplane-bucket-<hash>` in the 
-{{< hover label="xr" line="6">}}$bucket{{</hover >}} variable.
+{{< hover label="xr" line="5">}}$bucket{{</hover >}} variable.
 
-The {{< hover label="xr" line="9">}}spec.forProvider.region{{< /hover >}} tells 
+The {{< hover label="xr" line="8">}}spec.forProvider.region{{< /hover >}} tells 
 AWS which AWS region to use when deploying resources.  
 
 The region can be any 

--- a/content/v1.19/getting-started/provider-azure-part-2.md
+++ b/content/v1.19/getting-started/provider-azure-part-2.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-azure" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to Azure.
@@ -35,9 +35,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the Azure 
+2. When the Crossplane pods finish installing and are ready, apply the Azure
    Provider
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -45,11 +45,11 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
-3. Use the Azure CLI to create a service principal and save the JSON output as 
+3. Use the Azure CLI to create a service principal and save the JSON output as
    `azure-crednetials.json`
 {{< editCode >}}
 ```console
@@ -91,10 +91,10 @@ EOF
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -102,39 +102,39 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}compute.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -151,10 +151,10 @@ individual kinds representing different resources.
 
 For example a `compute` group may have a `VirtualMachine` and `BareMetal` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}VirtualMachine{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -165,51 +165,51 @@ kind: VirtualMachine
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="10">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -247,20 +247,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}VirtualMachine{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="30">}}VirtualMachineClaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -282,22 +282,22 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates an Azure
 {{<hover label="comp" line="11">}}LinuxVirtualMachine{{</hover>}}
-{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}}, 
+{{<hover label="comp" line="46">}}NetworkInterface{{</hover>}},
 {{<hover label="comp" line="69">}}Subnet{{</hover>}}
 {{<hover label="comp" line="90">}}VirtualNetwork{{</hover>}} and
 {{<hover label="comp" line="110">}}ResourceGroup{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="36">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="37">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -313,7 +313,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -363,7 +363,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: quickstart-nic
@@ -386,9 +386,9 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
-                    US: "Central US"            
+                    US: "Central US"
         - name: quickstart-subnet
           base:
             apiVersion: network.azure.upbound.io/v1beta1
@@ -418,7 +418,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
         - name: crossplane-resourcegroup
@@ -434,7 +434,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "Sweden Central"
                     US: "Central US"
   compositeTypeRef:
@@ -460,7 +460,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -468,8 +468,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -485,9 +485,9 @@ crossplane-quickstart-vm-with-network   XVirtualMachine   custom-api.example.org
 ## Install the Azure virtual machine provider
 
 Part 1 only installed the Azure Virtual Network Provider. To deploying virtual
-machines requires the Azure Compute provider as well. 
+machines requires the Azure Compute provider as well.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -496,7 +496,7 @@ kind: Provider
 metadata:
   name: provider-azure-compute
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.20.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2
 EOF
 ```
 
@@ -505,10 +505,10 @@ View the new Compute provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-compute          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    25s
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1    3h
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1     3h
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    23m
+provider-azure-compute                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-compute:v1.11.2   2m54s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   23m
 ```
 
 ## Access the custom API
@@ -516,7 +516,7 @@ crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane
 With the custom API (XRD) installed and associated to a resource template
 (Composition) users can access the API to create resources.
 
-Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to 
+Create a {{<hover label="xr" line="3">}}VirtualMachine{{</hover>}} object to
 create the cloud resources.
 
 ```yaml {copy-lines="all",label="xr"}
@@ -525,7 +525,7 @@ apiVersion: compute.example.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: my-vm
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -542,10 +542,10 @@ NAME    SYNCED   READY   COMPOSITION                             AGE
 my-vm   True     True    crossplane-quickstart-vm-with-network   3m3s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -568,7 +568,7 @@ virtualnetwork.network.azure.upbound.io/my-vm-pd2sw   True    True     my-vm-pd2
 ```
 
 Accessing the API created all five resources defined in the template and linked
-them together. 
+them together.
 
 Look at a specific resource to see it's created in the location used in the API.
 
@@ -598,17 +598,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `VirtualMachine` happens at the cluster scope.  
+Accessing the API `VirtualMachine` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -623,7 +623,7 @@ kind: VirtualMachineClaim
 metadata:
   name: my-namespaced-vm
   namespace: crossplane-test
-spec: 
+spec:
   location: "EU"
 EOF
 ```
@@ -636,7 +636,7 @@ my-namespaced-vm   True     True                        5m11s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -693,9 +693,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore Azure resources that Crossplane can configure in the 
+* Explore Azure resources that Crossplane can configure in the
   [Provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out
-  what else you can do with Crossplane. 
+  what else you can do with Crossplane.

--- a/content/v1.19/getting-started/provider-azure.md
+++ b/content/v1.19/getting-started/provider-azure.md
@@ -39,7 +39,7 @@ kind: Provider
 metadata:
   name: provider-azure-network
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2
 EOF
 ```
 
@@ -53,9 +53,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                            INSTALLED   HEALTHY   PACKAGE                                                  AGE
-provider-azure-network          True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-v1.11.1   38s
-crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.1    26s
+NAME                                       INSTALLED   HEALTHY   PACKAGE                                                                AGE
+crossplane-contrib-provider-family-azure   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v1.11.2    2m18s
+provider-azure-network                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-azure-network:v1.11.2   2m23s
 ```
 
 The Network Provider installs a second Provider, the
@@ -69,7 +69,7 @@ Every CRD maps to a unique Azure service Crossplane can provision and manage.
 
 {{< hint type="tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-azure/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-azure/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.19/getting-started/provider-gcp-part-2.md
+++ b/content/v1.19/getting-started/provider-gcp-part-2.md
@@ -7,20 +7,20 @@ aliases:
 ---
 
 {{< hint "important" >}}
-This guide is part 2 of a series.  
+This guide is part 2 of a series.
 
 [**Part 1**]({{<ref "provider-gcp" >}}) covers
 to installing Crossplane and connect your Kubernetes cluster to GCP.
 
 {{< /hint >}}
 
-This guide walks you through building and accessing a custom API with 
+This guide walks you through building and accessing a custom API with
 Crossplane.
 
 ## Prerequisites
 * Complete [quickstart part 1]({{<ref "provider-gcp" >}}) connecting Kubernetes
   to GCP.
-* a GCP account with permissions to create a GCP 
+* a GCP account with permissions to create a GCP
   [storage bucket](https://cloud.google.com/storage) and a
   [Pub/Sub topic](https://cloud.google.com/pubsub).
 
@@ -37,9 +37,9 @@ crossplane-stable/crossplane \
 --create-namespace
 ```
 
-2. When the Crossplane pods finish installing and are ready, apply the GCP 
+2. When the Crossplane pods finish installing and are ready, apply the GCP
 Provider.
-   
+
 ```yaml {label="provider",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
 apiVersion: pkg.crossplane.io/v1
@@ -47,16 +47,16 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
-3. Create a file called `gcp-credentials.json` with your GCP service account 
+3. Create a file called `gcp-credentials.json` with your GCP service account
 JSON file.
 
 {{< hint "tip" >}}
-The 
-[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
+The
+[GCP documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys)
 provides information on how to generate a service account JSON file.
 {{< /hint >}}
 
@@ -69,12 +69,12 @@ generic gcp-secret \
 ```
 
 5. Create a _ProviderConfig_
-Include your 
+Include your
 {{< hover label="providerconfig" line="7" >}}GCP project ID{{< /hover >}} in the
 _ProviderConfig_ settings.
 
 {{< hint type="tip" >}}
-Find your GCP project ID from the `project_id` field of the 
+Find your GCP project ID from the `project_id` field of the
 `gcp-credentials.json` file.
 {{< /hint >}}
 
@@ -101,11 +101,11 @@ EOF
 
 ## Install the PubSub Provider
 
-Part 1 only installed the GCP Storage Provider. This section deploys a 
-PubSub Topic along with a GCP storage bucket.  
+Part 1 only installed the GCP Storage Provider. This section deploys a
+PubSub Topic along with a GCP storage bucket.
 First install the GCP PubSub Provider.
 
-Add the new Provider to the cluster. 
+Add the new Provider to the cluster.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -114,7 +114,7 @@ kind: Provider
 metadata:
   name: provider-gcp-pubsub
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.11.4
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1
 EOF
 ```
 
@@ -122,10 +122,10 @@ View the new PubSub provider with `kubectl get providers`.
 
 ```shell {copy-lines="1"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-pubsub           True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4     39s
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4    13m
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4     12m
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    48m
+provider-gcp-pubsub                      True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-pubsub:v1.12.1    14s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   48m
 ```
 
 
@@ -134,10 +134,10 @@ crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.i
 <!-- vale alex.Condescending = NO -->
 Crossplane allows you to build your own custom APIs for your users, abstracting
 away details about the cloud provider and their resources. You can make your API
-as complex or simple as you wish. 
+as complex or simple as you wish.
 <!-- vale alex.Condescending = YES -->
 
-The custom API is a Kubernetes object.  
+The custom API is a Kubernetes object.
 Here is an example custom API.
 
 ```yaml {label="exAPI"}
@@ -145,39 +145,39 @@ apiVersion: database.example.com/v1alpha1
 kind: NoSQL
 metadata:
   name: my-nosql-database
-spec: 
+spec:
   location: "US"
 ```
 
-Like any Kubernetes object the API has a 
-{{<hover label="exAPI" line="1">}}version{{</hover>}}, 
-{{<hover label="exAPI" line="2">}}kind{{</hover>}} and 
+Like any Kubernetes object the API has a
+{{<hover label="exAPI" line="1">}}version{{</hover>}},
+{{<hover label="exAPI" line="2">}}kind{{</hover>}} and
 {{<hover label="exAPI" line="5">}}spec{{</hover>}}.
 
 ### Define a group and version
-To create your own API start by defining an 
-[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and 
-[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).  
+To create your own API start by defining an
+[API group](https://kubernetes.io/docs/reference/using-api/#api-groups) and
+[version](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
 The _group_ can be any value, but common convention is to map to a fully
-qualified domain name. 
+qualified domain name.
 
 <!-- vale gitlab.SentenceLength = NO -->
 The version shows how mature or stable the API is and increments when changing,
 adding or removing fields in the API.
 <!-- vale gitlab.SentenceLength = YES -->
 
-Crossplane doesn't require specific versions or a specific version naming 
-convention, but following 
+Crossplane doesn't require specific versions or a specific version naming
+convention, but following
 [Kubernetes API versioning guidelines](https://kubernetes.io/docs/reference/using-api/#api-versioning)
-is strongly recommended. 
+is strongly recommended.
 
 * `v1alpha1` - A new API that may change at any time.
 * `v1beta1` - An existing API that's considered stable. Breaking changes are
   strongly discouraged.
-* `v1` - A stable API that doesn't have breaking changes. 
+* `v1` - A stable API that doesn't have breaking changes.
 
-This guide uses the group 
+This guide uses the group
 {{<hover label="version" line="1">}}database.example.com{{</hover>}}.
 
 Because this is the first version of the API, this guide uses the version
@@ -194,10 +194,10 @@ individual kinds representing different resources.
 
 For example a `queue` group may have a `PubSub` and `CloudTask` kinds.
 
-The `kind` can be anything, but it must be 
+The `kind` can be anything, but it must be
 [UpperCamelCased](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects).
 
-This API's kind is 
+This API's kind is
 {{<hover label="kind" line="2">}}PubSub{{</hover>}}
 
 ```yaml {label="kind",copy-lines="none"}
@@ -208,51 +208,51 @@ kind: PubSub
 ### Define a spec
 
 The most important part of an API is the schema. The schema defines the inputs
-accepted from users. 
+accepted from users.
 
-This API allows users to provide a 
-{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their 
+This API allows users to provide a
+{{<hover label="spec" line="4">}}location{{</hover>}} of where to run their
 cloud resources.
 
 All other resource settings can't be configurable by the users. This allows
 Crossplane to enforce any policies and standards without worrying about
-user errors. 
+user errors.
 
 ```yaml {label="spec",copy-lines="none"}
 apiVersion: queue.example.com/v1alpha1
 kind: PubSub
-spec: 
+spec:
   location: "US"
 ```
 
 ### Apply the API
 
-Crossplane uses 
-{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}} 
+Crossplane uses
+{{<hover label="xrd" line="3">}}Composite Resource Definitions{{</hover>}}
 (also called an `XRD`) to install your custom API in
-Kubernetes. 
+Kubernetes.
 
 The XRD {{<hover label="xrd" line="6">}}spec{{</hover>}} contains all the
-information about the API including the 
+information about the API including the
 {{<hover label="xrd" line="7">}}group{{</hover>}},
 {{<hover label="xrd" line="12">}}version{{</hover>}},
-{{<hover label="xrd" line="9">}}kind{{</hover>}} and 
+{{<hover label="xrd" line="9">}}kind{{</hover>}} and
 {{<hover label="xrd" line="13">}}schema{{</hover>}}.
 
 The XRD's {{<hover label="xrd" line="5">}}name{{</hover>}} must be the
-combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and 
+combination of the {{<hover label="xrd" line="9">}}plural{{</hover>}} and
 {{<hover label="xrd" line="7">}}group{{</hover>}}.
 
 The {{<hover label="xrd" line="13">}}schema{{</hover>}} uses the
 {{<hover label="xrd" line="14">}}OpenAPIv3{{</hover>}} specification to define
-the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.  
+the API {{<hover label="xrd" line="17">}}spec{{</hover>}}.
 
 The API defines a {{<hover label="xrd" line="20">}}location{{</hover>}} that
-must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either 
-{{<hover label="xrd" line="23">}}EU{{</hover>}} or 
+must be {{<hover label="xrd" line="22">}}oneOf{{</hover>}} either
+{{<hover label="xrd" line="23">}}EU{{</hover>}} or
 {{<hover label="xrd" line="24">}}US{{</hover>}}.
 
-Apply this XRD to create the custom API in your Kubernetes cluster. 
+Apply this XRD to create the custom API in your Kubernetes cluster.
 
 ```yaml {label="xrd",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -290,20 +290,20 @@ EOF
 ```
 
 Adding the {{<hover label="xrd" line="29">}}claimNames{{</hover>}} allows users
-to access this API either at the cluster level with the 
+to access this API either at the cluster level with the
 {{<hover label="xrd" line="9">}}pubsub{{</hover>}} endpoint or in a namespace
-with the 
-{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint. 
+with the
+{{<hover label="xrd" line="29">}}pubsubclaim{{</hover>}} endpoint.
 
 The namespace scoped API is a Crossplane _Claim_.
 
 {{<hint "tip" >}}
 For more details on the fields and options of Composite Resource Definitions
-read the 
-[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}). 
+read the
+[XRD documentation]({{<ref "../concepts/composite-resource-definitions">}}).
 {{< /hint >}}
 
-View the installed XRD with `kubectl get xrd`.  
+View the installed XRD with `kubectl get xrd`.
 
 ```shell {copy-lines="1"}
 kubectl get xrd
@@ -325,21 +325,21 @@ When users access the custom API Crossplane takes their inputs and combines them
 with a template describing what infrastructure to deploy. Crossplane calls this
 template a _Composition_.
 
-The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the 
+The {{<hover label="comp" line="3">}}Composition{{</hover>}} defines all the
 cloud resources to deploy.
 Each entry in the template
 is a full resource definitions, defining all the resource settings and metadata
-like labels and annotations. 
+like labels and annotations.
 
 This template creates a GCP
 {{<hover label="comp" line="10">}}Storage{{</hover>}}
-{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a 
+{{<hover label="comp" line="11">}}Bucket{{</hover>}} and a
 {{<hover label="comp" line="25">}}PubSub{{</hover>}}
 {{<hover label="comp" line="26">}}Topic{{</hover>}}.
 
-This Composition takes the user's 
-{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the 
-{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual 
+This Composition takes the user's
+{{<hover label="comp" line="16">}}location{{</hover>}} input and uses it as the
+{{<hover label="comp" line="14">}}location{{</hover>}} used in the individual
 resource.
 
 {{<hint "important" >}}
@@ -355,7 +355,7 @@ Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 {{< /hint >}}
 
-Apply this Composition to your cluster. 
+Apply this Composition to your cluster.
 
 ```yaml {label="comp",copy-lines="all"}
 cat <<EOF | kubectl apply -f -
@@ -385,7 +385,7 @@ spec:
               toFieldPath: "spec.forProvider.location"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "EU"
                     US: "US"
         - name: crossplane-quickstart-topic
@@ -395,14 +395,14 @@ spec:
             spec:
               forProvider:
                 messageStoragePolicy:
-                  - allowedPersistenceRegions: 
+                  - allowedPersistenceRegions:
                     - "us-central1"
           patches:
             - fromFieldPath: "spec.location"
               toFieldPath: "spec.forProvider.messageStoragePolicy[0].allowedPersistenceRegions[0]"
               transforms:
                 - type: map
-                  map: 
+                  map:
                     EU: "europe-central2"
                     US: "us-central1"
   compositeTypeRef:
@@ -428,7 +428,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 EOF
 ```
 
@@ -436,8 +436,8 @@ EOF
 Read the [Composition documentation]({{<ref "../concepts/compositions">}}) for
 more information on configuring Compositions and all the available options.
 
-Read the 
-[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}}) 
+Read the
+[Patch and Transform function documentation]({{<ref "../guides/function-patch-and-transform">}})
 for more information on how it uses patches to map user inputs to Composition
 resource templates.
 {{< /hint >}}
@@ -464,7 +464,7 @@ apiVersion: queue.example.com/v1alpha1
 kind: PubSub
 metadata:
   name: my-pubsub-queue
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -477,10 +477,10 @@ NAME              SYNCED   READY   COMPOSITION         AGE
 my-pubsub-queue   True     True    topic-with-bucket   2m12s
 ```
 
-This object is a Crossplane _composite resource_ (also called an `XR`).  
+This object is a Crossplane _composite resource_ (also called an `XR`).
 It's a
 single object representing the collection of resources created from the
-Composition template. 
+Composition template.
 
 View the individual resources with `kubectl get managed`
 
@@ -513,17 +513,17 @@ No resources found
 
 ## Using the API with namespaces
 
-Accessing the API `pubsub` happens at the cluster scope.  
+Accessing the API `pubsub` happens at the cluster scope.
 Most organizations
-isolate their users into namespaces.  
+isolate their users into namespaces.
 
 A Crossplane _Claim_ is the custom API in a namespace.
 
 Creating a _Claim_ is just like accessing the custom API endpoint, but with the
-{{<hover label="claim" line="3">}}kind{{</hover>}} 
+{{<hover label="claim" line="3">}}kind{{</hover>}}
 from the custom API's `claimNames`.
 
-Create a new namespace to test create a Claim in. 
+Create a new namespace to test create a Claim in.
 
 ```shell
 kubectl create namespace crossplane-test
@@ -535,10 +535,10 @@ Then create a Claim in the `crossplane-test` namespace.
 cat <<EOF | kubectl apply -f -
 apiVersion: queue.example.com/v1alpha1
 kind: PubSubClaim
-metadata:  
+metadata:
   name: my-pubsub-queue
   namespace: crossplane-test
-spec: 
+spec:
   location: "US"
 EOF
 ```
@@ -551,7 +551,7 @@ my-pubsub-queue   True     True                        2m10s
 ```
 
 The Claim automatically creates a composite resource, which creates the managed
-resources. 
+resources.
 
 View the Crossplane created composite resource with `kubectl get composite`.
 
@@ -600,9 +600,9 @@ No resources found
 ```
 
 ## Next steps
-* Explore AWS resources that Crossplane can configure in the 
+* Explore AWS resources that Crossplane can configure in the
   [provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/package/crds).
-* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with 
+* Join the [Crossplane Slack](https://slack.crossplane.io/) and connect with
   Crossplane users and contributors.
 * Read more about the [Crossplane concepts]({{<ref "../concepts">}}) to find out what else you can do
-  with Crossplane. 
+  with Crossplane.

--- a/content/v1.19/getting-started/provider-gcp.md
+++ b/content/v1.19/getting-started/provider-gcp.md
@@ -36,7 +36,7 @@ kind: Provider
 metadata:
   name: provider-gcp-storage
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1
 EOF
 ```
 
@@ -50,9 +50,9 @@ Verify the provider installed with `kubectl get providers`.
 
 ```shell {copy-lines="1",label="getProvider"}
 kubectl get providers
-NAME                          INSTALLED   HEALTHY   PACKAGE                                                AGE
-provider-gcp-storage          True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-v1.11.4   36s
-crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-v1.11.4    29s
+NAME                                     INSTALLED   HEALTHY   PACKAGE                                                              AGE
+crossplane-contrib-provider-family-gcp   True        True      xpkg.crossplane.io/crossplane-contrib/provider-family-gcp:v1.12.1    33s
+provider-gcp-storage                     True        True      xpkg.crossplane.io/crossplane-contrib/provider-gcp-storage:v1.12.1   37s
 ```
 
 The Storage Provider installs a second Provider, the
@@ -66,7 +66,7 @@ Every CRD maps to a unique GCP service Crossplane can provision and manage.
 
 {{< hint "tip" >}}
 See details about all the supported CRDs in the 
-[provider CRD reference](https://github.com/crossplane-contrib/provider-upjet-gcp/blob/main/package/crds).
+[provider examples](https://github.com/crossplane-contrib/provider-upjet-gcp/tree/main/examples).
 {{< /hint >}}
 
 

--- a/content/v1.19/guides/function-patch-and-transform.md
+++ b/content/v1.19/guides/function-patch-and-transform.md
@@ -92,7 +92,7 @@ kind: Function
 metadata:
   name: function-patch-and-transform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.1.4
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
 ```
 
 {{<hint "tip" >}}

--- a/content/v1.19/guides/troubleshoot-crossplane.md
+++ b/content/v1.19/guides/troubleshoot-crossplane.md
@@ -6,7 +6,7 @@ weight: 306
 
 If you use the Crossplane CLI to install a `Provider` or
 `Configuration` (for example, `crossplane xpkg install provider
-xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.20.1`) and get `the server
+xpkg.crossplane.io/crossplane-contrib/provider-aws-s3:v1.21.1`) and get `the server
 could not find the requested resource` error, more often than not, that's an
 indicator that the Crossplane CLI you're using is outdated. In other words
 some Crossplane API has been graduated from alpha to beta or stable and the old

--- a/content/v1.19/software/uninstall.md
+++ b/content/v1.19/software/uninstall.md
@@ -135,7 +135,7 @@ List the installed _providers_ with `kubectl get providers`.
 ```shell {copy-lines="1"}
 kubectl get providers
 NAME                   INSTALLED   HEALTHY   PACKAGE                                        AGE
-crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.20.1    8h
+crossplane-contrib-provider-aws   True        True      xpkg.crossplane.io/crossplane-contrib/provider-aws:v1.21.1    8h
 ```
 
 Remove the installed _providers_ with `kubectl delete provider`.


### PR DESCRIPTION
This PR updates all the quick starts to use the latest healthy community provider versions. This fixes an issue where the providers did not have functioning RBAC across their dependencies due to a publishing bug in family providers.

Fixes https://github.com/crossplane/crossplane/issues/6320
Fixes #888 

I have walked through both parts of all 3 cloud provider quick starts, so I think these should be working good now ✅ 

Various other locations in the docs had references to the bad provider versions, so those were updated as well.  I tried keeping whitespace edits out of this PR, but after fighting with that for too long, sort of gave up. You can click the "ignore whitespace" option while reviewing the changes 🤷 