### PR TITLE
docs: Add CRD cleanup warning to uninstall guides across all versions

### DIFF
--- a/content/master/guides/uninstall-crossplane.md
+++ b/content/master/guides/uninstall-crossplane.md
@@ -190,3 +190,23 @@ kube-node-lease   Active   2m47s
 kube-public       Active   2m47s
 kube-system       Active   2m47s
 ```
+
+{{<hint "warning" >}}
+Custom Resource Definitions (CRDs) aren't automatically removed by `helm uninstall`.
+
+CRDs with names ending in `*.crossplane.io` remain in your cluster after uninstalling Crossplane.
+
+If desired, manually delete these CRDs:
+
+```shell
+# View remaining Crossplane CRDs
+kubectl get crd | grep crossplane.io
+
+# Example: Delete a specific CRD
+kubectl delete crd providers.pkg.crossplane.io
+```
+
+{{<hint "important" >}}
+Deleting CRDs removes all custom resources of that type. Ensure no important data exists before deletion.
+{{< /hint >}}
+{{< /hint >}}

--- a/content/v1.19/software/uninstall.md
+++ b/content/v1.19/software/uninstall.md
@@ -181,3 +181,23 @@ kube-node-lease   Active   2m47s
 kube-public       Active   2m47s
 kube-system       Active   2m47s
 ```
+
+{{<hint "warning" >}}
+Custom Resource Definitions (CRDs) aren't automatically removed by `helm uninstall`.
+
+CRDs with names ending in `*.crossplane.io` remain in your cluster after uninstalling Crossplane.
+
+If desired, manually delete these CRDs:
+
+```shell
+# View remaining Crossplane CRDs
+kubectl get crd | grep crossplane.io
+
+# Example: Delete a specific CRD
+kubectl delete crd providers.pkg.crossplane.io
+```
+
+{{<hint "important" >}}
+Deleting CRDs removes all custom resources of that type. Ensure no important data exists before deletion.
+{{< /hint >}}
+{{< /hint >}}

--- a/content/v1.20/software/uninstall.md
+++ b/content/v1.20/software/uninstall.md
@@ -181,3 +181,23 @@ kube-node-lease   Active   2m47s
 kube-public       Active   2m47s
 kube-system       Active   2m47s
 ```
+
+{{<hint "warning" >}}
+Custom Resource Definitions (CRDs) aren't automatically removed by `helm uninstall`.
+
+CRDs with names ending in `*.crossplane.io` remain in your cluster after uninstalling Crossplane.
+
+If desired, manually delete these CRDs:
+
+```shell
+# View remaining Crossplane CRDs
+kubectl get crd | grep crossplane.io
+
+# Example: Delete a specific CRD
+kubectl delete crd providers.pkg.crossplane.io
+```
+
+{{<hint "important" >}}
+Deleting CRDs removes all custom resources of that type. Ensure no important data exists before deletion.
+{{< /hint >}}
+{{< /hint >}}

--- a/content/v2.0/guides/uninstall-crossplane.md
+++ b/content/v2.0/guides/uninstall-crossplane.md
@@ -190,3 +190,23 @@ kube-node-lease   Active   2m47s
 kube-public       Active   2m47s
 kube-system       Active   2m47s
 ```
+
+{{<hint "warning" >}}
+Custom Resource Definitions (CRDs) aren't automatically removed by `helm uninstall`.
+
+CRDs with names ending in `*.crossplane.io` remain in your cluster after uninstalling Crossplane.
+
+If desired, manually delete these CRDs:
+
+```shell
+# View remaining Crossplane CRDs
+kubectl get crd | grep crossplane.io
+
+# Example: Delete a specific CRD
+kubectl delete crd providers.pkg.crossplane.io
+```
+
+{{<hint "important" >}}
+Deleting CRDs removes all custom resources of that type. Ensure no important data exists before deletion.
+{{< /hint >}}
+{{< /hint >}}


### PR DESCRIPTION
<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->

## Problem
Users expect `helm uninstall crossplane` to completely remove Crossplane, but CRDs with `*.crossplane.io` suffix remain in the cluster. 
This can cause confusion.

## Solution
Added consistent warning sections explaining:
  - CRDs aren't automatically removed by helm uninstall
  - How to view remaining CRDs with `kubectl get crd | grep crossplane.io`
  - Safe manual deletion example
  - Important data loss warning
