### PR TITLE
Fix unintended paragraph breaks

### DIFF
--- a/content/master/packages/providers.md
+++ b/content/master/packages/providers.md
@@ -684,28 +684,28 @@ package runtime container.
 
 <!-- vale write-good.Passive = NO -->
 The package manager is opinionated about some fields to ensure
-<!-- vale write-good.Passive = YES -->
 the runtime is working and overlay them on top of the values
 in the runtime configuration. For example, it defaults the replica count
 to 1 if not set and overrides the label selectors to make sure the Deployment
 and Service match. It also injects any necessary environment variables,
 ports and volumes and volume mounts.
+<!-- vale write-good.Passive = YES -->
 
+<!-- vale gitlab.FutureTense = NO -->
 The `Provider` or `Functions`'s `spec.runtimeConfigRef.name` field defaults
 to value `default`, which means Crossplane uses the default runtime configuration
 if not specified. Crossplane ensures there is always a default runtime
-<!-- vale gitlab.FutureTense = NO -->
 configuration in the cluster, but won't change it if it already exists. This
-<!-- vale gitlab.FutureTense = YES -->
 allows users to customize the default runtime configuration to their needs.
+<!-- vale gitlab.FutureTense = YES -->
 
 {{<hint "tip" >}}
 <!-- vale gitlab.SubstitutionWarning = NO -->
 Since `DeploymentRuntimeConfig` uses the same schema as Kubernetes `Deployment`
-<!-- vale gitlab.SubstitutionWarning = YES -->
 spec, you may need to pass empty values to bypass the schema validation.
 For example, if you just want to change the `replicas` field, you would
 need to pass the following:
+<!-- vale gitlab.SubstitutionWarning = YES -->
 
 ```yaml
 apiVersion: pkg.crossplane.io/v1beta1

--- a/content/v2.0/packages/providers.md
+++ b/content/v2.0/packages/providers.md
@@ -684,28 +684,28 @@ package runtime container.
 
 <!-- vale write-good.Passive = NO -->
 The package manager is opinionated about some fields to ensure
-<!-- vale write-good.Passive = YES -->
 the runtime is working and overlay them on top of the values
 in the runtime configuration. For example, it defaults the replica count
 to 1 if not set and overrides the label selectors to make sure the Deployment
 and Service match. It also injects any necessary environment variables,
 ports and volumes and volume mounts.
+<!-- vale write-good.Passive = YES -->
 
+<!-- vale gitlab.FutureTense = NO -->
 The `Provider` or `Functions`'s `spec.runtimeConfigRef.name` field defaults
 to value `default`, which means Crossplane uses the default runtime configuration
 if not specified. Crossplane ensures there is always a default runtime
-<!-- vale gitlab.FutureTense = NO -->
 configuration in the cluster, but won't change it if it already exists. This
-<!-- vale gitlab.FutureTense = YES -->
 allows users to customize the default runtime configuration to their needs.
+<!-- vale gitlab.FutureTense = YES -->
 
 {{<hint "tip" >}}
 <!-- vale gitlab.SubstitutionWarning = NO -->
 Since `DeploymentRuntimeConfig` uses the same schema as Kubernetes `Deployment`
-<!-- vale gitlab.SubstitutionWarning = YES -->
 spec, you may need to pass empty values to bypass the schema validation.
 For example, if you just want to change the `replicas` field, you would
 need to pass the following:
+<!-- vale gitlab.SubstitutionWarning = YES -->
 
 ```yaml
 apiVersion: pkg.crossplane.io/v1beta1


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

This moves HTML comments out of paragraphs because they're creating breaks. I couldn't find a way to inline these comments without adding a paragraph break, let me know if there's a way to fix the doc while keeping linter exceptions fine grained.