### PR TITLE
chore: update OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,21 +10,23 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://github.com/crossplane/crossplane/blob/main/OWNERS.md) with the following changes:
 
-
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976)) as a maintainer
 * Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis)) as a maintainer
 * Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred)) as a maintainer
-* Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis) as a maintainer
+* Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis)) as a maintainer
+* Rae Sharp <rae@upbound.io> ([tr0njavolta](https://github.com/tr0njavolta)) as a maintainer
 
 ## Maintainers
 
-* Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
-* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-* Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred))
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis))
-* Muvaffak Onus <monus@upbound.io> ([muvaf](https://github.com/muvaf))
 * Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
-* Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis)
+* Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
+* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+* Pete Lumbis <pete@upbound.io> ([plumbis](https://github.com/plumbis))
+* Michael Goff <michael@upbound.io> ([thephred](https://github.com/thephred))
+* Jean du Plessis <jean@upbound.io> ([jeanduplessis](https://github.com/jeanduplessis))
+* Rae Sharp <rae@upbound.io> ([tr0njavolta](https://github.com/tr0njavolta))
 
 ## Reviewers
 
@@ -32,10 +34,10 @@ The Maintainers and Reviewers mirror the [crossplane/crossplane OWNERS](https://
 * Daren Iott <daren@upbound.io> ([nullable-eth](https://github.com/nullable-eth))
 * Ezgi Demirel <ezgi@upbound.io> ([ezgidemirel](https://github.com/ezgidemirel))
 * Max Blatt ([MisterMX](https://github.com/MisterMX))
-* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
 * Lovro Sviben <lovro.sviben@upbound.io> ([lsviben](https://github.com/lsviben))
 
 ## Emeritus maintainers
 
 * Connor Chan <connor@upbound.io> ([connorchan](https://github.com/connorchan))
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
+* Muvaffak Onus <monus@upbound.io> ([muvaf](https://github.com/muvaf))


### PR DESCRIPTION
This PR makes the following changes to the OWNERS.md file:

* add tr0njavolta as new maintainer
* add phisco as maintainer since he's a core maintainer
* add jbw976 to diff list from crossplane repo
* move muvaf to emeritus
* organize maintainer list so it's in same order as crossplane repo

Most all of these changes are just housekeeping organization, the main change here is adding @tr0njavolta as a new maintainer. They have been focusing on documentation in multiple dimensions and will be a valuable resource for keeping this project healthy and sustainable. 🙏 