### PR TITLE
v2: use XP_CHANNEL=preview for CLI install

### DIFF
--- a/content/v2.0-preview/cli/_index.md
+++ b/content/v2.0-preview/cli/_index.md
@@ -17,17 +17,17 @@ The Crossplane CLI includes:
 The Crossplane CLI is a single standalone binary with no external dependencies.
 
 {{<hint "note" >}}
-Install the Crossplane CLI on a user's computer. 
+Install the Crossplane CLI on a user's computer.
 
-Most Crossplane CLI commands are independent of Kubernetes and 
+Most Crossplane CLI commands are independent of Kubernetes and
 don't require access to a Crossplane pod.
-{{< /hint >}} 
+{{< /hint >}}
 
 To download the latest version for your CPU architecture with the Crossplane
 install script.
 
 ```shell
-curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | sh
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=preview sh
 ```
 
 [The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
@@ -35,13 +35,13 @@ detects your CPU architecture and downloads the latest stable release.
 
 {{<expand "Manually install the Crossplane CLI" >}}
 
-If you don't want to run shell script you can manually download a binary from 
-the Crossplane releases repository at 
+If you don't want to run shell script you can manually download a binary from
+the Crossplane releases repository at
 https://releases.crossplane.io/stable/current/bin
 
 {{<hint "important" >}}
 <!-- vale write-good.Passive = NO -->
-The CLI is named `crank` in the release repository. Download this file. 
+The CLI is named `crank` in the release repository. Download this file.
 <!-- vale write-good.Passive = YES -->
 
 The `crossplane` binary is the Kubernetes Crossplane pod image.
@@ -53,12 +53,12 @@ Move the binary to a location in your `$PATH`, for example `/usr/local/bin`.
 ### Download other CLI versions
 
 Download different Crossplane CLI versions or different release branches with
-the `XP_CHANNEL` and `XP_VERSION` environmental variables. 
+the `XP_CHANNEL` and `XP_VERSION` environmental variables.
 
-By default the CLI installs from the `XP_CHANNEL` named `stable` and the 
+By default the CLI installs from the `XP_CHANNEL` named `stable` and the
 `XP_VERSION` of `current`, matching the most recent stable release.
 
-For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the 
-download script curl command:  
+For example, to install CLI version `v1.14.0` add `XP_VERSION=v1.14.0` to the
+download script curl command:
 
 `curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_VERSION=v1.14.0 sh`


### PR DESCRIPTION
This PR just updates the CLI installation instructions in the v2.0-preview docs to always use `XP_CHANNEL=preview`. This way, when using v2, folks will download and install the Crossplane CLI from the v2 preview.

The command in action:
```
❯ curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | XP_CHANNEL=preview sh
crossplane CLI downloaded successfully! Run the following commands to finish installing it:

sudo mv crossplane /usr/local/bin
crossplane --help

Visit https://crossplane.io to get started. 🚀
Have a nice day! 👋

❯ sudo mv crossplane /usr/local/bin
```

This gives me the latest version from the v2 preview:
```
❯ crossplane version
Client Version: v2.0.0-preview.0.39.g815fa2bba
...
```