### PR TITLE
Add alternative options to update connectionSecretKeys

### DIFF
--- a/content/master/concepts/connection-details.md
+++ b/content/master/concepts/connection-details.md
@@ -534,11 +534,10 @@ the secret key names to create. Crossplane only adds the keys listed to the
 combined secret.
 
 {{<hint "warning">}}
-You can't change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD. 
-You must delete and
-recreate the XRD to change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}}.
+When changing the {{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD the change isn't immediately reflected.
+You have two options to change the keys in the combined secret object.
+- Delete and recreate the XRD. This only makes sense if the XRD isn't used as it leads to the deletion of XRs.
+- Restart the XR reconciler, which can be done by restarting the Crossplane pod.
 {{</hint >}}
 
 For example, an XRD may restrict the secrets to only the 

--- a/content/v1.18/concepts/connection-details.md
+++ b/content/v1.18/concepts/connection-details.md
@@ -534,11 +534,10 @@ the secret key names to create. Crossplane only adds the keys listed to the
 combined secret.
 
 {{<hint "warning">}}
-You can't change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD. 
-You must delete and
-recreate the XRD to change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}}.
+When changing the {{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD the change isn't immediately reflected.
+You have two options to change the keys in the combined secret object.
+- Delete and recreate the XRD. This only makes sense if the XRD isn't used as it leads to the deletion of XRs.
+- Restart the XR reconciler, which can be done by restarting the Crossplane pod.
 {{</hint >}}
 
 For example, an XRD may restrict the secrets to only the 

--- a/content/v1.19/concepts/connection-details.md
+++ b/content/v1.19/concepts/connection-details.md
@@ -537,7 +537,7 @@ combined secret.
 When changing the {{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD the change isn't immediately reflected.
 You have two options to change the keys in the combined secret object.
 - Delete and recreate the XRD. This only makes sense if the XRD isn't used as it leads to the deletion of XRs.
-- Restart the XR reconciler effectively restarting the Crossplane pods.
+- Restart the XR reconciler, which can be done by restarting the Crossplane pod.
 {{</hint >}}
 
 For example, an XRD may restrict the secrets to only the 

--- a/content/v1.19/concepts/connection-details.md
+++ b/content/v1.19/concepts/connection-details.md
@@ -534,11 +534,10 @@ the secret key names to create. Crossplane only adds the keys listed to the
 combined secret.
 
 {{<hint "warning">}}
-You can't change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD. 
-You must delete and
-recreate the XRD to change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}}.
+When changing the {{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD the change isn't immediately reflected.
+You have two options to change the keys in the combined secret object.
+- Delete and recreate the XRD. This only makes sense if the XRD isn't used as it leads to the deletion of XRs.
+- Restart the XR reconciler effectively restarting the Crossplane pods.
 {{</hint >}}
 
 For example, an XRD may restrict the secrets to only the 

--- a/content/v1.20/concepts/connection-details.md
+++ b/content/v1.20/concepts/connection-details.md
@@ -534,11 +534,10 @@ the secret key names to create. Crossplane only adds the keys listed to the
 combined secret.
 
 {{<hint "warning">}}
-You can't change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD. 
-You must delete and
-recreate the XRD to change the 
-{{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}}.
+When changing the {{<hover label="xrd" line="4">}}connectionSecretKeys{{</hover>}} of an XRD the change isn't immediately reflected.
+You have two options to change the keys in the combined secret object.
+- Delete and recreate the XRD. This only makes sense if the XRD isn't used as it leads to the deletion of XRs.
+- Restart the XR reconciler, which can be done by restarting the Crossplane pod.
 {{</hint >}}
 
 For example, an XRD may restrict the secrets to only the 


### PR DESCRIPTION
I think the change is quite obvious. A less destructive way of updating the keys should be documented.
I believe that this is probably not needed anymore in crossplane v2 but for the time being let's safe users from some headaches.