### PR TITLE
Update argo-cd health check ConfigMap for v2 resources

### DIFF
--- a/content/master/guides/crossplane-with-argo-cd.md
+++ b/content/master/guides/crossplane-with-argo-cd.md
@@ -71,6 +71,7 @@ data:
         end
 
         local has_no_status = {
+          "ClusterProviderConfig",
           "ProviderConfig",
           "ProviderConfigUsage"
         }
@@ -82,7 +83,7 @@ data:
         end
 
         if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
+          if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
             return health_status
@@ -138,6 +139,7 @@ data:
           "Composition",
           "CompositionRevision",
           "DeploymentRuntimeConfig",
+          "ClusterProviderConfig",
           "ProviderConfig",
           "ProviderConfigUsage"
         }
@@ -148,7 +150,7 @@ data:
         end
 
         if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
+          if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
             return health_status
@@ -173,7 +175,7 @@ data:
             end
           end
 
-          if contains({"Ready", "Healthy", "Offered", "Established"}, condition.type) then
+          if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."

--- a/content/v2.0/guides/crossplane-with-argo-cd.md
+++ b/content/v2.0/guides/crossplane-with-argo-cd.md
@@ -71,6 +71,7 @@ data:
         end
 
         local has_no_status = {
+          "ClusterProviderConfig",
           "ProviderConfig",
           "ProviderConfigUsage"
         }
@@ -82,7 +83,7 @@ data:
         end
 
         if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
+          if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
             return health_status
@@ -138,6 +139,7 @@ data:
           "Composition",
           "CompositionRevision",
           "DeploymentRuntimeConfig",
+          "ClusterProviderConfig",
           "ProviderConfig",
           "ProviderConfigUsage"
         }
@@ -148,7 +150,7 @@ data:
         end
 
         if obj.status == nil or next(obj.status) == nil or obj.status.conditions == nil then
-          if obj.kind == "ProviderConfig" and obj.status.users ~= nil then
+          if (obj.kind == "ProviderConfig" or obj.kind == "ClusterProviderConfig") and obj.status.users ~= nil then
             health_status.status = "Healthy"
             health_status.message = "Resource is in use."
             return health_status
@@ -173,7 +175,7 @@ data:
             end
           end
 
-          if contains({"Ready", "Healthy", "Offered", "Established"}, condition.type) then
+          if contains({"Ready", "Healthy", "Offered", "Established", "ValidPipeline", "RevisionHealthy"}, condition.type) then
             if condition.status == "True" then
               health_status.status = "Healthy"
               health_status.message = "Resource is up-to-date."


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

In Crossplane v2, some of the resources that didn't used to have statuses now do, so we check those conditions.  We also add a new resource, `ClusterProviderConfig`, which doesn't have a status.