### PR TITLE
add documentation to cover the new render annotation

### DIFF
--- a/content/master/concepts/compositions.md
+++ b/content/master/concepts/compositions.md
@@ -599,6 +599,11 @@ the container, and `Orphan`, to leave it running.
   `Development` runtime this annotation tells the CLI to connect to a Function
   running at the specified target. It uses
   [gRPC target syntax](https://github.com/grpc/grpc/blob/v1.59.1/doc/naming.md).
+* `render.crossplane.io/runtime-docker-env` - When using the `Docker` runtime this
+  annotation specifies the environment variables that will be used for the
+  container. This is helpful to e.g. control KCL registry access to use a different
+  registry. The annotations value is a comma separated string of key=value pairs 
+  e.g. "key1=value1,key2=value2".
 
 ## Verify a Composition
 


### PR DESCRIPTION
This PR complements/depends on this crossplane PR https://github.com/crossplane/crossplane/pull/6372

It adds documentation for the new crossplane render annotation `render.crossplane.io/runtime-docker-env`

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->