### PR TITLE
Update header navigation community link to commercial

### DIFF
--- a/themes/geekboot/layouts/partials/docs-navbar.html
+++ b/themes/geekboot/layouts/partials/docs-navbar.html
@@ -58,7 +58,7 @@
             <a class="navbar-link"  aria-current="page" href="{{.Site.BaseURL}}">Documentation</a>
           </li>
           <li class="nav-item">
-            <a class="navbar-link"  href="https://www.crossplane.io/community">Community</a>
+            <a class="navbar-link"  href="https://www.crossplane.io/commercial">Commercial</a>
           </li>
           <li class="nav-item">
             <a class="navbar-link"  href="https://blog.crossplane.io/">Blog</a>


### PR DESCRIPTION
This was changed awhile ago on the main www.crossplane.io site to more accurately reflect its intent, as permitted by the CNCF website guidelines. This docs site header navigation should match that of the main www site, and we missed making this symmetrical update when the main site was updated.