### PR TITLE
chore: update links to community resources

### DIFF
--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -11,7 +11,7 @@ The Crossplane Contributing Guide is for anyone interested in contributing to
 the Crossplane documentation.
 
 Information on contributing to the Crossplane software project is in the
-Crossplane 
+Crossplane
 [`CONTRIBUTING.md`](https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md)
 file.
 
@@ -24,7 +24,7 @@ Taken directly from the code:
 >fostering an open and welcoming community, we pledge to respect all people who
 >contribute through reporting issues, posting feature requests, updating
 >documentation, submitting pull requests or patches, and other activities.
->  
+>
 >We are committed to making participation in the CNCF community a
 >harassment-free experience for everyone, regardless of level of experience,
 >gender, gender identity and expression, sexual orientation, disability,
@@ -32,9 +32,8 @@ Taken directly from the code:
 <!-- vale on -->
 
 ## Reporting violations
-To report violations contact the Crossplane maintainers at `info@crossplane.io`
+To report violations contact the Crossplane maintainers at `crossplane-info@lists.cncf.io`
 or the CNCF at `conduct@cncf.io`.
-
 
 All the information needed to contribute to the Crossplane documentation is
 here.
@@ -42,7 +41,7 @@ here.
 * Read [contributing to the docs]({{< ref "contribute" >}}) for information
   about the docs repository, cloning and local development.
 * The [writing style guide]({{< ref "writing-style-guide" >}}) describes the
-  guidelines for language, spelling and language style. 
+  guidelines for language, spelling and language style.
 * The [code styling guide]({{< ref "code-style-guide" >}}) covers the Crossplane guidelines
   specific to including code blocks in docs to provide the best reader
   experience.

--- a/content/master/learn/_index.md
+++ b/content/master/learn/_index.md
@@ -28,7 +28,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 <!-- vale Crossplane.Spelling = NO -->
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
-- Email us: [info@crossplane.io](mailto:info@crossplane.io)
+- Email us: [crossplane-info@lists.cncf.io](mailto:crossplane-info@lists.cncf.io)
 <!-- vale Crossplane.Spelling = YES -->
 
 <!-- Named links -->

--- a/content/master/learn/release-cycle.md
+++ b/content/master/learn/release-cycle.md
@@ -68,7 +68,7 @@ During feature freeze, no new functionality should be merged into the main
 development branch. Bug fixes, documentation changes, and non critical changes
 may be made. In the case that a new feature is deemed absolutely necessary for a
 release, the Crossplane maintainers will weigh the impact of the change and make
-a decision on whether it should be included. 
+a decision on whether it should be included.
 
 ### Code freeze
 
@@ -97,4 +97,4 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
 [CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
-[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane

--- a/content/v1.18/learn/_index.md
+++ b/content/v1.18/learn/_index.md
@@ -28,7 +28,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 <!-- vale Crossplane.Spelling = NO -->
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
-- Email us: [info@crossplane.io](mailto:info@crossplane.io)
+- Email us: [crossplane-info@lists.cncf.io](mailto:crossplane-info@lists.cncf.io)
 <!-- vale Crossplane.Spelling = YES -->
 
 <!-- Named links -->

--- a/content/v1.18/learn/release-cycle.md
+++ b/content/v1.18/learn/release-cycle.md
@@ -68,7 +68,7 @@ During feature freeze, no new functionality should be merged into the main
 development branch. Bug fixes, documentation changes, and non critical changes
 may be made. In the case that a new feature is deemed absolutely necessary for a
 release, the Crossplane maintainers will weigh the impact of the change and make
-a decision on whether it should be included. 
+a decision on whether it should be included.
 
 ### Code freeze
 
@@ -97,4 +97,4 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
 [CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
-[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane

--- a/content/v1.19/learn/_index.md
+++ b/content/v1.19/learn/_index.md
@@ -28,7 +28,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 <!-- vale Crossplane.Spelling = NO -->
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
-- Email us: [info@crossplane.io](mailto:info@crossplane.io)
+- Email us: [crossplane-info@lists.cncf.io](mailto:crossplane-info@lists.cncf.io)
 <!-- vale Crossplane.Spelling = YES -->
 
 <!-- Named links -->

--- a/content/v1.19/learn/release-cycle.md
+++ b/content/v1.19/learn/release-cycle.md
@@ -68,7 +68,7 @@ During feature freeze, no new functionality should be merged into the main
 development branch. Bug fixes, documentation changes, and non critical changes
 may be made. In the case that a new feature is deemed absolutely necessary for a
 release, the Crossplane maintainers will weigh the impact of the change and make
-a decision on whether it should be included. 
+a decision on whether it should be included.
 
 ### Code freeze
 
@@ -97,4 +97,4 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
 [CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
-[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane

--- a/content/v1.20/learn/_index.md
+++ b/content/v1.20/learn/_index.md
@@ -28,7 +28,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 <!-- vale Crossplane.Spelling = NO -->
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
-- Email us: [info@crossplane.io](mailto:info@crossplane.io)
+- Email us: [crossplane-info@lists.cncf.io](mailto:crossplane-info@lists.cncf.io)
 <!-- vale Crossplane.Spelling = YES -->
 
 <!-- Named links -->

--- a/content/v1.20/learn/release-cycle.md
+++ b/content/v1.20/learn/release-cycle.md
@@ -68,7 +68,7 @@ During feature freeze, no new functionality should be merged into the main
 development branch. Bug fixes, documentation changes, and non critical changes
 may be made. In the case that a new feature is deemed absolutely necessary for a
 release, the Crossplane maintainers will weigh the impact of the change and make
-a decision on whether it should be included. 
+a decision on whether it should be included.
 
 ### Code freeze
 
@@ -97,4 +97,4 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
 [CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
-[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane

--- a/content/v2.0-preview/learn/_index.md
+++ b/content/v2.0-preview/learn/_index.md
@@ -28,7 +28,7 @@ If you have any questions, please drop us a note on [Crossplane Slack][join-cros
 - Subscribe to our [YouTube Channel](https://www.youtube.com/channel/UC19FgzMBMqBro361HbE46Fw)
 <!-- vale Crossplane.Spelling = NO -->
 - Drop us a note on Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
-- Email us: [info@crossplane.io](mailto:info@crossplane.io)
+- Email us: [crossplane-info@lists.cncf.io](mailto:crossplane-info@lists.cncf.io)
 <!-- vale Crossplane.Spelling = YES -->
 
 <!-- Named links -->

--- a/content/v2.0-preview/learn/release-cycle.md
+++ b/content/v2.0-preview/learn/release-cycle.md
@@ -68,7 +68,7 @@ During feature freeze, no new functionality should be merged into the main
 development branch. Bug fixes, documentation changes, and non critical changes
 may be made. In the case that a new feature is deemed absolutely necessary for a
 release, the Crossplane maintainers will weigh the impact of the change and make
-a decision on whether it should be included. 
+a decision on whether it should be included.
 
 ### Code freeze
 
@@ -97,4 +97,4 @@ reviews, testing, and bug fixing to ensure a quality release.
 [Feature Freeze]: #feature-freeze
 [Code Freeze]: #code-freeze
 [CONTRIBUTING.md]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
-[community calendar]: https://calendar.google.com/calendar/embed?src=c_2cdn0hs9e2m05rrv1233cjoj1k%40group.calendar.google.com
+[community calendar]: https://zoom-lfx.platform.linuxfoundation.org/meetings/crossplane


### PR DESCRIPTION
This PR simply updates the README and other locations to point to newly migrated community accounts owned by the CNCF, e.g. email addresses, community calendars, etc.