### PR TITLE
Auto-generate child page indexes

### DIFF
--- a/content/master/_index.md
+++ b/content/master/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Welcome"
 weight: -1
+description: "Control plane framework for building cloud native platforms"
 cascade:
     version: "master"
 ---

--- a/content/master/cli/_index.md
+++ b/content/master/cli/_index.md
@@ -1,7 +1,7 @@
 ---
 weight: 200
 title: CLI Reference
-description: "Documentation for the Crossplane command-line interface"
+description: "Command-line tools for Crossplane development"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of

--- a/content/master/composition/_index.md
+++ b/content/master/composition/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Composition
 weight: 51
-description: Understand Crossplane's core components
+description: Build custom APIs by composing Kubernetes resources
 ---
 
 {{< auto-index >}}

--- a/content/master/composition/_index.md
+++ b/content/master/composition/_index.md
@@ -3,3 +3,5 @@ title: Composition
 weight: 51
 description: Understand Crossplane's core components
 ---
+
+{{< auto-index >}}

--- a/content/master/composition/composite-resource-definitions.md
+++ b/content/master/composition/composite-resource-definitions.md
@@ -1,7 +1,7 @@
 ---
 title: Composite Resource Definitions
 weight: 20
-description: "Composite Resource Definitions or XRDs define custom API schemas"
+description: "Define schemas for composite resources"
 ---
 
 Composite resource definitions (`XRDs`) define the schema for a custom API.

--- a/content/master/composition/composite-resources.md
+++ b/content/master/composition/composite-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Composite Resources
 weight: 10
-description: "Composite resources, an XR or XRs, represent a collection of related cloud resources."
+description: "Custom APIs created by composing Kubernetes resources"
 ---
 
 A composite resource, or XR, represents a set of Kubernetes resources as a

--- a/content/master/composition/composition-revisions.md
+++ b/content/master/composition/composition-revisions.md
@@ -1,6 +1,7 @@
 ---
 title: Composition Revisions
 weight: 35
+description: "Manage changes to Compositions with revisions"
 ---
 
 This guide discusses the use of "Composition Revisions" to make and roll

--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -5,7 +5,7 @@ aliases:
   - composition
   - composition-functions
   - /knowledge-base/guides/composition-functions
-description: "Compositions are a template for creating composite resources"
+description: "Define which resources to create and how"
 ---
 
 Compositions are a template for creating multiple Kubernetes resources as a

--- a/content/master/composition/compositions.md
+++ b/content/master/composition/compositions.md
@@ -784,15 +784,15 @@ Function response caching is an alpha feature. Enable it by setting the
 
 Crossplane can cache function responses to improve performance by reducing 
 repeated function calls. When enabled, Crossplane caches responses from 
-composition functions that include a Time-To-Live (TTL) value.
+composition functions that include a time to live (TTL) value.
 
 The cache works by:
 - Storing function responses on disk based on a hash of the request
-- Only caching responses with a non-zero TTL
+- Only caching responses with a nonzero TTL
 - Automatically removing expired cache entries
 - Reusing cached responses for identical requests until they expire
 
-This feature is particularly useful for functions that:
+This feature helps functions that:
 - Perform expensive computations or external API calls
 - Return stable results for the same inputs
 - Include appropriate TTL values in their responses
@@ -803,6 +803,6 @@ Control the cache behavior with these Crossplane pod arguments:
 
 - `--xfn-cache-max-ttl` - Maximum cache duration (default: 24 hours)
 
-The cache stores files in the `/cache/xfn/` directory within the Crossplane pod.
+The cache stores files in the `/cache/xfn/` directory in the Crossplane pod.
 For better performance, consider using an in-memory cache by mounting an 
 emptyDir volume with `medium: Memory`.

--- a/content/master/composition/environment-configs.md
+++ b/content/master/composition/environment-configs.md
@@ -4,7 +4,7 @@ weight: 75
 state: beta
 alphaVersion: "1.11"
 betaVersion: "1.18"
-description: "Environment Configs or EnvironmentConfigs are an in-memory datastore used in Compositions"
+description: "In-memory data stores for Compositions"
 ---
 
 <!--

--- a/content/master/get-started/_index.md
+++ b/content/master/get-started/_index.md
@@ -4,3 +4,4 @@ weight: 40
 description: Get started with Crossplane.
 ---
 
+{{< auto-index >}}

--- a/content/master/get-started/get-started-with-composition.md
+++ b/content/master/get-started/get-started-with-composition.md
@@ -1,6 +1,7 @@
 ---
 title: Get Started With Composition
 weight: 200
+description: "Build custom APIs with Crossplane composition"
 ---
 
 This guide shows how to create a new kind of custom resource named `App`. When a

