### PR TITLE
docs: Add a note about installing the compressed file for the CLI

### DIFF
--- a/content/master/cli/_index.md
+++ b/content/master/cli/_index.md
@@ -33,11 +33,25 @@ curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.s
 [The script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh)
 detects your CPU architecture and downloads the latest stable release.
 
+### Download the compressed file instead of the binary
+
+Since v1.18.0 there are also compressed files available. You can ask the
+install script to download and unpack the compressed files instead, which
+should save some bandwidth. Below is an example on how to do that:
+
+```shell
+curl -sL "https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh" | COMPRESSED=True sh
+```
+
 {{<expand "Manually install the Crossplane CLI" >}}
 
 If you don't want to run shell script you can manually download a binary from 
 the Crossplane releases repository at 
 https://releases.crossplane.io/stable/current/bin
+
+If you prefer to download a compressed file from the Crossplane releases
+repository, they are available at
+https://releases.crossplane.io/stable/current/bundle
 
 {{<hint "important" >}}
 <!-- vale write-good.Passive = NO -->


### PR DESCRIPTION
Since v1.18.0 there are compressed files available under the `bundle/` directory in releases.crossplane.io. This commit adds the functionality of downloading the compressed file and unpacking it, instead of downloading the binary, which would save some bandwidth.

This commit documents this functionality.

Related PR: https://github.com/crossplane/crossplane/pull/6436

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->