### PR TITLE
Ignore Mermaid styling when purging CSS

### DIFF
--- a/themes/geekboot/assets/scss/docs.scss
+++ b/themes/geekboot/assets/scss/docs.scss
@@ -50,4 +50,7 @@
 /* purgecss end ignore */
 @import "skippy";
 @import "fonts";
+// TODO(negz): Does import order matter? Can this go in the existing ignore block above?
+/* purgecss start ignore */
 @import "mermaid";
+/* purgecss end ignore */


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

We notice Mermaid styling looks good in Hugo (locally) but not when pushed to Netlify. Maybe this is why?

https://docs.crossplane.io/contribute/infrastructure/#how-optimization-works