--- a/content/master/get-started/get-started-with-managed-resources.md
+++ b/content/master/get-started/get-started-with-managed-resources.md
@@ -1,6 +1,7 @@
 ---
 title: Get Started With Managed Resources
 weight: 300
+description: "Manage cloud resources in Kubernetes with Crossplane providers"
 ---
 
 This guide shows how to install and use a new kind of custom resource called

--- a/content/master/get-started/get-started-with-operations.md
+++ b/content/master/get-started/get-started-with-operations.md
@@ -3,6 +3,7 @@ title: Get Started With Operations
 weight: 300
 state: alpha
 alphaVersion: 2.0
+description: "Run operational tasks with Crossplane operations"
 ---
 
 This guide shows how to use Crossplane Operations to automate day-two

--- a/content/master/get-started/install.md
+++ b/content/master/get-started/install.md
@@ -1,6 +1,7 @@
 ---
 title: Install Crossplane
 weight: 100
+description: "Install Crossplane in a Kubernetes cluster"
 ---
 
 Crossplane installs into an existing Kubernetes cluster, creating the

--- a/content/master/guides/_index.md
+++ b/content/master/guides/_index.md
@@ -3,3 +3,5 @@ title: Guides
 weight: 100
 description: Crossplane integrations and detailed examples.
 ---
+
+{{< auto-index >}}

--- a/content/master/guides/crossplane-with-argo-cd.md
+++ b/content/master/guides/crossplane-with-argo-cd.md
@@ -3,6 +3,7 @@
 ---  
 title: Configuring Crossplane with Argo CD
 weight: 270
+description: "Deploy Crossplane resources with GitOps"
 ---
 <!-- vale Google.Headings = YES -->
 <!-- vale Microsoft.HeadingAcronyms = YES -->  

--- a/content/master/guides/extensions-release-process.md
+++ b/content/master/guides/extensions-release-process.md
@@ -1,8 +1,7 @@
 ---
 title: Releasing Crossplane Extensions
 weight: 80
-description: "Configuring build pipelines for Crossplane extensions with GitHub
-Actions"
+description: "Build pipelines for Crossplane extensions"
 ---
 
 <!-- vale Google.Headings = NO -->

--- a/content/master/guides/function-patch-and-transform.md
+++ b/content/master/guides/function-patch-and-transform.md
@@ -1,7 +1,7 @@
 ---
 title: Function Patch and Transform
 weight: 70
-description: "A function that use patches and transforms to change inputs from composite resources before creating managed resources"
+description: "Write legacy Compositions"
 ---
 
 Function Patch and Transform allows you to write a Composition that specifies

--- a/content/master/guides/implementing-safe-start.md
+++ b/content/master/guides/implementing-safe-start.md
@@ -3,8 +3,7 @@ title: Implementing safe-start in Providers
 weight: 90
 state: alpha
 alphaVersion: 2.0
-description: Guide for provider developers to add safe-start capability for
-  selective resource activation
+description: Add selective resource activation to providers
 ---
 
 This guide shows provider developers how to implement safe-start capability in

