### PR TITLE
[v2] Link to Crossplane install guide

### DIFF
--- a/content/v2.0-preview/get-started/get-started-with-managed-resources.md
+++ b/content/v2.0-preview/get-started/get-started-with-managed-resources.md
@@ -10,13 +10,11 @@ with
 
 ## Prerequisites
 This quickstart requires:
-* a Kubernetes cluster with at least 2 GB of RAM
-* permissions to create pods and secrets in the Kubernetes cluster
-* [Helm](https://helm.sh/) version v3.2.0 or later
-* an AWS account with permissions to create an S3 storage bucket
-* AWS [access keys](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
 
-{{<include file="/master/getting-started/install-crossplane-include.md" type="page" >}}
+* A Kubernetes cluster with at least 2 GB of RAM
+* The Crossplane v2 preview [installed on the Kubernetes cluster]({{<ref "install">}})
+* An AWS account with permissions to create an S3 storage bucket
+* AWS [access keys](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
 
 ## Install the AWS provider
 


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

Don't repeat it.

This is a follow on from https://github.com/crossplane/docs/pull/896. That PR actually deleted the install include, but the document is actually including the file from the `content/master` directory, not the new `content/2.0-preview` directory. 🙃 