### PR TITLE
Update feature flags, helm chart values, and APIs for v1.20

### DIFF
--- a/content/master/api/crds/apiextensions.crossplane.io_usages.yaml
+++ b/content/master/api/crds/apiextensions.crossplane.io_usages.yaml
@@ -213,3 +213,200 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.annotations.crossplane\.io/usage-details
+      name: DETAILS
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          A Usage defines a deletion blocking relationship between two resources.
+
+          Usages prevent accidental deletion of a single resource or deletion of
+          resources with dependent resources.
+
+          Read the Crossplane documentation for
+          [more information about Compositions](https://docs.crossplane.io/latest/concepts/usages).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UsageSpec defines the desired state of Usage.
+            properties:
+              by:
+                description: By is the resource that is "using the other resource".
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  resourceRef:
+                    description: Reference to the resource.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  resourceSelector:
+                    description: |-
+                      Selector to the resource.
+                      This field will be ignored if ResourceRef is set.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: either a resource reference or a resource selector should
+                    be set.
+                  rule: has(self.resourceRef) || has(self.resourceSelector)
+              of:
+                description: Of is the resource that is "being used".
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  resourceRef:
+                    description: Reference to the resource.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  resourceSelector:
+                    description: |-
+                      Selector to the resource.
+                      This field will be ignored if ResourceRef is set.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: either a resource reference or a resource selector should
+                    be set.
+                  rule: has(self.resourceRef) || has(self.resourceSelector)
+              reason:
+                description: Reason is the reason for blocking deletion of the resource.
+                type: string
+              replayDeletion:
+                description: ReplayDeletion will trigger a deletion on the used resource
+                  during the deletion of the usage itself, if it was attempted to
+                  be deleted at least once.
+                type: boolean
+            required:
+            - of
+            type: object
+            x-kubernetes-validations:
+            - message: either "spec.by" or "spec.reason" must be specified.
+              rule: has(self.by) || has(self.reason)
+          status:
+            description: UsageStatus defines the observed state of Usage.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/content/master/api/crds/pkg.crossplane.io_configurationrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_configurationrevisions.yaml
@@ -146,6 +146,27 @@ spec:
             description: PackageRevisionStatus represents the observed state of a
               PackageRevision.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this revision, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -281,6 +302,12 @@ spec:
                   - verbs
                   type: object
                 type: array
+              resolvedImage:
+                description: |-
+                  ResolvedPackage is the name of the package that was installed. It may be
+                  different from spec.image if the package path was rewritten using an
+                  image config.
+                type: string
             type: object
         type: object
     served: true

--- a/content/master/api/crds/pkg.crossplane.io_configurations.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_configurations.yaml
@@ -138,6 +138,27 @@ spec:
           status:
             description: ConfigurationStatus represents the observed state of a Configuration.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this package, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -198,6 +219,12 @@ spec:
                   CurrentRevision is the name of the current package revision. It will
                   reflect the most up to date revision, whether it has been activated or
                   not.
+                type: string
+              resolvedPackage:
+                description: |-
+                  ResolvedPackage is the name of the package that was used for version
+                  resolution. It may be different from spec.package if the package path was
+                  rewritten using an image config.
                 type: string
             type: object
         type: object

--- a/content/master/api/crds/pkg.crossplane.io_functionrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_functionrevisions.yaml
@@ -189,6 +189,27 @@ spec:
             description: FunctionRevisionStatus represents the observed state of a
               FunctionRevision.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this revision, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -329,6 +350,12 @@ spec:
                   - verbs
                   type: object
                 type: array
+              resolvedImage:
+                description: |-
+                  ResolvedPackage is the name of the package that was installed. It may be
+                  different from spec.image if the package path was rewritten using an
+                  image config.
+                type: string
             type: object
         type: object
     served: true
@@ -507,6 +534,27 @@ spec:
             description: FunctionRevisionStatus represents the observed state of a
               FunctionRevision.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this revision, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -647,6 +695,12 @@ spec:
                   - verbs
                   type: object
                 type: array
+              resolvedImage:
+                description: |-
+                  ResolvedPackage is the name of the package that was installed. It may be
+                  different from spec.image if the package path was rewritten using an
+                  image config.
+                type: string
             type: object
         type: object
     served: true

--- a/content/master/api/crds/pkg.crossplane.io_functions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_functions.yaml
@@ -168,6 +168,27 @@ spec:
           status:
             description: FunctionStatus represents the observed state of a Function.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this package, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -228,6 +249,12 @@ spec:
                   CurrentRevision is the name of the current package revision. It will
                   reflect the most up to date revision, whether it has been activated or
                   not.
+                type: string
+              resolvedPackage:
+                description: |-
+                  ResolvedPackage is the name of the package that was used for version
+                  resolution. It may be different from spec.package if the package path was
+                  rewritten using an image config.
                 type: string
             type: object
         type: object
@@ -386,6 +413,27 @@ spec:
           status:
             description: FunctionStatus represents the observed state of a Function.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this package, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -446,6 +494,12 @@ spec:
                   CurrentRevision is the name of the current package revision. It will
                   reflect the most up to date revision, whether it has been activated or
                   not.
+                type: string
+              resolvedPackage:
+                description: |-
+                  ResolvedPackage is the name of the package that was used for version
+                  resolution. It may be different from spec.package if the package path was
+                  rewritten using an image config.
                 type: string
             type: object
         type: object

--- a/content/master/api/crds/pkg.crossplane.io_imageconfigs.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_imageconfigs.yaml
@@ -47,13 +47,19 @@ spec:
             description: ImageConfigSpec contains the configuration for matching images.
             properties:
               matchImages:
-                description: MatchImages is a list of image matching rules that should
-                  be satisfied.
+                description: |-
+                  MatchImages is a list of image matching rules. This ImageConfig will
+                  match an image if any one of these rules is satisfied. In the case where
+                  multiple ImageConfigs match an image for a given purpose the one with the
+                  most specific match will be used. If multiple rules of equal specificity
+                  match an arbitrary one will be selected.
                 items:
                   description: ImageMatch defines a rule for matching image.
                   properties:
                     prefix:
-                      description: Prefix is the prefix that should be matched.
+                      description: |-
+                        Prefix is the prefix that should be matched. When multiple prefix rules
+                        match an image path, the longest one takes precedence.
                       type: string
                     type:
                       default: Prefix
@@ -94,6 +100,19 @@ spec:
                     required:
                     - pullSecretRef
                     type: object
+                type: object
+              rewriteImage:
+                description: RewriteImage defines how a matched image's path should
+                  be rewritten.
+                properties:
+                  prefix:
+                    description: |-
+                      Prefix is the prefix that will replace the portion of the image's path
+                      matched by the prefix in the ImageMatch. If multiple prefixes matched,
+                      the longest one will be replaced.
+                    type: string
+                required:
+                - prefix
                 type: object
               verification:
                 description: Verification contains the configuration for verifying

--- a/content/master/api/crds/pkg.crossplane.io_locks.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_locks.yaml
@@ -44,6 +44,9 @@ spec:
             items:
               description: LockPackage is a package that is in the lock.
               properties:
+                apiVersion:
+                  description: APIVersion of the package.
+                  type: string
                 dependencies:
                   description: |-
                     Dependencies are the list of dependencies of this package. The order of
@@ -52,25 +55,39 @@ spec:
                     description: A Dependency is a dependency of a package in the
                       lock.
                     properties:
+                      apiVersion:
+                        description: APIVersion of the package.
+                        type: string
                       constraints:
                         description: |-
                           Constraints is a valid semver range or a digest, which will be used to select a valid
                           dependency version.
+                        type: string
+                      kind:
+                        description: Kind of the package (not the kind of the package
+                          revision).
                         type: string
                       package:
                         description: Package is the OCI image name without a tag or
                           digest.
                         type: string
                       type:
-                        description: Type is the type of package. Can be either Configuration
-                          or Provider.
+                        description: |-
+                          Type is the type of package. Can be either Configuration or Provider.
+                          Deprecated: Specify an apiVersion and kind instead.
+                        enum:
+                        - Configuration
+                        - Provider
+                        - Function
                         type: string
                     required:
                     - constraints
                     - package
-                    - type
                     type: object
                   type: array
+                kind:
+                  description: Kind of the package (not the kind of the package revision).
+                  type: string
                 name:
                   description: Name corresponds to the name of the package revision
                     for this package.
@@ -79,8 +96,13 @@ spec:
                   description: Source is the OCI image name without a tag or digest.
                   type: string
                 type:
-                  description: Type is the type of package. Can be either Configuration
-                    or Provider.
+                  description: |-
+                    Type is the type of package.
+                    Deprecated: Specify an apiVersion and kind instead.
+                  enum:
+                  - Configuration
+                  - Provider
+                  - Function
                   type: string
                 version:
                   description: Version is the tag or digest of the OCI image.
@@ -89,7 +111,6 @@ spec:
               - dependencies
               - name
               - source
-              - type
               - version
               type: object
             type: array

--- a/content/master/api/crds/pkg.crossplane.io_providerrevisions.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_providerrevisions.yaml
@@ -189,6 +189,27 @@ spec:
             description: PackageRevisionStatus represents the observed state of a
               PackageRevision.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this revision, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -324,6 +345,12 @@ spec:
                   - verbs
                   type: object
                 type: array
+              resolvedImage:
+                description: |-
+                  ResolvedPackage is the name of the package that was installed. It may be
+                  different from spec.image if the package path was rewritten using an
+                  image config.
+                type: string
             type: object
         type: object
     served: true

--- a/content/master/api/crds/pkg.crossplane.io_providers.yaml
+++ b/content/master/api/crds/pkg.crossplane.io_providers.yaml
@@ -170,6 +170,27 @@ spec:
           status:
             description: ProviderStatus represents the observed state of a Provider.
             properties:
+              appliedImageConfigRefs:
+                description: |-
+                  AppliedImageConfigRefs records any image configs that were applied in
+                  reconciling this package, and what they were used for.
+                items:
+                  description: |-
+                    ImageConfigRef is a reference to an image config that indicates how the
+                    referenced image config was used by the package manager.
+                  properties:
+                    name:
+                      description: Name is the name of the image config.
+                      type: string
+                    reason:
+                      description: Reason indicates what the image config was used
+                        for.
+                      type: string
+                  required:
+                  - name
+                  - reason
+                  type: object
+                type: array
               conditions:
                 description: Conditions of the resource.
                 items:
@@ -230,6 +251,12 @@ spec:
                   CurrentRevision is the name of the current package revision. It will
                   reflect the most up to date revision, whether it has been activated or
                   not.
+                type: string
+              resolvedPackage:
+                description: |-
+                  ResolvedPackage is the name of the package that was used for version
+                  resolution. It may be different from spec.package if the package path was
+                  rewritten using an image config.
                 type: string
             type: object
         type: object

--- a/content/master/concepts/packages.md
+++ b/content/master/concepts/packages.md
@@ -5,44 +5,44 @@ altTitle: "Crossplane Packages"
 weight: 200
 ---
 
-A _Configuration_ package is an 
+A _Configuration_ package is an
 [OCI container image](https://opencontainers.org/) containing a collection of
-[Compositions]({{<ref "./compositions" >}}), 
+[Compositions]({{<ref "./compositions" >}}),
 [Composite Resource Definitions]({{<ref "./composite-resource-definitions" >}})
-and any required [Providers]({{<ref "./providers">}}) or 
+and any required [Providers]({{<ref "./providers">}}) or
 [Functions]({{<ref "./compositions" >}}).
 
-Configuration packages make your Crossplane configuration fully portable. 
+Configuration packages make your Crossplane configuration fully portable.
 
 {{<hint "important" >}}
-Crossplane [Providers]({{<ref "./providers">}}) and 
-[Functions]({{<ref "./compositions">}}) are also Crossplane packages.  
+Crossplane [Providers]({{<ref "./providers">}}) and
+[Functions]({{<ref "./compositions">}}) are also Crossplane packages.
 
-This document describes how to install and manage configuration packages.  
+This document describes how to install and manage configuration packages.
 
-Refer to the 
-[Provider]({{<ref "./providers">}}) and 
+Refer to the
+[Provider]({{<ref "./providers">}}) and
 [Composition Functions]({{<ref "./compositions">}}) chapters for
-details on their usage of packages. 
+details on their usage of packages.
 {{< /hint >}}
 
 ## Install a Configuration
 
-Install a Configuration with a Crossplane 
-{{<hover line="2" label="install">}}Configuration{{</hover>}} object by setting 
+Install a Configuration with a Crossplane
+{{<hover line="2" label="install">}}Configuration{{</hover>}} object by setting
 the {{<hover line="6" label="install">}}spec.package{{</hover>}} value to the
 location of the configuration package.
 
 {{< hint "important" >}}
 Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
-installing packages. 
+installing packages.
 
 Specify the full domain name with the `package` or change the default Crossplane
 registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
 {{< /hint >}}
 
-For example to install the 
-[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart), 
+For example to install the
+[Getting Started Configuration](https://github.com/crossplane-contrib/configuration-quickstart),
 
 ```yaml {label="install"}
 apiVersion: pkg.crossplane.io/v1
@@ -68,7 +68,7 @@ spec:
 {{< /hint >}}
 
 Crossplane installs the Compositions, Composite Resource Definitions and
-Providers listed in the Configuration. 
+Providers listed in the Configuration.
 
 ### Install with Helm
 
@@ -93,7 +93,7 @@ crossplane-stable/crossplane \
 
 Installing Crossplane packages offline requires a local container registry, such as
 [Harbor](https://goharbor.io/) to host the packages. Crossplane only
-supports installing packages from a container registry. 
+supports installing packages from a container registry.
 
 Crossplane doesn't support installing packages directly from Kubernetes
 volumes.
@@ -101,15 +101,15 @@ volumes.
 ### Installation options
 
 Configurations support multiple options to change configuration package related
-settings. 
+settings.
 
 
 #### Configuration revisions
 
 When installing a newer version of an existing Configuration Crossplane creates
-a new configuration revision. 
+a new configuration revision.
 
-View the configuration revisions with 
+View the configuration revisions with
 {{<hover label="rev" line="1">}}kubectl get configurationrevisions{{</hover>}}.
 
 ```shell {label="rev",copy-lines="1"}
@@ -120,20 +120,20 @@ platform-ref-aws-3ac761211893   True      1          xpkg.crossplane.io/crosspla
 ```
 
 Only a single revision is active at a time. The active revision determines the
-available resources, including Compositions and Composite Resource Definitions. 
+available resources, including Compositions and Composite Resource Definitions.
 
 By default Crossplane keeps only a single _Inactive_ revision.
 
-Change the number of revisions Crossplane maintains with a Configuration package 
-{{<hover label="revHistory" line="6">}}revisionHistoryLimit{{</hover>}}. 
+Change the number of revisions Crossplane maintains with a Configuration package
+{{<hover label="revHistory" line="6">}}revisionHistoryLimit{{</hover>}}.
 
 The {{<hover label="revHistory" line="6">}}revisionHistoryLimit{{</hover>}}
-field is an integer.  
-The default value is `1`.  
-Disable storing revisions by setting 
+field is an integer.
+The default value is `1`.
+Disable storing revisions by setting
 {{<hover label="revHistory" line="6">}}revisionHistoryLimit{{</hover>}} to `0`.
 
-For example, to change the default setting and store 10 revisions use 
+For example, to change the default setting and store 10 revisions use
 {{<hover label="revHistory" line="6">}}revisionHistoryLimit: 10{{</hover>}}.
 
 ```yaml {label="revHistory"}
@@ -152,26 +152,26 @@ Use a {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} to
 define when Crossplane should download the Configuration package to the local
 Crossplane package cache.
 
-The `packagePullPolicy` options are: 
+The `packagePullPolicy` options are:
 * `IfNotPresent` - (**default**) Only download the package if it isn't in the cache.
 * `Always` - Check for new packages every minute and download any matching
   package that isn't in the cache.
 * `Never` - Never download the package. Packages are only installed from the
-  local package cache. 
+  local package cache.
 
 {{<hint "tip" >}}
-The Crossplane 
+The Crossplane
 {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} works
-like the Kubernetes container image 
-[image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).  
+like the Kubernetes container image
+[image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).
 
 Crossplane supports the use of tags and package digest hashes like
-Kubernetes images. 
+Kubernetes images.
 {{< /hint >}}
 
-For example, to `Always` download a given Configuration package use the 
+For example, to `Always` download a given Configuration package use the
 {{<hover label="pullpolicy" line="6">}}packagePullPolicy: Always{{</hover>}}
-configuration. 
+configuration.
 
 ```yaml {label="pullpolicy",copy-lines="6"}
 apiVersion: pkg.crossplane.io/v1
@@ -186,20 +186,20 @@ spec:
 #### Revision activation policy
 
 The `Active` package revision
-is the package controller actively reconciling resources. 
+is the package controller actively reconciling resources.
 
-By default Crossplane sets the most recently installed package revision as 
+By default Crossplane sets the most recently installed package revision as
 `Active`.
 
 Control the Configuration upgrade behavior with a
 {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}}.
 
-The {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}} 
+The {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}}
 options are:
 * `Automatic` - (**default**) Automatically activate the last installed configuration.
-* `Manual` - Don't automatically activate a configuration. 
+* `Manual` - Don't automatically activate a configuration.
 
-For example, to change the upgrade behavior to require manual upgrades, set 
+For example, to change the upgrade behavior to require manual upgrades, set
 {{<hover label="revision" line="6">}}revisionActivationPolicy: Manual{{</hover>}}.
 
 ```yaml {label="revision"}
@@ -215,14 +215,14 @@ spec:
 
 #### Install a Configuration from a private registry
 
-Like Kubernetes uses `imagePullSecrets` to 
-[install images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/), 
-Crossplane uses `packagePullSecrets` to install Configuration packages from a 
-private registry. 
+Like Kubernetes uses `imagePullSecrets` to
+[install images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/),
+Crossplane uses `packagePullSecrets` to install Configuration packages from a
+private registry.
 
 Use {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}} to provide a
-Kubernetes secret to use for authentication when downloading a Configuration 
-package. 
+Kubernetes secret to use for authentication when downloading a Configuration
+package.
 
 {{<hint "important" >}}
 The Kubernetes secret must be in the same namespace as Crossplane.
@@ -232,7 +232,7 @@ The {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}} is a list of
 secrets.
 
 For example, to use the secret named
-{{<hover label="pps" line="6">}}example-secret{{</hover>}} configure a 
+{{<hover label="pps" line="6">}}example-secret{{</hover>}} configure a
 {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}}.
 
 ```yaml {label="pps"}
@@ -241,7 +241,7 @@ kind: Configuration
 metadata:
   name: platform-ref-aws
 spec:
-  packagePullSecrets: 
+  packagePullSecrets:
     - name: example-secret
 # Removed for brevity
 ```