--- a/content/master/guides/metrics.md
+++ b/content/master/guides/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 weight: 60
-description: "Metrics are essential for monitoring Crossplane's operations, helping to identify and resolve potential issues."
+description: "Monitor Crossplane operations with metrics"
 ---
 
 Crossplane produces [Prometheus style metrics](https://prometheus.io/docs/introduction/overview/#what-are-metrics) for effective monitoring and alerting in your environment.

--- a/content/master/guides/pods.md
+++ b/content/master/guides/pods.md
@@ -1,7 +1,7 @@
 ---
 title: Crossplane Pods
 weight: 1
-description: Background on the components installed with Crossplane and their functions.
+description: Components installed with Crossplane
 ---
 
 The base Crossplane installation consists of two pods, the `crossplane` pod and

--- a/content/master/guides/pods.md
+++ b/content/master/guides/pods.md
@@ -137,7 +137,7 @@ Kubernetes API server when a composed resource changes. For example, when
 a provider sets the `Ready` condition to `true`.
 
 {{<hint "important" >}}
-Real time compositions are a beta feature. Beta features are enabled by
+Real time compositions are a beta feature. Crossplane enables beta features by
 default. 
 {{< /hint >}}
 

--- a/content/master/guides/self-signed-ca-certs.md
+++ b/content/master/guides/self-signed-ca-certs.md
@@ -2,7 +2,8 @@
 <!-- vale Microsoft.HeadingAcronyms = NO -->
 ---  
 title: Self-signed CA certs
-weight: 270   
+weight: 270
+description: "Configure Crossplane with self-signed certificates"
 ---
 <!-- vale Google.Headings = YES -->
 <!-- vale Microsoft.HeadingAcronyms = YES -->  

--- a/content/master/guides/troubleshoot-crossplane.md
+++ b/content/master/guides/troubleshoot-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshoot Crossplane
 weight: 306
+description: "Debug common Crossplane issues"
 ---
 ## Requested resource not found
 

--- a/content/master/guides/uninstall-crossplane.md
+++ b/content/master/guides/uninstall-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Uninstall Crossplane
 weight: 500
+description: "Remove Crossplane from your cluster"
 ---
 
 {{<hint "warning" >}}

--- a/content/master/guides/upgrade-crossplane.md
+++ b/content/master/guides/upgrade-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade Crossplane
 weight: 400
+description: "Upgrade Crossplane to newer versions"
 ---
 
 The recommended upgrade method for an existing Crossplane install is to use

--- a/content/master/guides/write-a-composition-function-in-go.md
+++ b/content/master/guides/write-a-composition-function-in-go.md
@@ -1,7 +1,7 @@
 ---
 title: Write a Composition Function in Go
 weight: 80
-description: "Composition functions allow you to template resources using Go"
+description: "Build composition functions in Go"
 ---
 
 Composition functions (or just functions, for short) are custom programs that

--- a/content/master/guides/write-a-composition-function-in-python.md
+++ b/content/master/guides/write-a-composition-function-in-python.md
@@ -1,7 +1,7 @@
 ---
 title: Write a Composition Function in Python
 weight: 81
-description: "Composition functions allow you to template resources using Python"
+description: "Build composition functions in Python"
 ---
 
 Composition functions (or just functions, for short) are custom programs that

--- a/content/master/learn/feature-lifecycle.md
+++ b/content/master/learn/feature-lifecycle.md
@@ -3,6 +3,7 @@ title: Feature Lifecycle
 toc: true
 weight: 309
 indent: true
+description: "Crossplane's feature development process"
 ---
 
 # Feature lifecycle

--- a/content/master/learn/release-cycle.md
+++ b/content/master/learn/release-cycle.md
@@ -1,6 +1,7 @@
 ---
 title: Release Cycle
 weight: 308
+description: "When and how Crossplane releases are cut"
 ---
 
 Starting with the v1.10.0 release, Crossplane releases on a quarterly (13

--- a/content/master/managed-resources/_index.md
+++ b/content/master/managed-resources/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Managed Resources
 weight: 52
-description: Understand Crossplane's managed resources and selective activation
+description: Manage cloud resources in Kubernetes
 ---
 
 {{< auto-index >}}

--- a/content/master/managed-resources/_index.md
+++ b/content/master/managed-resources/_index.md
@@ -3,3 +3,5 @@ title: Managed Resources
 weight: 52
 description: Understand Crossplane's managed resources and selective activation
 ---
+
+{{< auto-index >}}

--- a/content/master/managed-resources/managed-resource-activation-policies.md
+++ b/content/master/managed-resources/managed-resource-activation-policies.md
@@ -3,9 +3,7 @@ title: Managed Resource Activation Policies
 weight: 20
 state: alpha
 alphaVersion: 2.0
-description: ManagedResourceActivationPolicies control which
-  ManagedResourceDefinitions activate for selective provider resource
-  installation
+description: Choose which provider resources Crossplane activates
 ---
 
 {{<hint "important">}}

--- a/content/master/managed-resources/managed-resource-definitions.md
+++ b/content/master/managed-resources/managed-resource-definitions.md
@@ -3,8 +3,7 @@ title: Managed Resource Definitions
 weight: 15
 state: alpha
 alphaVersion: 2.0
-description: ManagedResourceDefinitions enable selective activation of provider
-  resources and reduce CRD overhead
+description: Enable selective activation of provider resources
 ---
 
 {{<hint "important">}}

--- a/content/master/managed-resources/managed-resources.md
+++ b/content/master/managed-resources/managed-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Managed Resources
 weight: 10
-description: "Managed resources are the Crossplane representation of external provider resources"
+description: "Kubernetes representations of cloud resources"
 ---
 
 A _managed resource_ (`MR`) represents an external service in a Provider. When

--- a/content/master/managed-resources/usages.md
+++ b/content/master/managed-resources/usages.md
@@ -4,7 +4,7 @@ weight: 30
 state: beta
 alphaVersion: "1.14"
 betaVersion: "1.19"
-description: "Usage indicates a resource is in use"
+description: "Block deletion of in-use resources"
 ---
 
 A `Usage` indicates a resource is in use. Two main use cases for Usages are

--- a/content/master/operations/_index.md
+++ b/content/master/operations/_index.md
@@ -3,7 +3,7 @@ title: Operations
 weight: 52
 state: alpha
 alphaVersion: 2.0
-description: Understand Crossplane's Operations feature
+description: Run operational tasks with Crossplane
 ---
 
 {{< auto-index >}}

--- a/content/master/operations/_index.md
+++ b/content/master/operations/_index.md
@@ -5,3 +5,5 @@ state: alpha
 alphaVersion: 2.0
 description: Understand Crossplane's Operations feature
 ---
+
+{{< auto-index >}}

--- a/content/master/operations/cronoperation.md
+++ b/content/master/operations/cronoperation.md
@@ -3,7 +3,7 @@ title: Cron Operations
 weight: 120
 state: alpha
 alphaVersion: 2.0
-description: CronOperations create Operations on a schedule for recurring tasks
+description: Run function pipelines on a schedule
 ---
 
 A `CronOperation` creates [Operations]({{<ref "operation">}}) on a schedule,

--- a/content/master/operations/operation.md
+++ b/content/master/operations/operation.md
@@ -3,7 +3,7 @@ title: Operations
 weight: 110
 state: alpha
 alphaVersion: 2.0
-description: Operations run function pipelines once to completion for operational tasks
+description: Run function pipelines once to completion
 ---
 
 An `Operation` runs a function pipeline once to completion to perform operational

--- a/content/master/operations/operation.md
+++ b/content/master/operations/operation.md
@@ -304,17 +304,17 @@ Function response caching is an alpha feature. Enable it by setting the
 `--enable-function-response-cache` feature flag.
 {{< /hint >}}
 
-Operations can benefit from function response caching to improve performance,
-especially for operations that:
-- Call the same functions repeatedly with identical inputs
+Operations can use function response caching to improve performance
+for operations that:
+- Call the same functions often with identical inputs
 - Use functions that perform expensive computations or external API calls
 - Run frequently through CronOperation or WatchOperation
 
 The cache works the same way as for Compositions - function responses with
-time to live values are cached and reused for identical requests until
+time to live values cache and reuse identical requests until
 they expire.
 
-This is particularly useful for Operations that:
+Function response caching helps Operations that:
 - Validate configurations using expensive checks
 - Query external systems for status information
 - Perform complex calculations that don't change frequently

--- a/content/master/operations/watchoperation.md
+++ b/content/master/operations/watchoperation.md
@@ -3,7 +3,7 @@ title: Watch Operations
 weight: 130
 state: alpha
 alphaVersion: 2.0
-description: WatchOperations create Operations when watched resources change
+description: Run function pipelines on resource changes
 ---
 
 A `WatchOperation` creates [Operations]({{<ref "operation">}}) when watched

--- a/content/master/packages/_index.md
+++ b/content/master/packages/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Packages
 weight: 53
-description: Understand Crossplane's core components
+description: Extend Crossplane with packages
 ---
 
 {{< auto-index >}}

--- a/content/master/packages/_index.md
+++ b/content/master/packages/_index.md
@@ -3,3 +3,5 @@ title: Packages
 weight: 53
 description: Understand Crossplane's core components
 ---
+
+{{< auto-index >}}

--- a/content/master/packages/configurations.md
+++ b/content/master/packages/configurations.md
@@ -1,6 +1,6 @@
 ---
 title: Configurations
-description: "Packages combine multiple Crossplane resources into a single, portable, OCI image."
+description: "Portable packages of Crossplane resources"
 altTitle: "Crossplane Packages"
 weight: 200
 ---

--- a/content/master/packages/image-configs.md
+++ b/content/master/packages/image-configs.md
@@ -1,7 +1,7 @@
 ---
 title: Image Configs
 weight: 400
-description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+description: "Centralized control of package image configuration"
 ---
 
 <!-- vale write-good.Passive = NO -->

--- a/content/v2.0/cli/_index.md
+++ b/content/v2.0/cli/_index.md
@@ -1,7 +1,7 @@
 ---
 weight: 200
 title: CLI Reference
-description: "Documentation for the Crossplane command-line interface"
+description: "Command-line tools for Crossplane development"
 ---
 
 The Crossplane CLI helps simplify some development and administration aspects of

--- a/content/v2.0/composition/_index.md
+++ b/content/v2.0/composition/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Composition
 weight: 51
-description: Understand Crossplane's core components
+description: Build custom APIs by composing Kubernetes resources
 ---
+
+{{< auto-index >}}

--- a/content/v2.0/composition/composite-resource-definitions.md
+++ b/content/v2.0/composition/composite-resource-definitions.md
@@ -1,7 +1,7 @@
 ---
 title: Composite Resource Definitions
 weight: 20
-description: "Composite Resource Definitions or XRDs define custom API schemas"
+description: "Define schemas for composite resources"
 ---
 
 Composite resource definitions (`XRDs`) define the schema for a custom API.

--- a/content/v2.0/composition/composite-resources.md
+++ b/content/v2.0/composition/composite-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Composite Resources
 weight: 10
-description: "Composite resources, an XR or XRs, represent a collection of related cloud resources."
+description: "Custom APIs created by composing Kubernetes resources"
 ---
 
 A composite resource, or XR, represents a set of Kubernetes resources as a

--- a/content/v2.0/composition/composition-revisions.md
+++ b/content/v2.0/composition/composition-revisions.md
@@ -1,6 +1,7 @@
 ---
 title: Composition Revisions
 weight: 35
+description: "Manage changes to Compositions with revisions"
 ---
 
 This guide discusses the use of "Composition Revisions" to make and roll

--- a/content/v2.0/composition/environment-configs.md
+++ b/content/v2.0/composition/environment-configs.md
@@ -4,7 +4,7 @@ weight: 75
 state: beta
 alphaVersion: "1.11"
 betaVersion: "1.18"
-description: "Environment Configs or EnvironmentConfigs are an in-memory datastore used in Compositions"
+description: "In-memory data stores for Compositions"
 ---
 
 <!--

--- a/content/v2.0/get-started/_index.md
+++ b/content/v2.0/get-started/_index.md
@@ -4,3 +4,4 @@ weight: 40
 description: Get started with Crossplane.
 ---
 
+{{< auto-index >}}

--- a/content/v2.0/get-started/get-started-with-composition.md
+++ b/content/v2.0/get-started/get-started-with-composition.md
@@ -1,6 +1,7 @@
 ---
 title: Get Started With Composition
 weight: 200
+description: "Build custom APIs with Crossplane composition"
 ---
 
 This guide shows how to create a new kind of custom resource named `App`. When a

--- a/content/v2.0/get-started/get-started-with-managed-resources.md
+++ b/content/v2.0/get-started/get-started-with-managed-resources.md
@@ -1,6 +1,7 @@
 ---
 title: Get Started With Managed Resources
 weight: 300
+description: "Manage cloud resources in Kubernetes with Crossplane providers"
 ---
 
 This guide shows how to install and use a new kind of custom resource called

--- a/content/v2.0/get-started/get-started-with-operations.md
+++ b/content/v2.0/get-started/get-started-with-operations.md
@@ -3,6 +3,7 @@ title: Get Started With Operations
 weight: 300
 state: alpha
 alphaVersion: 2.0
+description: "Run operational tasks with Crossplane operations"
 ---
 
 This guide shows how to use Crossplane Operations to automate day-two

--- a/content/v2.0/get-started/install.md
+++ b/content/v2.0/get-started/install.md
@@ -1,6 +1,7 @@
 ---
 title: Install Crossplane
 weight: 100
+description: "Install Crossplane in a Kubernetes cluster"
 ---
 
 Crossplane installs into an existing Kubernetes cluster, creating the
@@ -106,8 +107,9 @@ at the table below.
 | --- | --- | --- |
 | Beta | `--enable-deployment-runtime-configs` | Enable support for DeploymentRuntimeConfigs. |
 | Beta | `--enable-usages` | Enable support for Usages. |
-| Alpha | `--enable-realtime-compositions` | Enable support for real time compositions. |
+| Beta | `--enable-realtime-compositions` | Enable support for real time compositions. |
 | Alpha | `--enable-dependency-version-upgrades ` | Enable automatic version upgrades of dependencies when updating packages. |
+| Alpha | `--enable-function-response-cache` | Enable caching of composition function responses to improve performance. |
 | Alpha | `--enable-signature-verification` | Enable support for package signature verification via ImageConfig API. |
 {{< /table >}}
 {{< /expand >}}

--- a/content/v2.0/guides/_index.md
+++ b/content/v2.0/guides/_index.md
@@ -3,3 +3,5 @@ title: Guides
 weight: 100
 description: Crossplane integrations and detailed examples.
 ---
+
+{{< auto-index >}}

--- a/content/v2.0/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0/guides/crossplane-with-argo-cd.md
@@ -3,6 +3,7 @@
 ---  
 title: Configuring Crossplane with Argo CD
 weight: 270
+description: "Deploy Crossplane resources with GitOps"
 ---
 <!-- vale Google.Headings = YES -->
 <!-- vale Microsoft.HeadingAcronyms = YES -->  

--- a/content/v2.0/guides/extensions-release-process.md
+++ b/content/v2.0/guides/extensions-release-process.md
@@ -1,8 +1,7 @@
 ---
 title: Releasing Crossplane Extensions
 weight: 80
-description: "Configuring build pipelines for Crossplane extensions with GitHub
-Actions"
+description: "Build pipelines for Crossplane extensions"
 ---
 
 <!-- vale Google.Headings = NO -->

--- a/content/v2.0/guides/function-patch-and-transform.md
+++ b/content/v2.0/guides/function-patch-and-transform.md
@@ -1,7 +1,7 @@
 ---
 title: Function Patch and Transform
 weight: 70
-description: "A function that use patches and transforms to change inputs from composite resources before creating managed resources"
+description: "Write legacy Compositions"
 ---
 
 Function Patch and Transform allows you to write a Composition that specifies
@@ -424,7 +424,7 @@ environment:
   patches:
   - type: ToCompositeFieldPath
     fromFieldPath: tags
-    toFieldPath: metadata.labels[envTag]
+    toFieldPath: status.envTag
   - type: FromCompositeFieldPath
     fromFieldPath: metadata.name
     toFieldPath: newEnvironmentKey
@@ -667,7 +667,12 @@ Composition and use it in a second composed resource in the same Composition.
 {{< /hint >}}
 
 For example, after Crossplane creates a new managed resource, take the value
-`hostedZoneID` and apply it as a `label` in the composite resource.
+`hostedZoneID` and store it in the composite resource's status.
+
+{{< hint "important" >}}
+To patch to composite resource status fields, you must first define the custom 
+status fields in the CompositeResourceDefinition.
+{{< /hint >}}
 
 ```yaml {label="toComposite",copy-lines="9-11"}
 apiVersion: pt.fn.crossplane.io/v1beta1
@@ -683,7 +688,7 @@ resources:
   patches:
     - type: ToCompositeFieldPath
       fromFieldPath: status.atProvider.hostedZoneId
-      toFieldPath: metadata.labels['ZoneID']
+      toFieldPath: status.hostedZoneId
 ```
 
 View the created managed resource to see the
@@ -698,12 +703,14 @@ Status:
     # Removed for brevity
 ```
 
-Next view the composite resource and confirm the patch applied the `label`
+Next view the composite resource and confirm the patch applied to the status
 
 ```yaml {label="toCompositeXR",copy-lines="none"}
 $ kubectl describe composite
 Name:         my-example-p5pxf
-Labels:       ZoneID=Z2O1EMRO9K5GLX
+# Removed for brevity
+Status:
+  Hosted Zone Id: Z2O1EMRO9K5GLX
 ```
 
 <!-- vale Google.Headings = NO -->

--- a/content/v2.0/guides/implementing-safe-start.md
+++ b/content/v2.0/guides/implementing-safe-start.md
@@ -3,8 +3,7 @@ title: Implementing safe-start in Providers
 weight: 90
 state: alpha
 alphaVersion: 2.0
-description: Guide for provider developers to add safe-start capability for
-  selective resource activation
+description: Add selective resource activation to providers
 ---
 
 This guide shows provider developers how to implement safe-start capability in

--- a/content/v2.0/guides/metrics.md
+++ b/content/v2.0/guides/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 weight: 60
-description: "Metrics are essential for monitoring Crossplane's operations, helping to identify and resolve potential issues."
+description: "Monitor Crossplane operations with metrics"
 ---
 
 Crossplane produces [Prometheus style metrics](https://prometheus.io/docs/introduction/overview/#what-are-metrics) for effective monitoring and alerting in your environment.

--- a/content/v2.0/guides/pods.md
+++ b/content/v2.0/guides/pods.md
@@ -1,7 +1,7 @@
 ---
 title: Crossplane Pods
 weight: 1
-description: Background on the components installed with Crossplane and their functions.
+description: Components installed with Crossplane
 ---
 
 The base Crossplane installation consists of two pods, the `crossplane` pod and
@@ -137,7 +137,7 @@ Kubernetes API server when a composed resource changes. For example, when
 a provider sets the `Ready` condition to `true`.
 
 {{<hint "important" >}}
-Real time compositions are an alpha feature. Alpha features aren't enabled by
+Real time compositions are a beta feature. Crossplane enables beta features by
 default. 
 {{< /hint >}}
 

--- a/content/v2.0/guides/self-signed-ca-certs.md
+++ b/content/v2.0/guides/self-signed-ca-certs.md
@@ -2,7 +2,8 @@
 <!-- vale Microsoft.HeadingAcronyms = NO -->
 ---  
 title: Self-signed CA certs
-weight: 270   
+weight: 270
+description: "Configure Crossplane with self-signed certificates"
 ---
 <!-- vale Google.Headings = YES -->
 <!-- vale Microsoft.HeadingAcronyms = YES -->  

--- a/content/v2.0/guides/troubleshoot-crossplane.md
+++ b/content/v2.0/guides/troubleshoot-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshoot Crossplane
 weight: 306
+description: "Debug common Crossplane issues"
 ---
 ## Requested resource not found
 

--- a/content/v2.0/guides/uninstall-crossplane.md
+++ b/content/v2.0/guides/uninstall-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Uninstall Crossplane
 weight: 500
+description: "Remove Crossplane from your cluster"
 ---
 
 {{<hint "warning" >}}

--- a/content/v2.0/guides/upgrade-crossplane.md
+++ b/content/v2.0/guides/upgrade-crossplane.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade Crossplane
 weight: 400
+description: "Upgrade Crossplane to newer versions"
 ---
 
 The recommended upgrade method for an existing Crossplane install is to use

--- a/content/v2.0/guides/write-a-composition-function-in-go.md
+++ b/content/v2.0/guides/write-a-composition-function-in-go.md
@@ -1,7 +1,7 @@
 ---
 title: Write a Composition Function in Go
 weight: 80
-description: "Composition functions allow you to template resources using Go"
+description: "Build composition functions in Go"
 ---
 
 Composition functions (or just functions, for short) are custom programs that

--- a/content/v2.0/guides/write-a-composition-function-in-python.md
+++ b/content/v2.0/guides/write-a-composition-function-in-python.md
@@ -1,7 +1,7 @@
 ---
 title: Write a Composition Function in Python
 weight: 81
-description: "Composition functions allow you to template resources using Python"
+description: "Build composition functions in Python"
 ---
 
 Composition functions (or just functions, for short) are custom programs that

--- a/content/v2.0/learn/feature-lifecycle.md
+++ b/content/v2.0/learn/feature-lifecycle.md
@@ -3,6 +3,7 @@ title: Feature Lifecycle
 toc: true
 weight: 309
 indent: true
+description: "Crossplane's feature development process"
 ---
 
 # Feature lifecycle

--- a/content/v2.0/learn/release-cycle.md
+++ b/content/v2.0/learn/release-cycle.md
@@ -1,6 +1,7 @@
 ---
 title: Release Cycle
 weight: 308
+description: "When and how Crossplane releases are cut"
 ---
 
 Starting with the v1.10.0 release, Crossplane releases on a quarterly (13

--- a/content/v2.0/managed-resources/_index.md
+++ b/content/v2.0/managed-resources/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Managed Resources
 weight: 52
-description: Understand Crossplane's managed resources and selective activation
+description: Manage cloud resources in Kubernetes
 ---
+
+{{< auto-index >}}

--- a/content/v2.0/managed-resources/managed-resource-activation-policies.md
+++ b/content/v2.0/managed-resources/managed-resource-activation-policies.md
@@ -3,9 +3,7 @@ title: Managed Resource Activation Policies
 weight: 20
 state: alpha
 alphaVersion: 2.0
-description: ManagedResourceActivationPolicies control which
-  ManagedResourceDefinitions activate for selective provider resource
-  installation
+description: Choose which provider resources Crossplane activates
 ---
 
 {{<hint "important">}}

--- a/content/v2.0/managed-resources/managed-resource-definitions.md
+++ b/content/v2.0/managed-resources/managed-resource-definitions.md
@@ -3,8 +3,7 @@ title: Managed Resource Definitions
 weight: 15
 state: alpha
 alphaVersion: 2.0
-description: ManagedResourceDefinitions enable selective activation of provider
-  resources and reduce CRD overhead
+description: Enable selective activation of provider resources
 ---
 
 {{<hint "important">}}

--- a/content/v2.0/managed-resources/managed-resources.md
+++ b/content/v2.0/managed-resources/managed-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Managed Resources
 weight: 10
-description: "Managed resources are the Crossplane representation of external provider resources"
+description: "Kubernetes representations of cloud resources"
 ---
 
 A _managed resource_ (`MR`) represents an external service in a Provider. When

--- a/content/v2.0/managed-resources/usages.md
+++ b/content/v2.0/managed-resources/usages.md
@@ -4,7 +4,7 @@ weight: 30
 state: beta
 alphaVersion: "1.14"
 betaVersion: "1.19"
-description: "Usage indicates a resource is in use"
+description: "Block deletion of in-use resources"
 ---
 
 A `Usage` indicates a resource is in use. Two main use cases for Usages are

--- a/content/v2.0/operations/_index.md
+++ b/content/v2.0/operations/_index.md
@@ -3,5 +3,7 @@ title: Operations
 weight: 52
 state: alpha
 alphaVersion: 2.0
-description: Understand Crossplane's Operations feature
+description: Run operational tasks with Crossplane
 ---
+
+{{< auto-index >}}

--- a/content/v2.0/operations/cronoperation.md
+++ b/content/v2.0/operations/cronoperation.md
@@ -3,7 +3,7 @@ title: Cron Operations
 weight: 120
 state: alpha
 alphaVersion: 2.0
-description: CronOperations create Operations on a schedule for recurring tasks
+description: Run function pipelines on a schedule
 ---
 
 A `CronOperation` creates [Operations]({{<ref "operation">}}) on a schedule,

--- a/content/v2.0/operations/operation.md
+++ b/content/v2.0/operations/operation.md
@@ -3,7 +3,7 @@ title: Operations
 weight: 110
 state: alpha
 alphaVersion: 2.0
-description: Operations run function pipelines once to completion for operational tasks
+description: Run function pipelines once to completion
 ---
 
 An `Operation` runs a function pipeline once to completion to perform operational
@@ -296,6 +296,31 @@ that your Operations need to access.
 For more details on RBAC configuration, see the 
 [Compositions RBAC documentation]({{<ref "../composition/compositions#grant-access-to-composed-resources">}}).
 {{</hint>}}
+
+### Function response cache
+
+{{<hint "note" >}}
+Function response caching is an alpha feature. Enable it by setting the 
+`--enable-function-response-cache` feature flag.
+{{< /hint >}}
+
+Operations can use function response caching to improve performance
+for operations that:
+- Call the same functions often with identical inputs
+- Use functions that perform expensive computations or external API calls
+- Run frequently through CronOperation or WatchOperation
+
+The cache works the same way as for Compositions - function responses with
+time to live values cache and reuse identical requests until
+they expire.
+
+Function response caching helps Operations that:
+- Validate configurations using expensive checks
+- Query external systems for status information
+- Perform complex calculations that don't change frequently
+
+For cache configuration details, see the 
+[Function response cache documentation]({{<ref "../composition/compositions#function-response-cache">}}).
 
 ### Required resources
 

--- a/content/v2.0/operations/watchoperation.md
+++ b/content/v2.0/operations/watchoperation.md
@@ -3,7 +3,7 @@ title: Watch Operations
 weight: 130
 state: alpha
 alphaVersion: 2.0
-description: WatchOperations create Operations when watched resources change
+description: Run function pipelines on resource changes
 ---
 
 A `WatchOperation` creates [Operations]({{<ref "operation">}}) when watched

--- a/content/v2.0/packages/_index.md
+++ b/content/v2.0/packages/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Packages
 weight: 53
-description: Understand Crossplane's core components
+description: Extend Crossplane with packages
 ---
+
+{{< auto-index >}}

--- a/content/v2.0/packages/configurations.md
+++ b/content/v2.0/packages/configurations.md
@@ -1,6 +1,6 @@
 ---
 title: Configurations
-description: "Packages combine multiple Crossplane resources into a single, portable, OCI image."
+description: "Portable packages of Crossplane resources"
 altTitle: "Crossplane Packages"
 weight: 200
 ---

--- a/content/v2.0/packages/image-configs.md
+++ b/content/v2.0/packages/image-configs.md
@@ -1,7 +1,7 @@
 ---
 title: Image Configs
 weight: 400
-description: "Image Configs is an API for centralized control of the configuration of Crossplane package images."
+description: "Centralized control of package image configuration"
 ---
 
 <!-- vale write-good.Passive = NO -->

--- a/themes/geekboot/layouts/partials/auto-index.html
+++ b/themes/geekboot/layouts/partials/auto-index.html
@@ -1,0 +1,14 @@
+{{/*
+Auto-generates an index page with links to child pages, ordered by weight.
+Usage: {{ partial "auto-index" . }}
+*/}}
+{{ if .RegularPages }}
+<div class="auto-index">
+  <p>Topics in this section:</p>
+  <ul>
+  {{ range .RegularPages.ByWeight }}
+    <li><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Params.description }} - {{ .Params.description }}{{ end }}</li>
+  {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/themes/geekboot/layouts/partials/auto-index.html
+++ b/themes/geekboot/layouts/partials/auto-index.html
@@ -4,6 +4,9 @@ Usage: {{ partial "auto-index" . }}
 */}}
 {{ if .RegularPages }}
 <div class="auto-index">
+  {{ if .Params.description }}
+  <p>{{ .Params.description }}</p>
+  {{ end }}
   <p>Topics in this section:</p>
   <ul>
   {{ range .RegularPages.ByWeight }}

--- a/themes/geekboot/layouts/shortcodes/auto-index.html
+++ b/themes/geekboot/layouts/shortcodes/auto-index.html
@@ -1,0 +1,5 @@
+{{/*
+Shortcode to auto-generate an index of child pages.
+Usage: {{< auto-index >}}
+*/}}
+{{ partial "auto-index" .Page }}

--- a/utils/vale/styles/Crossplane/allowed-jargon.txt
+++ b/utils/vale/styles/Crossplane/allowed-jargon.txt
@@ -108,6 +108,7 @@ syscall
 templated
 TLS
 tolerations
+TTL
 UI
 VM
 walkthrough


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

In addition to #973 I'd like to auto-generate a list on each index page. This is because it's possible to browse to the index pages, even if you can't do it by the sidebar. For example the top-level index page links to top-level get started, not to a specific get started guide.

This PR:

* Adds code to automatically generate a list of child/sibling pages
* Uses it in index.md files
* Updates many page front-matter descriptions for succinctness and clarity, since they'll now appear in the lists