### PR TITLE
Add Get Started documentation for v2.0 and v2.0-preview

### DIFF
--- a/content/v2.0-preview/get-started/_index.md
+++ b/content/v2.0-preview/get-started/_index.md
@@ -1,6 +1,15 @@
 ---
 title: Get Started
 weight: 40
-description: Get started with Crossplane.
+description: An introduction to Crossplane and Crossplane quickstart guides.
 ---
 
+{{<img src="/media/banner.png" alt="Crossplane Popsicle Truck" size="large" >}}
+
+## Hands-on
+Want a hands-on example? Follow a Crossplane Quickstart for different resource types
+* [Composition quickstart]({{<ref "get-started-with-composition" >}})
+* [Managed Resources quickstart]({{<ref "get-started-with-managed-resources" >}})
+
+## Install
+Ready to get started? [Install Crossplane]({{<ref "install" >}}) in a Kubernetes cluster.

--- a/content/v2.0/get-started/_index.md
+++ b/content/v2.0/get-started/_index.md
@@ -1,6 +1,16 @@
 ---
 title: Get Started
 weight: 40
-description: Get started with Crossplane.
+description: An introduction to Crossplane and Crossplane quickstart guides.
 ---
 
+{{<img src="/media/banner.png" alt="Crossplane Popsicle Truck" size="large" >}}
+
+## Hands-on
+Want a hands-on example? Follow a Crossplane Quickstart for different resource types
+* [Composition quickstart]({{<ref "get-started-with-composition" >}})
+* [Managed Resources quickstart]({{<ref "get-started-with-managed-resources" >}})
+* [Operations quickstart]({{<ref "get-started-with-operations" >}})
+
+## Install
+Ready to get started? [Install Crossplane]({{<ref "install" >}}) in a Kubernetes cluster.


### PR DESCRIPTION
Currently the [Get Started](https://docs.crossplane.io/v2.0/get-started/) page for `v2.0` and `v2.0-preview` are empty (and are linked to from the crossplane github repo). 

I've added some basic content to this page along the same lines as the [Getting Started](https://docs.crossplane.io/v1.20/getting-started/) page for `v1.20`.