@@ -249,19 +249,19 @@ spec:
 #### Ignore dependencies
 
 By default Crossplane installs any [dependencies](#manage-dependencies) listed
-in a Configuration package. 
+in a Configuration package.
 
-Crossplane can ignore a Configuration package's dependencies with 
+Crossplane can ignore a Configuration package's dependencies with
 {{<hover label="pkgDep" line="6" >}}skipDependencyResolution{{</hover>}}.
 
 {{< hint "warning" >}}
-Most Configurations include dependencies for the required Providers. 
+Most Configurations include dependencies for the required Providers.
 
-If a Configuration ignores dependencies, the required Providers must be 
+If a Configuration ignores dependencies, the required Providers must be
 manually installed.
 {{< /hint >}}
 
-For example, to disable dependency resolution configure 
+For example, to disable dependency resolution configure
 {{<hover label="pkgDep" line="6" >}}skipDependencyResolution: true{{</hover>}}.
 
 ```yaml {label="pkgDep"}
@@ -285,15 +285,15 @@ installations. Suppose configuration A, which depends on package X with the
 constraint`>=v0.0.0`, is installed on the control plane. In this case, the package
 manager installs the latest version of package X, such as `v3.0.0`. Later, you decide
 to install configuration B, which depends on package X with the constraint `<=v2.0.0`.
-Since version `v2.0.0`satisfies both conditions, package X must be downgraded to
+Since version `v2.0.0` satisfies both conditions, package X must be downgraded to
 allow the installation of configuration B which is disabled by default.
 
-For enabling automatic dependency version downgrades, there is a configuration
-option as a helm value `packageManager.enableAutomaticDependencyDowngrade=true`.
-Downgrading a package can cause unexpected behavior, therefore, this
-option is disabled by default. After enabling this option, the package manager will
-automatically downgrade a package's dependency version to the maximum valid version
-that satisfies the constraints.
+Automatic dependency version downgrades is also an alpha feature that can be
+enabled with the `--enable-dependency-version-downgrades` flag. Downgrading a
+package can cause unexpected behavior, therefore, this option is disabled by
+default. After enabling this option, the package manager will automatically
+downgrade a package's dependency version to the maximum valid version that
+satisfies the constraints.
 
 {{<hint "note" >}}
 This configuration requires the `--enable-dependency-version-upgrades` flag.
@@ -309,7 +309,7 @@ section for more details.
 {{<hint "important" >}}
 Enabling automatic dependency downgrades may have unintended consequences, such as:
 
-1) CRDs missing in the downgraded version, possibly leaving orphaned MRs without 
+1) CRDs missing in the downgraded version, possibly leaving orphaned MRs without
 controllers to reconcile them.
 2) Loss of data if downgraded CRD versions omit fields that were set before.
 3) Changes in the CRD storage version, which may prevent package version update.
@@ -317,15 +317,15 @@ controllers to reconcile them.
 
 #### Ignore Crossplane version requirements
 
-A Configuration package may require a specific or minimum Crossplane version 
-before installing. By default, Crossplane doesn't install a Configuration if 
-the Crossplane version doesn't meet the required version. 
+A Configuration package may require a specific or minimum Crossplane version
+before installing. By default, Crossplane doesn't install a Configuration if
+the Crossplane version doesn't meet the required version.
 
-Crossplane can ignore the required version with 
+Crossplane can ignore the required version with
 {{<hover label="xpVer" line="6">}}ignoreCrossplaneConstraints{{</hover>}}.
 
 For example, to install a Configuration package into an unsupported Crossplane
-version, configure 
+version, configure
 {{<hover label="xpVer" line="6">}}ignoreCrossplaneConstraints: true{{</hover>}}.
 
 ```yaml {label="xpVer"}
@@ -341,7 +341,7 @@ spec:
 
 ### Verify a Configuration
 
-Verify a Configuration with 
+Verify a Configuration with
 {{<hover label="verify" line="1">}}kubectl get configuration{{</hover >}}.
 
 A working configuration reports `Installed` and `Healthy` as `True`.
@@ -355,10 +355,10 @@ platform-ref-aws   True        True      xpkg.crossplane.io/crossplane-contrib/c
 ### Manage dependencies
 
 Configuration packages may include dependencies on other packages including
-Functions, Providers or other Configurations. 
+Functions, Providers or other Configurations.
 
 If Crossplane can't meet the dependencies of a Configuration the Configuration
-reports `HEALTHY` as `False`. 
+reports `HEALTHY` as `False`.
 
 For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
@@ -369,7 +369,7 @@ NAME               INSTALLED   HEALTHY   PACKAGE                                
 platform-ref-aws   True        False     xpkg.crossplane.io/crossplane-contrib/configuration-quickstart:v0.1.0   71s
 ```
 
-To see more information on why the Configuration isn't `HEALTHY` use 
+To see more information on why the Configuration isn't `HEALTHY` use
 {{<hover label="depend" line="1">}}kubectl describe configurationrevisions{{</hover>}}.
 
 ```yaml {copy-lines="1",label="depend"}
@@ -396,64 +396,64 @@ Events:
   Warning  LintPackage  29s (x2 over 29s)  packages/configurationrevision.pkg.crossplane.io  incompatible Crossplane version: package isn't compatible with Crossplane version (v1.12.0)
 ```
 
-The {{<hover label="depend" line="18">}}Events{{</hover>}} show a 
+The {{<hover label="depend" line="18">}}Events{{</hover>}} show a
 {{<hover label="depend" line="21">}}Warning{{</hover>}} with a message that the
-current version of Crossplane doesn't meet the Configuration package 
+current version of Crossplane doesn't meet the Configuration package
 requirements.
 
 ## Create a Configuration
 
-Crossplane Configuration packages are 
+Crossplane Configuration packages are
 [OCI container images](https://opencontainers.org/) containing one or more YAML
-files. 
+files.
 
 {{<hint "important" >}}
 Configuration packages are fully OCI compliant. Any tool that builds OCI images
-can build Configuration packages.  
+can build Configuration packages.
 
 It's strongly recommended to use the Crossplane command-line tool to
-provide error checking and formatting to Crossplane package builds. 
+provide error checking and formatting to Crossplane package builds.
 
-Read the 
-[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md) 
+Read the
+[Crossplane package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md)
 for package requirements when building packages with third-party tools.
 {{</hint >}}
 
 A Configuration package requires a `crossplane.yaml` file and may include
-Composition and CompositeResourceDefinition files. 
+Composition and CompositeResourceDefinition files.
 
 <!-- vale Google.Headings = NO -->
 ### The crossplane.yaml file
 <!-- vale Google.Headings = YES -->
 
 To build a Configuration package using the Crossplane CLI, create a file
-named 
-{{<hover label="cfgMeta" line="1">}}crossplane.yaml{{</hover>}}.  
-The 
+named
+{{<hover label="cfgMeta" line="1">}}crossplane.yaml{{</hover>}}.
+The
 {{<hover label="cfgMeta" line="1">}}crossplane.yaml{{</hover>}}
-file defines the requirements and name of the 
+file defines the requirements and name of the
 Configuration.
 
 {{<hint "important" >}}
 The Crossplane CLI only supports a file named `crossplane.yaml`.
 {{< /hint >}}
 
-Configuration package uses the 
+Configuration package uses the
 {{<hover label="cfgMeta" line="2">}}meta.pkg.crossplane.io{{</hover>}}
 Crossplane API group.
 
-Specify any other Configurations, Functions or Providers in the 
-{{<hover label="cfgMeta" line="7">}}dependsOn{{</hover>}} list.  
-Optionally, you can require a specific or minimum package version with the 
+Specify any other Configurations, Functions or Providers in the
+{{<hover label="cfgMeta" line="7">}}dependsOn{{</hover>}} list.
+Optionally, you can require a specific or minimum package version with the
 {{<hover label="cfgMeta" line="9">}}version{{</hover>}} option.
 
 You can also define a specific or minimum version of Crossplane for this
-Configuration with the 
-{{<hover label="cfgMeta" line="11">}}crossplane.version{{</hover>}} option. 
+Configuration with the
+{{<hover label="cfgMeta" line="11">}}crossplane.version{{</hover>}} option.
 
 {{<hint "note" >}}
-Defining the {{<hover label="cfgMeta" line="10">}}crossplane{{</hover>}} object 
-or required versions is optional. 
+Defining the {{<hover label="cfgMeta" line="10">}}crossplane{{</hover>}} object
+or required versions is optional.
 {{< /hint >}}
 
 ```yaml {label="cfgMeta",copy-lines="all"}
@@ -474,8 +474,8 @@ spec:
 
 ### Build the package
 
-Create the package using the 
-[Crossplane CLI]({{<ref "../cli">}}) command 
+Create the package using the
+[Crossplane CLI]({{<ref "../cli">}}) command
 `crossplane xpkg build --package-root=<directory>`.
 
 Where the `<directory>` is the directory containing the `crossplane.yaml` file
@@ -485,19 +485,19 @@ The CLI recursively searches for `.yml` or `.yaml` files in the directory to
 include in the package.
 
 {{<hint "important" >}}
-You must ignore any other YAML files with `--ignore=<file_list>`.  
+You must ignore any other YAML files with `--ignore=<file_list>`.
 For
 example, `crossplane xpkg build --package-root=test-directory --ignore=".tmp/*"`.
 
-Including YAML files that aren't Compositions or CompositeResourceDefinitions, 
+Including YAML files that aren't Compositions or CompositeResourceDefinitions,
 including Claims isn't supported.
 {{</hint >}}
 
-By default, Crossplane creates a `.xpkg` file of the Configuration name and 
+By default, Crossplane creates a `.xpkg` file of the Configuration name and
 a SHA-256 hash of the package contents.
 
 For example, a {{<hover label="xpkgName" line="2">}}Configuration{{</hover>}}
-named {{<hover label="xpkgName" line="4">}}test-configuration{{</hover>}}.  
+named {{<hover label="xpkgName" line="4">}}test-configuration{{</hover>}}.
 The
 Crossplane CLI builds a package named `test-configuration-e8c244f6bf21.xpkg`.
 

--- a/content/master/concepts/providers.md
+++ b/content/master/concepts/providers.md
@@ -24,7 +24,7 @@ Examples of providers include:
 <!-- vale write-good.Passive = NO -->
 <!-- "are Managed" isn't passive in this context -->
 Providers define every external resource they can create in Kubernetes as a
-Kubernetes API endpoint.  
+Kubernetes API endpoint.
 These endpoints are
 [_Managed Resources_]({{<ref "managed-resources" >}}).
 <!-- vale write-good.Passive = YES -->
@@ -32,10 +32,10 @@ These endpoints are
 
 ## Install a Provider
 
-Installing a provider creates new Kubernetes resources representing the 
-Provider's APIs. Installing a provider also creates a Provider pod that's 
-responsible for reconciling the Provider's APIs into the Kubernetes cluster. 
-Providers constantly watch the state of the desired managed resources and create 
+Installing a provider creates new Kubernetes resources representing the
+Provider's APIs. Installing a provider also creates a Provider pod that's
+responsible for reconciling the Provider's APIs into the Kubernetes cluster.
+Providers constantly watch the state of the desired managed resources and create
 any external resources that are missing.
 
 Install a Provider with a Crossplane
@@ -45,7 +45,7 @@ location of the provider package.
 
 {{< hint "important" >}}
 Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
-installing packages. 
+installing packages.
 
 Specify the full domain name with the `package` or change the default Crossplane
 registry with the `--registry` flag on the [Crossplane pod]({{<ref "./pods">}})
@@ -67,19 +67,19 @@ By default, the Provider pod installs in the same namespace as Crossplane
 (`crossplane-system`).
 
 {{<hint "note" >}}
-Providers are part of the 
-{{<hover label="install" line="1">}}pkg.crossplane.io{{</hover>}} group.  
+Providers are part of the
+{{<hover label="install" line="1">}}pkg.crossplane.io{{</hover>}} group.
 
 The {{<hover label="meta-pkg" line="1">}}meta.pkg.crossplane.io{{</hover>}}
-group is for creating Provider packages. 
+group is for creating Provider packages.
 
 Instructions on building Providers are outside of the scope of this
-document.  
-Read the Crossplane contributing 
+document.
+Read the Crossplane contributing
 [Provider Development Guide](https://github.com/crossplane/crossplane/blob/main/contributing/guide-provider-development.md)
 for more information.
 
-For information on the specification of Provider packages read the 
+For information on the specification of Provider packages read the
 [Crossplane Provider Package specification](https://github.com/crossplane/crossplane/blob/main/contributing/specifications/xpkg.md#provider-package-requirements).
 
 ```yaml {label="meta-pkg"}
@@ -113,9 +113,9 @@ crossplane-stable/crossplane \
 
 ### Install offline
 
-Installing Crossplane Providers offline requires a local container registry like 
+Installing Crossplane Providers offline requires a local container registry like
 [Harbor](https://goharbor.io/) to host Provider packages. Crossplane only
-supports installing Provider packages from a container registry. 
+supports installing Provider packages from a container registry.
 
 Crossplane doesn't support installing Provider packages directly from Kubernetes
 volumes.
@@ -123,11 +123,11 @@ volumes.
 ### Installation options
 
 Providers support multiple configuration options to change installation related
-settings. 
+settings.
 
 {{<hint "tip" >}}
 Crossplane supports installations with image digests instead of tags to get deterministic
-and repeatable installations.  
+and repeatable installations.
 
 ```yaml {label="digest"}
 apiVersion: pkg.crossplane.io/v1
@@ -145,26 +145,26 @@ Use a {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} to
 define when Crossplane should download the Provider package to the local
 Crossplane package cache.
 
-The `packagePullPolicy` options are: 
+The `packagePullPolicy` options are:
 * `IfNotPresent` - (**default**) Only download the package if it isn't in the cache.
 * `Always` - Check for new packages every minute and download any matching
   package that isn't in the cache.
 * `Never` - Never download the package. Packages are only installed from the
-  local package cache. 
+  local package cache.
 
 {{<hint "tip" >}}
-The Crossplane 
+The Crossplane
 {{<hover label="pullpolicy" line="6">}}packagePullPolicy{{</hover>}} works
-like the Kubernetes container image 
-[image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).  
+like the Kubernetes container image
+[image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).
 
 Crossplane supports the use of tags and package digest hashes like
-Kubernetes images. 
+Kubernetes images.
 {{< /hint >}}
 
-For example, to `Always` download a given Provider package use the 
+For example, to `Always` download a given Provider package use the
 {{<hover label="pullpolicy" line="6">}}packagePullPolicy: Always{{</hover>}}
-configuration. 
+configuration.
 
 ```yaml {label="pullpolicy",copy-lines="6"}
 apiVersion: pkg.crossplane.io/v1
@@ -179,20 +179,20 @@ spec:
 #### Revision activation policy
 
 The `Active` package revision
-is the package controller actively reconciling resources. 
+is the package controller actively reconciling resources.
 
-By default Crossplane sets the most recently installed package revision as 
+By default Crossplane sets the most recently installed package revision as
 `Active`.
 
 Control the Provider upgrade behavior with a
 {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}}.
 
-The {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}} 
+The {{<hover label="revision" line="6">}}revisionActivationPolicy{{</hover>}}
 options are:
 * `Automatic` - (**default**) Automatically activate the last installed Provider.
 * `Manual` - Don't automatically activate a Provider.
 
-For example, to change the upgrade behavior to require manual upgrades, set 
+For example, to change the upgrade behavior to require manual upgrades, set
 {{<hover label="revision" line="6">}}revisionActivationPolicy: Manual{{</hover>}}.
 
 ```yaml {label="revision"}
@@ -207,26 +207,26 @@ spec:
 
 #### Package revision history limit
 
-When Crossplane installs a different version of the same Provider package 
-Crossplane creates a new _revision_. 
+When Crossplane installs a different version of the same Provider package
+Crossplane creates a new _revision_.
 
-By default Crossplane maintains one _Inactive_ revision. 
+By default Crossplane maintains one _Inactive_ revision.
 
 {{<hint "note" >}}
 Read the [Provider upgrade](#upgrade-a-provider) section for
 more information on the use of package revisions.
 {{< /hint >}}
 
-Change the number of revisions Crossplane maintains with a Provider Package 
-{{<hover label="revHistoryLimit" line="6">}}revisionHistoryLimit{{</hover>}}. 
+Change the number of revisions Crossplane maintains with a Provider Package
+{{<hover label="revHistoryLimit" line="6">}}revisionHistoryLimit{{</hover>}}.
 
 The {{<hover label="revHistoryLimit" line="6">}}revisionHistoryLimit{{</hover>}}
-field is an integer.  
-The default value is `1`.  
-Disable storing revisions by setting 
+field is an integer.
+The default value is `1`.
+Disable storing revisions by setting
 {{<hover label="revHistoryLimit" line="6">}}revisionHistoryLimit{{</hover>}} to `0`.
 
-For example, to change the default setting and store 10 revisions use 
+For example, to change the default setting and store 10 revisions use
 {{<hover label="revHistoryLimit" line="6">}}revisionHistoryLimit: 10{{</hover>}}.
 
 ```yaml {label="revHistoryLimit"}
@@ -241,13 +241,13 @@ spec:
 
 #### Install a provider from a private registry
 
-Like Kubernetes uses `imagePullSecrets` to 
-[install images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/), 
+Like Kubernetes uses `imagePullSecrets` to
+[install images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/),
 Crossplane uses `packagePullSecrets` to install Provider packages from a private
-registry. 
+registry.
 
 Use {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}} to provide a
-Kubernetes secret to use for authentication when downloading a Provider package. 
+Kubernetes secret to use for authentication when downloading a Provider package.
 
 {{<hint "important" >}}
 The Kubernetes secret must be in the same namespace as Crossplane.
@@ -257,7 +257,7 @@ The {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}} is a list of
 secrets.
 
 For example, to use the secret named
-{{<hover label="pps" line="6">}}example-secret{{</hover>}} configure a 
+{{<hover label="pps" line="6">}}example-secret{{</hover>}} configure a
 {{<hover label="pps" line="6">}}packagePullSecrets{{</hover>}}.
 
 ```yaml {label="pps"}
@@ -266,25 +266,25 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  packagePullSecrets: 
+  packagePullSecrets:
     - name: example-secret
 # Removed for brevity
 ```
 
 {{<hint "note" >}}
 Configured `packagePullSecrets` aren't passed to any Provider package
-dependencies. 
+dependencies.
 {{< /hint >}}
 
 #### Ignore dependencies
 
 By default Crossplane installs any [dependencies](#manage-dependencies) listed
-in a Provider package. 
+in a Provider package.
 
-Crossplane can ignore a Provider package's dependencies with 
+Crossplane can ignore a Provider package's dependencies with
 {{<hover label="pkgDep" line="6" >}}skipDependencyResolution{{</hover>}}.
 
-For example, to disable dependency resolution configure 
+For example, to disable dependency resolution configure
 {{<hover label="pkgDep" line="6" >}}skipDependencyResolution: true{{</hover>}}.
 
 ```yaml {label="pkgDep"}
@@ -308,15 +308,15 @@ installations. Suppose configuration A, which depends on package X with the
 constraint`>=v0.0.0`, is installed on the control plane. In this case, the package
 manager installs the latest version of package X, such as `v3.0.0`. Later, you decide
 to install configuration B, which depends on package X with the constraint `<=v2.0.0`.
-Since version `v2.0.0`satisfies both conditions, package X must be downgraded to
+Since version `v2.0.0` satisfies both conditions, package X must be downgraded to
 allow the installation of configuration B which is disabled by default.
 
-For enabling automatic dependency version downgrades, there is a configuration
-option as a helm value `packageManager.enableAutomaticDependencyDowngrade=true`.
-Downgrading a package can cause unexpected behavior, therefore, this
-option is disabled by default. After enabling this option, the package manager will
-automatically downgrade a package's dependency version to the maximum valid version
-that satisfies the constraints.
+Automatic dependency version downgrades is also an alpha feature that can be
+enabled with the `--enable-dependency-version-downgrades` flag. Downgrading a
+package can cause unexpected behavior, therefore, this option is disabled by
+default. After enabling this option, the package manager will automatically
+downgrade a package's dependency version to the maximum valid version that
+satisfies the constraints.
 
 {{<hint "note" >}}
 This configuration requires the `--enable-dependency-version-upgrades` flag.
@@ -342,13 +342,13 @@ controllers to reconcile them.
 
 A Provider package may require a specific or minimum Crossplane version before
 installing. By default, Crossplane doesn't install a Provider if the Crossplane
-version doesn't meet the required version. 
+version doesn't meet the required version.
 
-Crossplane can ignore the required version with 
+Crossplane can ignore the required version with
 {{<hover label="xpVer" line="6">}}ignoreCrossplaneConstraints{{</hover>}}.
 
 For example, to install a Provider package into an unsupported Crossplane
-version, configure 
+version, configure
 {{<hover label="xpVer" line="6">}}ignoreCrossplaneConstraints: true{{</hover>}}.
 
 ```yaml {label="xpVer"}
@@ -364,10 +364,10 @@ spec:
 ### Manage dependencies
 
 Providers packages may include dependencies on other packages including
-Configurations or other Providers. 
+Configurations or other Providers.
 
 If Crossplane can't meet the dependencies of a Provider package the Provider
-reports `HEALTHY` as `False`. 
+reports `HEALTHY` as `False`.
 
 For example, this installation of the Getting Started Configuration is
 `HEALTHY: False`.
@@ -404,9 +404,9 @@ Events:
   Warning  LintPackage        41s (x3 over 47s)  packages/providerrevision.pkg.crossplane.io  incompatible Crossplane version: package isn't compatible with Crossplane version (v1.10.0)
 ```
 
-The {{<hover label="depend" line="17">}}Events{{</hover>}} show a 
+The {{<hover label="depend" line="17">}}Events{{</hover>}} show a
 {{<hover label="depend" line="20">}}Warning{{</hover>}} with a message that the
-current version of Crossplane doesn't meet the Configuration package 
+current version of Crossplane doesn't meet the Configuration package
 requirements.
 
 ## Upgrade a Provider
@@ -420,7 +420,7 @@ Crossplane installs the new image and creates a new `ProviderRevision`.
 The `ProviderRevision` allows Crossplane to store deprecated Provider CRDs
 without removing them until you decide.
 
-View the `ProviderRevisions` with 
+View the `ProviderRevisions` with
 {{<hover label="getPR" line="1">}}kubectl get providerrevisions{{</hover>}}
 
 ```shell {label="getPR",copy-lines="1"}
@@ -436,14 +436,14 @@ By default Crossplane keeps a single
 {{<hover label="getPR" line="5">}}Inactive{{</hover>}} Provider.
 
 Read the [revision history limit](#package-revision-history-limit) section to
-change the default value. 
+change the default value.
 
-Only a single revision of a Provider is 
+Only a single revision of a Provider is
 {{<hover label="getPR" line="4">}}Active{{</hover>}} at a time.
 
 ## Remove a Provider
 
-Remove a Provider by deleting the Provider object with 
+Remove a Provider by deleting the Provider object with
 `kubectl delete provider`.
 
 {{< hint "warning" >}}
@@ -495,7 +495,7 @@ The Crossplane community has more
 
 ### Provider conditions
 
-Crossplane uses a standard set of `Conditions` for Providers.  
+Crossplane uses a standard set of `Conditions` for Providers.
 View the conditions of a provider under their `Status` with
 `kubectl describe provider`.
 
@@ -622,7 +622,7 @@ Providers have two different types of configurations:
   an external provider. For example, cloud provider authentication.
 
 {{<hint "important" >}}
-Apply `ControllerConfig` objects to Providers.  
+Apply `ControllerConfig` objects to Providers.
 
 Apply `ProviderConfig` objects to managed resources.
 {{< /hint >}}

--- a/content/master/software/install.md
+++ b/content/master/software/install.md
@@ -132,6 +132,9 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `extraVolumeMountsCrossplane` | Add custom `volumeMounts` to the Crossplane pod. | `{}` |
 | `extraVolumesCrossplane` | Add custom `volumes` to the Crossplane pod. | `{}` |
 | `function.packages` | A list of Function packages to install | `[]` |
+| `functionCache.medium` | Set to `Memory` to hold the function cache in a RAM backed file system. Useful for Crossplane development. | `""` |
+| `functionCache.pvc` | The name of a PersistentVolumeClaim to use as the function cache. Disables the default function cache `emptyDir` Volume. | `""` |
+| `functionCache.sizeLimit` | The size limit for the function cache. If medium is `Memory` the `sizeLimit` can't exceed Node memory. | `"512Mi"` |
 | `hostNetwork` | Enable `hostNetwork` for the Crossplane deployment. Caution: enabling `hostNetwork` grants the Crossplane Pod access to the host network namespace. Consider setting `dnsPolicy` to `ClusterFirstWithHostNet`. | `false` |
 | `image.pullPolicy` | The image pull policy used for Crossplane and RBAC Manager pods. | `"IfNotPresent"` |
 | `image.repository` | Repository for the Crossplane pod image. | `"xpkg.crossplane.io/crossplane/crossplane"` |
@@ -145,7 +148,6 @@ Apply customizations with the command line or with a Helm _values_ file.
 | `packageCache.medium` | Set to `Memory` to hold the package cache in a RAM backed file system. Useful for Crossplane development. | `""` |
 | `packageCache.pvc` | The name of a PersistentVolumeClaim to use as the package cache. Disables the default package cache `emptyDir` Volume. | `""` |
 | `packageCache.sizeLimit` | The size limit for the package cache. If medium is `Memory` the `sizeLimit` can't exceed Node memory. | `"20Mi"` |
-| `packageManager.enableAutomaticDependencyDowngrade` | Enable automatic dependency version downgrades. This configuration is only used when `--enable-dependency-version-upgrades` flag is passed. | `false` |
 | `podSecurityContextCrossplane` | Add a custom `securityContext` to the Crossplane pod. | `{}` |
 | `podSecurityContextRBACManager` | Add a custom `securityContext` to the RBAC Manager pod. | `{}` |
 | `priorityClassName` | The PriorityClass name to apply to the Crossplane and RBAC Manager pods. | `""` |
@@ -265,10 +267,12 @@ at the table below.
 | Beta | `--enable-deployment-runtime-configs` | Enable support for DeploymentRuntimeConfigs. |
 | Beta | `--enable-usages` | Enable support for Usages. |
 | Beta | `--enable-ssa-claims` | Enable support for using server-side apply to sync claims with XRs. |
+| Beta | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-external-secret-stores` | Enable support for External Secret Stores. |
-| Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
-| Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
+| Alpha | `--enable-dependency-version-upgrades` | Enable automatic version upgrades of dependencies when updating packages. |
+| Alpha | `--enable-dependency-version-downgrades` | Enable automatic version downgrades of dependencies when updating packages. |
 | Alpha | `--enable-signature-verification` | Enable support for package signature verification via ImageConfig API. |
+| Alpha | `--enable-function-response-cache` | Enable support for caching composition function responses. |
 {{< /table >}}
 {{< /expand >}}
 
@@ -279,7 +283,7 @@ args='{"--enable-composition-functions","--enable-composition-webhook-schema-val
 #### Change the default package registry
 
 Beginning with Crossplane version 1.20.0 Crossplane uses the [crossplane-contrib](https://github.com/orgs/crossplane-contrib/packages) GitHub Container Registry at `xpkg.crossplane.io` by default for downloading and
-installing packages. 
+installing packages.
 
 Change the default registry location during the Crossplane install with
 `--set args='{"--registry=index.docker.io"}'`.


### PR DESCRIPTION
While authoring the release notes for the [v1.20 RC](https://github.com/crossplane/crossplane/releases/tag/v1.20.0-rc.1) today, I was reminded of a handful of changes to our feature flags, helm chart values, and APIs that should also be updated in the docs.  I am only updating master now and that will become the new v1.20 version on release day.

I've split it into 3 commits to make browsing a bit easier:

* updating feature flags and helm chart values
* updating the explanation and usage of the `--enable-dependency-version-downgrades` flag
* updating the core Crossplane CRDs (simply by copying them over from crossplane [`main` branch](https://github.com/crossplane/crossplane/tree/main/cluster/crds)

The CRD updates look to pick up a few changes that were actually part of the v1.19 release - I believe we forgot to update the CRDs in the master content as part of the v1.19 release - they're correct now 😇 