### PR TITLE
docs(cli): add a TypeScript tab to the projects get-started guide

### DIFF
--- a/content/cli/master/get-started/get-started-with-control-plane-projects.md
+++ b/content/cli/master/get-started/get-started-with-control-plane-projects.md
@@ -796,6 +796,131 @@ bindings the CLI generated when you added the Kubernetes dependency, so the
 compiler checks the resources you create.
 {{< /tab >}}
 
+{{< tab "TypeScript" >}}
+TypeScript is a good choice if you want your composition logic type checked
+before it runs. The function is an ordinary Node.js project, so you can use any
+package from [npm](https://www.npmjs.com).
+
+Unlike the other languages, TypeScript model generation is opt in. Add it to
+`crossplane-project.yaml` before generating the function:
+
+```yaml
+spec:
+  schemas:
+    languages:
+    - typescript
+```
+
+Without this the CLI generates no TypeScript models, and the scaffolded function
+would have no `crossplane-models` dependency to import from. Rather than
+scaffold a function that can't compile, `function generate` fails and tells you
+to add the language.
+
+Generate a TypeScript function named `compose-webapp` and add it to the
+composition's pipeline:
+
+```shell
+crossplane function generate compose-webapp apis/webapps/composition.yaml --language typescript
+```
+
+The command scaffolds the function under `functions/compose-webapp/` and adds a
+pipeline step to `apis/webapps/composition.yaml`.
+
+Replace the contents of `functions/compose-webapp/src/function.ts` with the
+following function logic:
+
+```typescript
+import {
+  type ComposeFunction,
+  fatal,
+  fromModel,
+  getObservedCompositeResource,
+  normal,
+} from '@crossplane-org/function-sdk-typescript';
+import { type IWebApp } from 'crossplane-models/platform.example.com/v1alpha1';
+import { Deployment } from 'kubernetes-models/apps/v1';
+import { Service } from 'kubernetes-models/v1';
+
+/**
+ * compose turns a WebApp into a Deployment and a Service.
+ */
+export const compose: ComposeFunction = async (req, rsp, logger) => {
+  try {
+    const observed = getObservedCompositeResource(req);
+    const xr = observed?.resource as IWebApp | undefined;
+
+    const name = xr?.metadata?.name;
+    const image = xr?.spec?.image;
+    if (!name || !image) {
+      fatal(rsp, 'observed composite resource is missing metadata.name or spec.image');
+      return rsp;
+    }
+
+    const namespace = xr?.metadata?.namespace;
+    const ports = xr?.spec?.ports ?? [];
+    const labels = { 'app.kubernetes.io/name': name };
+
+    const deployment = new Deployment({
+      metadata: { ...(namespace && { namespace }), labels },
+      spec: {
+        selector: { matchLabels: labels },
+        ...(xr?.spec?.replicas !== undefined && { replicas: xr.spec.replicas }),
+        template: {
+          metadata: { labels },
+          spec: {
+            containers: [
+              {
+                name: 'app',
+                image,
+                ports: ports.map((p) => ({ containerPort: p })),
+              },
+            ],
+          },
+        },
+      },
+    });
+    rsp.desired.resources['deployment'] = fromModel(deployment);
+
+    const service = new Service({
+      metadata: { ...(namespace && { namespace }), labels },
+      spec: {
+        ports: ports.map((p) => ({ port: p, targetPort: p })),
+        selector: labels,
+      },
+    });
+    rsp.desired.resources['service'] = fromModel(service);
+
+    normal(rsp, 'composed deployment and service');
+    return rsp;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    logger?.error({ error: msg }, 'function invocation failed');
+    fatal(rsp, msg);
+    return rsp;
+  }
+};
+```
+
+The function reads the observed `WebApp` XR, then builds a `Deployment` and a
+`Service` from its `spec`.
+
+Types come from two places. `crossplane-models` holds the bindings the CLI
+generated from your XRD, so `IWebApp` describes the XR you defined. Kubernetes
+built-ins like `Deployment` and `Service` come from the
+[kubernetes-models](https://www.npmjs.com/package/kubernetes-models) package,
+which the function scaffold already depends on. The CLI doesn't generate
+bindings for the Kubernetes API itself.
+
+`fromModel` converts a typed object into the protobuf `Resource` value that
+`rsp.desired.resources` holds. Assigning the model directly doesn't compile.
+
+The scaffold enables TypeScript's `exactOptionalPropertyTypes`, which is why the
+example checks `spec.image` before use and spreads `replicas` conditionally.
+Every field in a generated XR model is optional, because the XRD's schema
+decides what's required, so passing one straight into a field that isn't
+optional fails to compile.
+{{< /tab >}}
+
 {{< tab "KCL" >}}
 [KCL](https://kcl-lang.io) is a good choice for functions with dynamic logic.
 It's fast and sandboxed.
@@ -934,6 +1059,14 @@ functions automatically, so you only pass the example XR and the composition:
 ```shell
 crossplane composition render examples/webapps/podinfo.yaml apis/webapps/composition.yaml
 ```
+
+{{<hint "note">}}
+`render` times out after a minute by default. A first TypeScript build pulls the
+Node.js images, installs the npm dependencies and runs `tsc`, which takes longer
+than that and fails with `context deadline exceeded`. Pass `--timeout 5m` on the
+first render. Later renders reuse the cached images and packages, so they fit
+inside the default.
+{{</hint>}}
 
 The command prints the rendered `Deployment` and `Service` as well as the
 updates Crossplane would make to the `WebApp` XR:

--- a/utils/vale/styles/Crossplane/allowed-jargon.txt
+++ b/utils/vale/styles/Crossplane/allowed-jargon.txt
@@ -91,6 +91,8 @@ RPCs
 RSS
 runtimeClassName
 sandboxed
+scaffolded
+scaffolds
 SCSS
 SDK
 SDKs

--- a/utils/vale/styles/Crossplane/brands.txt
+++ b/utils/vale/styles/Crossplane/brands.txt
@@ -20,8 +20,10 @@ instant.page
 Kubebuilder
 Kustomize
 Netlify
+Node.js
 NodeJS
 NPM
+npm
 OPA
 OpenAPI
 OpenAPIv3
@@ -32,6 +34,7 @@ PostgreSQL
 Protobuf
 PurgeCSS
 Rego
+TypeScript
 Upbound
 Upbound's
 Upjet

--- a/utils/vale/styles/Crossplane/crossplane-words.txt
+++ b/utils/vale/styles/Crossplane/crossplane-words.txt
@@ -32,6 +32,7 @@ crossplane-browse
 crossplane-edit
 controller-runtime
 Controller-runtime
+crossplane-models
 crossplane-runtime
 Crossplane's
 crossplane-view
@@ -67,6 +68,7 @@ InactivePackageRevision
 initProvider
 KCL
 kro
+kubernetes-models
 LateInitialize
 ManagedResourceActivationPolicies
 ManagedResourceActivationPolicy

--- a/utils/vale/styles/Crossplane/spelling-exceptions.txt
+++ b/utils/vale/styles/Crossplane/spelling-exceptions.txt
@@ -1,5 +1,6 @@
 backporting
 built-in
+built-ins
 call-outs
 ClusterRoles`
 comma-separated


### PR DESCRIPTION


Document writing composition functions in TypeScript alongside the existing Templated YAML, Python, Go and KCL tabs, covering the parts that differ from the other languages:

- TypeScript model generation is opt in. generator.Filter maps an unset spec.schemas.languages to a default set that excludes TypeScript, so the language has to be named explicitly before generating a function.
- Kubernetes built-ins come from kubernetes-models, not crossplane-models. The CLI generates bindings from CRDs and XRDs, not from the Kubernetes API itself, so Deployment and Service are imported from the scaffold's own dependency.
- fromModel is required to write a typed object into rsp.desired.resources; assigning the model directly doesn't compile.
- The scaffold enables exactOptionalPropertyTypes, which is why the example guards spec.image and spreads replicas conditionally.

Depends on https://github.com/crossplane/cli/pull/170

Also note the render timeout. `composition render` defaults to 1m, and a first TypeScript build pulls the Node.js images, installs npm dependencies and runs tsc, which overruns it and fails with "context deadline exceeded".

Add the terms the new prose needs to the Vale dictionaries so the content lints clean.

<!--
Thanks for contributing to the docs! 

For information about local previews with Hugo read the contributing getting started guide:
https://docs.crossplane.io/contribute/contribute/

For information about Hugo's features like tabs and hint boxes read the styling features guide:
https://docs.crossplane.io/contribute/features/

For information on using Vale and testing locally read our Using Vale guide:
https://docs.crossplane.io/contribute/vale/

Need more help? Join the Crossplane Slack and ask in the #documentation channel.
https://slack.crossplane.io/
-->