### PR TITLE
[v2] Move manual RBAC documentation to compositions page

### DIFF
--- a/content/v2.0-preview/get-started/get-started-with-composition.md
+++ b/content/v2.0-preview/get-started/get-started-with-composition.md
@@ -660,6 +660,13 @@ Functions can change the results of earlier functions in the pipeline.
 Crossplane uses the result returned by the last function.
 {{</hint>}}
 
+{{<hint "tip">}}
+If you edit this composition to include a different kind of resource you might
+need to grant Crossplane access to compose it. Read
+[the composition documentation]({{<ref "../composition/compositions#grant-access-to-composed-resources">}})
+to learn how to grant Crossplane access.
+{{</hint>}}
+
 ## Use the custom resource
 
 Crossplane now understands `App` custom resources.

--- a/content/v2.0-preview/whats-new/_index.md
+++ b/content/v2.0-preview/whats-new/_index.md
@@ -207,32 +207,12 @@ compose-pg@{animate: true}
 This opens composition to exciting new use cases - for example building custom
 app models with Crossplane.
 
-### Beware Crossplane's default access
-
-Crossplane by default can only access a limited set of kubernetes resources beyond what gets configured by any providers.
-
-To grant access to additional resource resource types, create additional `ClusterRoles` and include them in the default Crossplane `ClusterRole` through [aggregation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles). Crossplane's default ClusterRole aggregates using a selector for the label `rbac.crossplane.io/aggregate-to-crossplane: "true"`
-
-If you don't include this you may experience RBAC issues composing third party custom resources.
-
-Here is an example of allowing Crossplane handle the lifecycle of CloudNativePG PostgreSQL `Cluster`.
-
-``` yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cnpg:aggregate-to-crossplane
-  labels:
-    app: crossplane    
-    rbac.crossplane.io/aggregate-to-crossplane: "true"
-rules:
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - clusters
-  verbs:
-  - "*"
-```
+{{<hint "tip">}}
+You must grant Crossplane access to compose resources that aren't Crossplane
+resources like MRs or XRs. Read
+[the composition documentation]({{<ref "../composition/compositions#grant-access-to-composed-resources">}})
+to learn how to grant Crossplane access.
+{{</hint>}}
 
 ## Backward compatibility
 


### PR DESCRIPTION
Add refs from other pages where it might come up.

I also added a bit of detail and rephrased to address some Vale linter warnings.

This is a follow-up from https://github.com/crossplane/docs/pull/911.

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->