### PR TITLE
Use a different warning for preview versions

### DIFF
--- a/content/contribute/infrastructure.md
+++ b/content/contribute/infrastructure.md
@@ -390,6 +390,7 @@ Expand the tab below to see an annotated `tree` output of the website repository
 │       │   │   ├── meta-common.html  # <meta> tags used on all pages
 │       │   │   ├── ms-clarity.html   # Microsoft Clarity tags
 │       │   │   ├── old-version-alert.html  # Alert box for versions that aren't the latest
+│       │   │   ├── preview-version-alert.html  # Alert box for preview versions
 │       │   │   ├── redirect.html     # HTML meta redirect
 │       │   │   ├── release-notes.html  # Release note summary page generator
 │       │   │   ├── rollworks.html    # Rollworks analytics tags

--- a/content/contribute/infrastructure.md
+++ b/content/contribute/infrastructure.md
@@ -389,7 +389,7 @@ Expand the tab below to see an annotated `tree` output of the website repository
 │       │   │   ├── mermaid.html      # Styling and JavaScript for mermaid diagrams
 │       │   │   ├── meta-common.html  # <meta> tags used on all pages
 │       │   │   ├── ms-clarity.html   # Microsoft Clarity tags
-│       │   │   ├── not-latest-version-alert.html  # Alert box for versions that aren't the latest
+│       │   │   ├── old-version-alert.html  # Alert box for versions that aren't the latest
 │       │   │   ├── redirect.html     # HTML meta redirect
 │       │   │   ├── release-notes.html  # Release note summary page generator
 │       │   │   ├── rollworks.html    # Rollworks analytics tags

--- a/content/v2.0-preview/get-started/install.md
+++ b/content/v2.0-preview/get-started/install.md
@@ -3,13 +3,6 @@ title: Install Crossplane
 weight: 100
 ---
 
-{{< hint "warning" >}}
-Crossplane v2 is a preview release.
-
-**Don't use this Crossplane v2 preview in production.**
-{{< /hint >}}
-
-
 Crossplane installs into an existing Kubernetes cluster, creating the
 Crossplane pod.
 

--- a/themes/geekboot/layouts/partials/old-version-alert.html
+++ b/themes/geekboot/layouts/partials/old-version-alert.html
@@ -4,7 +4,7 @@
             <svg class="bi flex-shrink-0" role="img" aria-label="Info:"><use xlink:href="#info"/></svg>
         </div>
         <div class="d-flex">
-            This document isn't for the latest version of Crossplane.
+            This document is for an older version of Crossplane.
         </div>
     </div>
     <div class="mt-3">

--- a/themes/geekboot/layouts/partials/preview-version-alert.html
+++ b/themes/geekboot/layouts/partials/preview-version-alert.html
@@ -1,15 +1,18 @@
-<div class="bd-callout bd-callout-info d-flex flex-column w-100">
+<div class="bd-callout bd-callout-danger d-flex flex-column w-100">
     <div class="d-flex bd-title fs-6 fw-bold border-bottom border-info">
         <div class="d-flex pe-3 align-self-center">
             <svg class="bi flex-shrink-0" role="img" aria-label="Info:"><use xlink:href="#info"/></svg>
         </div>
         <div class="d-flex">
-            This document is for an older version of Crossplane.
+            This document is for a preview version of Crossplane.
         </div>
     </div>
     <div class="mt-3">
         <p>
             This document applies to Crossplane v{{ .Page.Params.version }} and not to the latest release v{{.Site.Params.latest}}.
+            <br />
+            <br />
+            <b>Don't use Crossplane v{{ .Page.Params.version }} in production.</b>
         </p>
     </div>
 </div>

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -72,6 +72,8 @@
 
           {{- if eq .Page.Params.version "master" -}}
             {{ partialCached "master-version-alert" . }}
+          {{- else if strings.HasSuffix $pageVer "-preview" -}}
+            {{ partialCached "preview-version-alert" . .Section }}
           {{- else if ne $pageVer .Site.Params.latest -}}
             {{ partialCached "old-version-alert" . .Section }}
           {{ end }}

--- a/themes/geekboot/layouts/partials/single-list.html
+++ b/themes/geekboot/layouts/partials/single-list.html
@@ -73,7 +73,7 @@
           {{- if eq .Page.Params.version "master" -}}
             {{ partialCached "master-version-alert" . }}
           {{- else if ne $pageVer .Site.Params.latest -}}
-            {{ partialCached "not-latest-version-alert" . .Section }}
+            {{ partialCached "old-version-alert" . .Section }}
           {{ end }}
         {{ end }}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

This'll match any version ending with "-preview" and show a warning that it's a preview, instead of warning that it's an old version.